### PR TITLE
Update Node version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,16 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
 
       # Enable Corepack to use Yarn 4
       - run: corepack enable

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   prettier:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
 
       # Enable Corepack to use Yarn 4
       - run: corepack enable

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "vite": "6.3.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^18 || ^20"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Unlicense",
   "engines": {
-    "node": ">=18"
+    "node": "^18 || ^20"
   },
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
## Summary
- support Node 20 alongside Node 18 in `package.json`
- update lockfile engine field
- run CI and Prettier workflows on Node 18 and 20

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68579dedd0c4832b84bb0c78e2fe3355