### PR TITLE
Add UI test for App component

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,7 +17,12 @@ const dropzoneStyles = {
   fontSize: '1.2em',
 } as const;
 
-const App: React.FC = () => {
+/**
+ * React entry component that renders the file selection and mode
+ * toggling user interface. Extraction as an exported constant allows
+ * the component to be reused in tests without side effects.
+ */
+export const App: React.FC = () => {
   const [files, setFiles] = React.useState<File[]>([]);
   const [withFrame, setWithFrame] = React.useState(false);
   const [frameTitle, setFrameTitle] = React.useState('');
@@ -98,7 +103,7 @@ const App: React.FC = () => {
         {mode === 'diagram' ? 'a diagram' : 'a list of cards'}
       </p>
       <div {...dropzone.getRootProps({ style })}>
-        <input {...dropzone.getInputProps()} />
+        <input data-testid="file-input" {...dropzone.getInputProps()} />
         {dropzone.isDragAccept ? (
           <p className="dnd-text">Drop your JSON file here</p>
         ) : (
@@ -153,5 +158,7 @@ const App: React.FC = () => {
 };
 
 const container = document.getElementById('root');
-const root = createRoot(container!);
-root.render(<App />);
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { App } from '../src/app';
+import { GraphProcessor } from '../src/GraphProcessor';
+import { CardProcessor } from '../src/CardProcessor';
+
+declare const global: any;
+
+describe('App UI integration', () => {
+  beforeEach(() => {
+    global.miro = { board: { notifications: { showError: jest.fn() } } };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  function selectFile(): File {
+    const file = new File(['{}'], 'graph.json', { type: 'application/json' });
+    const input = screen.getByTestId('file-input');
+    fireEvent.change(input, { target: { files: [file] } });
+    return file;
+  }
+
+  test('renders and processes diagram file', async () => {
+    const spy = jest
+      .spyOn(GraphProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as any);
+    render(React.createElement(App));
+    selectFile();
+    const button = screen.getByRole('button', { name: /create diagram/i });
+    fireEvent.click(button);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('toggles to cards mode and processes', async () => {
+    const spy = jest
+      .spyOn(CardProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as any);
+    render(React.createElement(App));
+    fireEvent.click(screen.getByLabelText(/cards/i));
+    selectFile();
+    const button = screen.getByRole('button', { name: /create cards/i });
+    fireEvent.click(button);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('mode radio buttons change description text', () => {
+    render(React.createElement(App));
+    fireEvent.click(screen.getByLabelText(/cards/i));
+    expect(
+      screen.getByText(/select the json file to import a list of cards/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/diagram/i));
+    expect(
+      screen.getByText(/select the json file to import a diagram/i),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- export `App` component for testing
- make rendering conditional and add test ID
- add React Testing Library based tests for App UI interactions

## Testing
- `npm install --silent` *(fails: blocked by network)*
- `npm run typecheck --silent`
- `npm test --silent` *(fails: jest environment jsdom missing)*
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852b5a621e4832b8fc94a33b3ed4f11