### PR TITLE
Update sidebar layout with data-driven tabs

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { ResizeTab } from '../ui/pages/ResizeTab';
-import { StyleTab } from '../ui/pages/StyleTab';
-import { GridTab } from '../ui/pages/GridTab';
-import { SpacingTab } from '../ui/pages/SpacingTab';
-import { DiagramTab } from '../ui/pages/DiagramTab';
-import { CardsTab } from '../ui/pages/CardsTab';
-import { TabBar, allTabs } from '../ui/components/TabBar';
-
-export type Tab = 'diagram' | 'cards' | 'resize' | 'style' | 'grid' | 'spacing';
+import { TabBar } from '../ui/components/TabBar';
+import { TAB_DATA, Tab } from '../ui/pages/tabs';
 
 /**
  * React entry component that renders the file selection and mode
@@ -17,28 +10,30 @@ export type Tab = 'diagram' | 'cards' | 'resize' | 'style' | 'grid' | 'spacing';
  * the component to be reused in tests without side effects.
  */
 export const App: React.FC = () => {
-  const [tab, setTab] = React.useState<Tab>('diagram');
+  const [tab, setTab] = React.useState<Tab>(TAB_DATA[0][1]);
+  const tabIds = React.useMemo(() => TAB_DATA.map(t => t[1]), []);
   React.useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.altKey) {
         const idx = parseInt(e.key, 10);
-        if (idx >= 1 && idx <= allTabs.length) {
-          setTab(allTabs[idx - 1]);
+        if (idx >= 1 && idx <= tabIds.length) {
+          setTab(tabIds[idx - 1]);
         }
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, []);
+  }, [tabIds]);
+  const current = TAB_DATA.find(t => t[1] === tab)!;
+  const CurrentComp = current[4];
   return (
-    <div>
-      <TabBar tab={tab} onChange={setTab} />
-      {tab === 'diagram' && <DiagramTab />}
-      {tab === 'cards' && <CardsTab />}
-      {tab === 'resize' && <ResizeTab />}
-      {tab === 'style' && <StyleTab />}
-      {tab === 'grid' && <GridTab />}
-      {tab === 'spacing' && <SpacingTab />}
+    <div id='root'>
+      <TabBar tabs={TAB_DATA} tab={tab} onChange={setTab} />
+      <div className='scrollable'>
+        <h2>{current[2]}</h2>
+        <p>{current[3]}</p>
+        <CurrentComp />
+      </div>
     </div>
   );
 };

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -4,63 +4,76 @@
 *,
 *:before,
 *:after {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html,
 body {
-    height: unset;
-    background: none;
+  height: unset;
+  background: none;
 }
 
 #root {
-    padding: var(--space-small);
-    display: flex;
-    justify-items: center;
-        flex-direction: column;
-        align-items: stretch;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: hidden;
+}
+
+.scrollable {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-small);
 }
 
 #root .buttons {
-    position: sticky;
-    bottom: 0;
-    padding-block: var(--space-medium);
-    background: #fff;
+  position: sticky;
+  bottom: 0;
+  padding-block: var(--space-medium);
+  background: #fff;
 }
 .custom-centered .custom-buttons {
-    position: sticky;
-    bottom: 0;
-    padding-block: var(--space-medium);
-    background: var(--colors-white);
+  position: sticky;
+  bottom: 0;
+  padding-block: var(--space-medium);
+  background: var(--colors-white);
 }
 
 .custom-dropped-files {
-    list-style: none;
-    padding: var(--space-xxsmall) var(--space-xsmall);
-    border: 3px dashed var(--indigoAlpha40);
-    max-height: 80px;
-    overflow-y: auto;
-    font-size: var(--font-size-large);
+  list-style: none;
+  padding: var(--space-xxsmall) var(--space-xsmall);
+  border: 3px dashed var(--indigoAlpha40);
+  max-height: 80px;
+  overflow-y: auto;
+  font-size: var(--font-size-large);
 }
 
 .custom-preview-grid th,
 .custom-preview-grid td {
-    padding: var(--space-xxsmall) var(--space-xsmall);
+  padding: var(--space-xxsmall) var(--space-xsmall);
 }
 
