### PR TITLE
Add live colour preview

### DIFF
--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { Button, Icon, Input, Text, InputLabel } from '../components/legacy';
 import { tweakFillColor } from '../../board/style-tools';
+import { adjustColor } from '../../core/utils/color-utils';
+import { tokens } from '../tokens';
 import type { TabTuple } from './tab-definitions';
 
 /** Adjusts the fill colour of selected widgets. */
 export const StyleTab: React.FC = () => {
   const [adjust, setAdjust] = React.useState(0);
+  // Preview colour updated live as the user tweaks the slider
+  const preview = React.useMemo(
+    () => adjustColor('#808080', adjust / 100),
+    [adjust],
+  );
   const apply = async (): Promise<void> => {
     await tweakFillColor(adjust / 100);
   };
@@ -27,6 +34,17 @@ export const StyleTab: React.FC = () => {
             <option key={n} value={n} />
           ))}
         </datalist>
+        <span
+          data-testid='adjust-preview'
+          style={{
+            display: 'inline-block',
+            width: '24px',
+            height: '24px',
+            marginLeft: tokens.space.small,
+            border: `1px solid ${tokens.color.gray[200]}`,
+            backgroundColor: preview,
+          }}
+        />
       </InputLabel>
       <InputLabel>
         Adjust value

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -97,6 +97,16 @@ describe('tab components', () => {
     expect(input.value).toBe('30');
   });
 
+  test('StyleTab preview updates on change', async () => {
+    render(React.createElement(StyleTab));
+    const slider = screen.getByTestId('adjust-slider');
+    const preview = screen.getByTestId('adjust-preview');
+    await act(async () => {
+      fireEvent.change(slider, { target: { value: '50' } });
+    });
+    expect(preview).toHaveStyle({ backgroundColor: '#c0c0c0' });
+  });
+
   test('GridTab applies layout', async () => {
     const spy = jest
       .spyOn(gridTools, 'applyGridLayout')


### PR DESCRIPTION
## Summary
- add preview swatch to StyleTab to show adjusted colour live
- test StyleTab preview

## Testing
- `npm test --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858a96cb3bc832ba0e7d9a578ca033f