### PR TITLE
Implement node grouping

### DIFF
--- a/src/logic/shapeRenderer.ts
+++ b/src/logic/shapeRenderer.ts
@@ -43,7 +43,12 @@ export async function renderNodes(nodes: PositionedNode[]): Promise<WidgetMap> {
           ? { fillColor: template.fillColor, color: template.color }
           : undefined,
     });
-    attachShapeMetadata(widget, { type: 'node', nodeId: node.id });
+    const group = await miro.board.group({ items: [widget] });
+    attachShapeMetadata(widget, {
+      type: 'node',
+      nodeId: node.id,
+      groupId: group.id,
+    });
     map[node.id] = widget;
   }
   return map;

--- a/tests/shapeRenderer.test.ts
+++ b/tests/shapeRenderer.test.ts
@@ -3,9 +3,11 @@ import * as metadata from '../src/logic/metadata';
 
 describe('renderNodes', () => {
   const createShape = jest.fn();
+  const group = jest.fn();
   beforeEach(() => {
-    Object.assign(globalThis, { miro: { board: { createShape } } });
+    Object.assign(globalThis, { miro: { board: { createShape, group } } });
     createShape.mockReset();
+    group.mockReset();
     jest.spyOn(metadata, 'attachShapeMetadata').mockImplementation((s) => s);
   });
 
@@ -13,12 +15,26 @@ describe('renderNodes', () => {
     const shape1 = { id: 'w1' };
     const shape2 = { id: 'w2' };
     createShape.mockResolvedValueOnce(shape1).mockResolvedValueOnce(shape2);
+    group
+      .mockResolvedValueOnce({ id: 'g1' })
+      .mockResolvedValueOnce({ id: 'g2' });
     const nodes = [
       { id: 'n1', x: 0, y: 0, width: 50, height: 50, label: 'A' },
       { id: 'n2', x: 10, y: 10, width: 50, height: 50, label: 'B' },
     ];
     const map = await renderNodes(nodes);
     expect(createShape).toHaveBeenCalledTimes(2);
+    expect(group).toHaveBeenCalledTimes(2);
+    expect(metadata.attachShapeMetadata).toHaveBeenCalledWith(shape1, {
+      type: 'node',
+      nodeId: 'n1',
+      groupId: 'g1',
+    });
+    expect(metadata.attachShapeMetadata).toHaveBeenCalledWith(shape2, {
+      type: 'node',
+      nodeId: 'n2',
+      groupId: 'g2',
+    });
     expect(map).toEqual({ n1: shape1, n2: shape2 });
   });
 });


### PR DESCRIPTION
## Summary
- group each rendered node on the board
- store group id in node metadata
- verify grouping logic in unit tests

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6849113b2b80832ba56560b45873f28f