### PR TITLE
Fix dummy tab filtering

### DIFF
--- a/src/ui/pages/tabs.ts
+++ b/src/ui/pages/tabs.ts
@@ -3,12 +3,14 @@ const modules = import.meta.glob<{ tabDef: TabTuple }>('./*Tab.tsx', {
   eager: true,
 });
 
+/**
+ * Auto registers all sidebar tabs. Dummy tab appears only in test mode to
+ * avoid leaking internal helpers into development or production builds.
+ */
 export const TAB_DATA: TabTuple[] = Object.values(modules)
   .filter((m): m is { tabDef: TabTuple } => 'tabDef' in m)
   .map((m) => m.tabDef)
-  .filter((t) =>
-    process.env.NODE_ENV === 'production' ? t[1] !== 'dummy' : true,
-  )
+  .filter((t) => (process.env.NODE_ENV === 'test' ? true : t[1] !== 'dummy'))
   .sort((a, b) => a[0] - b[0]);
 
 export type Tab = TabId;

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -214,11 +214,19 @@ describe('tab components', () => {
 });
 
 describe('tab auto-registration', () => {
-  test('includes DummyTab in development', async () => {
+  test('includes DummyTab in test environment', async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+    const { TAB_DATA } = await import('../src/ui/pages/tabs?test');
+    expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(true);
+    process.env.NODE_ENV = prev;
+  });
+
+  test('excludes DummyTab in development', async () => {
     const prev = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
-    const { TAB_DATA } = await import('../src/ui/pages/tabs');
-    expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(true);
+    const { TAB_DATA } = await import('../src/ui/pages/tabs?dev');
+    expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(false);
     process.env.NODE_ENV = prev;
   });
 


### PR DESCRIPTION
## Summary
- prevent DummyTab from appearing outside of tests
- adjust tests for new behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685948037ed0832b9f1fe5e9d8f70dee