-.custom-segment button+button {
-    margin-left: var(--space-xxsmall);
+.custom-segment button + button {
+  margin-left: var(--space-xxsmall);
 }
-
 
 .custom-visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
-    border: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tabs-header-list {
+  flex-wrap: wrap;
+}
+
+button {
+  padding: var(--space-xxsmall) var(--space-xsmall);
 }

--- a/src/ui/components/TabBar.tsx
+++ b/src/ui/components/TabBar.tsx
@@ -1,34 +1,22 @@
 import React from 'react';
-import type { Tab } from '../../app/app';
-
-const primaryTabs: Tab[] = [
-  'diagram',
-  'cards',
-  'resize',
-  'style',
-  'grid',
-  'spacing',
-];
-
-export const allTabs: Tab[] = [...primaryTabs];
+import type { Tab, TabTuple } from '../pages/tabs';
 
 /** Tab bar with an overflow menu for additional tabs. */
-export const TabBar: React.FC<{ tab: Tab; onChange: (t: Tab) => void }> = ({
-  tab,
-  onChange,
-}) => (
+export const TabBar: React.FC<{
+  tabs: TabTuple[];
+  tab: Tab;
+  onChange: (t: Tab) => void;
+}> = ({ tabs, tab, onChange }) => (
   <div className='tabs'>
     <div className='tabs-header-list'>
-      {primaryTabs.map(t => (
+      {tabs.map(([, id, label]) => (
         <div
-          key={t}
+          key={id}
           role='tab'
-          className={`tab ${tab === t ? 'tab-active' : ''}`}
-          onClick={() => onChange(t)}
+          className={`tab ${tab === id ? 'tab-active' : ''}`}
+          onClick={() => onChange(id)}
         >
-          <div className='tab-text'>
-            {t.charAt(0).toUpperCase() + t.slice(1)}
-          </div>
+          <div className='tab-text'>{label}</div>
         </div>
       ))}
     </div>

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -12,6 +12,7 @@ import {
 } from 'mirotone-react';
 import { CardProcessor } from '../../board/CardProcessor';
 import { cardLoader, CardData } from '../../core/utils/cards';
+import type { TabTuple } from './tab-definitions';
 import { showError } from '../hooks/notifications';
 import { getDropzoneStyle, undoLastImport } from '../hooks/ui-utils';
 
@@ -115,7 +116,6 @@ export const CardsTab: React.FC = () => {
 
   return (
     <div>
-      <Paragraph>Select the JSON file to import a list of cards</Paragraph>
       <div
         {...dropzone.getRootProps({ style })}
         aria-label='File drop area'
@@ -239,3 +239,10 @@ export const CardsTab: React.FC = () => {
     </div>
   );
 };
+export const cardsTabDef: TabTuple = [
+  2,
+  'cards',
+  'Cards',
+  'Select the JSON file to import a list of cards',
+  CardsTab,
+];

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -14,6 +14,7 @@ import {
 } from 'mirotone-react';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { GraphProcessor } from '../../core/graph/GraphProcessor';
+import type { TabTuple } from './tab-definitions';
 import { showError } from '../hooks/notifications';
 import {
   ALGORITHMS,
@@ -103,7 +104,6 @@ export const DiagramTab: React.FC = () => {
 
   return (
     <div>
-      <Paragraph>Select the JSON file to import a diagram</Paragraph>
       <div
         {...dropzone.getRootProps({ style })}
         aria-label='File drop area'
@@ -251,3 +251,10 @@ export const DiagramTab: React.FC = () => {
     </div>
   );
 };
+export const diagramTabDef: TabTuple = [
+  1,
+  'diagram',
+  'Diagram',
+  'Select the JSON file to import a diagram',
+  DiagramTab,
+];

--- a/src/ui/pages/GridTab.tsx
+++ b/src/ui/pages/GridTab.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from 'mirotone-react';
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
+import type { TabTuple } from './tab-definitions';
 
 /** UI for the Grid tab. */
 export const GridTab: React.FC = () => {
@@ -82,3 +83,10 @@ export const GridTab: React.FC = () => {
     </div>
   );
 };
+export const gridTabDef: TabTuple = [
+  5,
+  'grid',
+  'Grid',
+  'Arrange selected items into a grid',
+  GridTab,
+];

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -7,7 +7,6 @@ import {
   Paragraph,
   Icon,
   Text,
-  Heading,
 } from 'mirotone-react';
 import {
   applySizeToSelection,
@@ -15,6 +14,7 @@ import {
   Size,
 } from '../../board/resize-tools';
 import { useSelection } from '../hooks/useSelection';
+import type { TabTuple } from './tab-definitions';
 import {
   boardUnitsToMm,
   boardUnitsToInches,
@@ -84,7 +84,6 @@ export const ResizeTab: React.FC = () => {
 
   return (
     <div className='custom-centered'>
-      <Heading level={2}>Resize Shapes</Heading>
       <Paragraph data-testid='size-display'>
         {copiedSize
           ? `Copied: ${copiedSize.width}×${copiedSize.height}`
@@ -151,3 +150,10 @@ export const ResizeTab: React.FC = () => {
     </div>
   );
 };
+export const resizeTabDef: TabTuple = [
+  3,
+  'resize',
+  'Resize',
+  'Adjust size manually or copy from selection',
+  ResizeTab,
+];

--- a/src/ui/pages/SpacingTab.tsx
+++ b/src/ui/pages/SpacingTab.tsx
@@ -3,6 +3,7 @@ import { Button, Input, InputLabel, Icon, Text } from 'mirotone-react';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
 
+import type { TabTuple } from './tab-definitions';
 /** UI for evenly spacing selected items. */
 export const SpacingTab: React.FC = () => {
   const [opts, setOpts] = React.useState<SpacingOptions>({
@@ -51,3 +52,10 @@ export const SpacingTab: React.FC = () => {
     </div>
   );
 };
+export const spacingTabDef: TabTuple = [
+  6,
+  'spacing',
+  'Spacing',
+  'Distribute items evenly',
+  SpacingTab,
+];

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../board/style-tools';
 import { useSelection } from '../hooks/useSelection';
 
+import type { TabTuple } from './tab-definitions';
 /** UI for the Style tab. */
 export const StyleTab: React.FC = () => {
   const selection = useSelection();
@@ -215,3 +216,10 @@ export const StyleTab: React.FC = () => {
     </div>
   );
 };
+export const styleTabDef: TabTuple = [
+  4,
+  'style',
+  'Style',
+  'Modify color and typography of selected shapes',
+  StyleTab,
+];

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -1,0 +1,17 @@
+import type React from 'react';
+
+export type TabId =
+  | 'diagram'
+  | 'cards'
+  | 'resize'
+  | 'style'
+  | 'grid'
+  | 'spacing';
+
+export type TabTuple = readonly [
+  order: number,
+  id: TabId,
+  label: string,
+  instructions: string,
+  Component: React.FC,
+];

--- a/src/ui/pages/tabs.ts
+++ b/src/ui/pages/tabs.ts
@@ -1,0 +1,19 @@
+import type { TabTuple, TabId } from './tab-definitions';
+import { diagramTabDef } from './DiagramTab';
+import { cardsTabDef } from './CardsTab';
+import { resizeTabDef } from './ResizeTab';
+import { styleTabDef } from './StyleTab';
+import { gridTabDef } from './GridTab';
+import { spacingTabDef } from './SpacingTab';
+
+export const TAB_DATA: TabTuple[] = [
+  diagramTabDef,
+  cardsTabDef,
+  resizeTabDef,
+  styleTabDef,
+  gridTabDef,
+  spacingTabDef,
+].sort((a, b) => a[0] - b[0]);
+
+export type Tab = TabId;
+export type { TabTuple } from './tab-definitions';


### PR DESCRIPTION
## Summary
- style root for scrollable content and sticky buttons
- allow tab bar wrapping and button padding
- make tabs data-driven via new definitions
- fix app component to use new tab data and header area

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68580cf428dc832b8dd0838b14db5e4d