### PR TITLE
Ensure label associations for form controls

### DIFF
--- a/src/ui/components/legacy/Checkbox.tsx
+++ b/src/ui/components/legacy/Checkbox.tsx
@@ -27,10 +27,14 @@ export function Checkbox({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     onChange?.(e.target.checked);
   };
+  const generatedId = React.useId();
+  const inputId = props.id ?? generatedId;
+
   return (
     <div className='form-group-small'>
-      <label className={`toggle ${className}`.trim()}>
+      <label htmlFor={inputId} className={`toggle ${className}`.trim()}>
         <input
+          id={inputId}
           type='checkbox'
           checked={value}
           onChange={handleChange}

--- a/src/ui/components/legacy/InputField.tsx
+++ b/src/ui/components/legacy/InputField.tsx
@@ -59,16 +59,13 @@ export function InputField({
       />
     );
   }
+
   return (
     <div className='form-group-small'>
-      <label className={wrapperClassName}>{label}</label>
-      {children ?? (
-        <input
-          className={`input ${className}`.trim()}
-          onChange={handleChange}
-          {...props}
-        />
-      )}
+      <label htmlFor={inputId} className={wrapperClassName}>
+        {label}
+      </label>
+      {control}
     </div>
   );
 }

--- a/tests/checkbox.test.tsx
+++ b/tests/checkbox.test.tsx
@@ -12,6 +12,8 @@ test('Checkbox renders span for Mirotone styling', () => {
   render(<Checkbox label='Option' value={false} onChange={() => {}} />);
   const input = screen.getByRole('checkbox', { name: 'Option' });
   expect(input.nextSibling).toBeInstanceOf(HTMLElement);
+  const label = screen.getByText('Option').closest('label');
+  expect(label).toHaveAttribute('for', input.getAttribute('id'));
 });
 
 test('triggers onChange when toggled on', () => {

--- a/tests/inputfield.test.tsx
+++ b/tests/inputfield.test.tsx
@@ -6,7 +6,10 @@ import { InputField } from '../src/ui/components/legacy/InputField';
 
 test('renders label and input', () => {
   render(<InputField label='Name' value='x' onChange={() => {}} />);
-  expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  const input = screen.getByLabelText('Name');
+  expect(input).toBeInTheDocument();
+  const label = screen.getByText('Name');
+  expect(label).toHaveAttribute('for', input.getAttribute('id'));
 });
 
 test('calls onChange with value', () => {
@@ -23,5 +26,8 @@ test('supports custom child element', () => {
       <input data-testid='custom' type='file' />
     </InputField>,
   );
-  expect(screen.getByTestId('custom')).toBeInTheDocument();
+  const input = screen.getByTestId('custom');
+  const label = screen.getByText('File');
+  expect(label).toHaveAttribute('for', input.getAttribute('id'));
+  expect(input).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add `htmlFor` and `id` mapping to `InputField`
- include generated id on `Checkbox` and map label to it
- verify associations in component tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68594026e2c4832bac11e99b9dc74adb