### PR TITLE
Improve test coverage

### DIFF
--- a/tests/app-ui-options.test.ts
+++ b/tests/app-ui-options.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { App } from '../src/app';
+import { GraphProcessor } from '../src/GraphProcessor';
+
+function selectFile(): File {
+  const file = new File(['{}'], 'graph.json', { type: 'application/json' });
+  const input = screen.getByTestId('file-input');
+  fireEvent.change(input, { target: { files: [file] } });
+  return file;
+}
+
+describe('App layout options and undo button', () => {
+  test('updates layout options and passes them to processor', async () => {
+    const procSpy = jest
+      .spyOn(GraphProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined);
+    render(React.createElement(App));
+    await act(async () => {
+      selectFile();
+    });
+    fireEvent.change(screen.getByLabelText('Algorithm'), {
+      target: { value: 'force' },
+    });
+    fireEvent.change(screen.getByLabelText('Direction'), {
+      target: { value: 'LEFT' },
+    });
+    fireEvent.change(screen.getByLabelText('Spacing'), {
+      target: { value: '50' },
+    });
+    const button = screen.getByRole('button', { name: /create diagram/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(procSpy).toHaveBeenCalledWith(
+      expect.any(File),
+      expect.objectContaining({
+        layout: { algorithm: 'force', direction: 'LEFT', spacing: 50 },
+      }),
+    );
+  });
+});

--- a/tests/index-error.test.ts
+++ b/tests/index-error.test.ts
@@ -1,0 +1,16 @@
+/** Entry index error handling */
+jest.mock('../src/DiagramApp', () => {
+  return {
+    DiagramApp: {
+      getInstance: jest.fn(() => ({
+        init: jest.fn().mockRejectedValue(new Error('fail')),
+      })),
+    },
+  };
+});
+
+test('logs error when initialization fails', async () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  await import('../src/index');
+  expect(errorSpy).toHaveBeenCalled();
+});

--- a/tests/undo.test.ts
+++ b/tests/undo.test.ts
@@ -20,4 +20,22 @@ describe('undo operations', () => {
     await cp.undoLast();
     expect(remove).toHaveBeenCalledWith([1]);
   });
+
+  test('CardProcessor.undoLast handles empty list', async () => {
+    const builder = new BoardBuilder();
+    const remove = jest.spyOn(builder, 'removeItems').mockResolvedValue();
+    const cp = new CardProcessor(builder);
+    (cp as unknown as { lastCreated: unknown[] }).lastCreated = [];
+    await cp.undoLast();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  test('GraphProcessor.undoLast handles empty list', async () => {
+    const builder = new BoardBuilder();
+    const remove = jest.spyOn(builder, 'removeItems').mockResolvedValue();
+    const gp = new GraphProcessor(builder);
+    (gp as unknown as { lastCreated: unknown[] }).lastCreated = [];
+    await gp.undoLast();
+    expect(remove).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- test error path for index initialization
- test layout option updates in UI
- add undoLast no-op tests for processors

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npx prettier '**/*.{js,jsx,ts,tsx,md,json,yml,yaml,html}' --write`

------
https://chatgpt.com/codex/tasks/task_e_6853ff18b000832ba79bddfcb6c08485