### PR TITLE
Update Node.js version references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Contribution Guide
 
-This project uses **Node.js v18** and **Yarn v4**. The CI workflow enables Corepack and runs with these versions. Local development should match this setup.
+This project uses **Node.js v22** and **Yarn v4**. The CI workflow enables Corepack and runs with these versions. Local development should match this setup.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The **Miro Structured Graph Generator** plugin demonstrates how to import struct
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (version 18 LTS is recommended)
+- [Node.js](https://nodejs.org/) (version 22 LTS is recommended)
 - [Yarn](https://yarnpkg.com/) (v4 is used in this project)
 
 ## Installation


### PR DESCRIPTION
## Summary
- update docs to refer to Node.js v22 instead of v18

## Testing
- `yarn prettier`
- `yarn prettier:check`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684910cd9544832bbcf353f34732210c