### PR TITLE
Avoid duplicate connectors

### DIFF
--- a/src/GraphProcessor.ts
+++ b/src/GraphProcessor.ts
@@ -1,4 +1,4 @@
-import { loadGraph, createNode, createEdges, NodeData, EdgeData, GraphData } from './graph';
+import { loadGraph, createNode, createEdges, GraphData } from './graph';
 import { layoutGraph } from './elk-layout';
 import type { BaseItem, Group, Connector } from '@mirohq/websdk-types';
 

--- a/tests/edges.test.ts
+++ b/tests/edges.test.ts
@@ -2,22 +2,49 @@ import { createEdges } from '../src/graph';
 
 declare const global: any;
 
-global.miro = {
-  board: {
-    createConnector: jest.fn().mockResolvedValue({ setMetadata: jest.fn(), sync: jest.fn(), id: 'c1' })
-  }
-};
+describe('createEdges', () => {
+  beforeEach(() => {
+    global.miro = {
+      board: {
+        get: jest.fn().mockResolvedValue([]),
+        createConnector: jest.fn().mockResolvedValue({
+          setMetadata: jest.fn(),
+          sync: jest.fn(),
+          id: 'c1'
+        })
+      }
+    };
+  });
 
-test('createEdges skips missing nodes', async () => {
-  const edges = [{ from: 'n1', to: 'n2' }];
-  const nodeMap = { n1: { id: 'a' } } as any;
-  const connectors = await createEdges(edges as any, nodeMap);
-  expect(connectors).toHaveLength(0);
-});
+  afterEach(() => jest.restoreAllMocks());
 
-test('createEdges creates connectors', async () => {
-  const edges = [{ from: 'n1', to: 'n2', label: 'l' }];
-  const nodeMap = { n1: { id: 'a' }, n2: { id: 'b' } } as any;
-  const connectors = await createEdges(edges as any, nodeMap);
-  expect(connectors).toHaveLength(1);
+  test('skips missing nodes', async () => {
+    const edges = [{ from: 'n1', to: 'n2' }];
+    const nodeMap = { n1: { id: 'a' } } as any;
+    const connectors = await createEdges(edges as any, nodeMap);
+    expect(connectors).toHaveLength(0);
+  });
+
+  test('creates connectors', async () => {
+    const edges = [{ from: 'n1', to: 'n2', label: 'l' }];
+    const nodeMap = { n1: { id: 'a' }, n2: { id: 'b' } } as any;
+    const connectors = await createEdges(edges as any, nodeMap);
+    expect(connectors).toHaveLength(1);
+    expect(global.miro.board.createConnector).toHaveBeenCalled();
+  });
+
+  test('reuses existing connectors when metadata matches', async () => {
+    (global.miro.board.get as jest.Mock).mockResolvedValueOnce([
+      {
+        getMetadata: jest.fn().mockResolvedValue({ from: 'n1', to: 'n2' }),
+        sync: jest.fn(),
+        id: 'cExisting'
+      }
+    ]);
+    const edges = [{ from: 'n1', to: 'n2' }];
+    const nodeMap = { n1: { id: 'a' }, n2: { id: 'b' } } as any;
+    const connectors = await createEdges(edges as any, nodeMap);
+    expect(connectors).toHaveLength(1);
+    expect(global.miro.board.createConnector).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- check for existing connectors before creating new ones
- expose a helper to find connectors by metadata
- adjust GraphProcessor imports
- expand edge tests for connector reuse

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850afb6d41c832babaa9ec848ed85b1