### PR TITLE
Add tests for CardProcessor utilities

### DIFF
--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -169,4 +169,35 @@ describe('CardProcessor', () => {
     await (processor as any).loadCardMap();
     expect(global.miro.board.get).toHaveBeenCalledTimes(1);
   });
+
+  test('computeStartCoordinate derives correct origin', () => {
+    const margin = (CardProcessor as any).CARD_MARGIN;
+    const result = (processor as any).computeStartCoordinate(200, 400, 100);
+    expect(result).toBe(200 - 400 / 2 + margin + 100 / 2);
+  });
+
+  test('maybeCreateFrame creates frame when enabled', async () => {
+    const builder = {
+      createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
+      setFrame: jest.fn(),
+    } as any;
+    const p = new CardProcessor(builder);
+    const dims = { width: 10, height: 20, spot: { x: 1, y: 2 } };
+    const frame = await (p as any).maybeCreateFrame(true, dims, 't');
+    expect(builder.createFrame).toHaveBeenCalledWith(10, 20, 1, 2, 't');
+    expect(frame).toEqual({ id: 'f' });
+  });
+
+  test('maybeCreateFrame skips frame when disabled', async () => {
+    const builder = {
+      createFrame: jest.fn(),
+      setFrame: jest.fn(),
+    } as any;
+    const p = new CardProcessor(builder);
+    const dims = { width: 5, height: 5, spot: { x: 0, y: 0 } };
+    const frame = await (p as any).maybeCreateFrame(false, dims);
+    expect(frame).toBeUndefined();
+    expect(builder.createFrame).not.toHaveBeenCalled();
+    expect(builder.setFrame).toHaveBeenCalledWith(undefined);
+  });
 });


### PR DESCRIPTION
## Summary
- test computeStartCoordinate calculations
- test maybeCreateFrame creation logic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6852b2ebbd70832bb5e38241bcbc9190