### PR TITLE
Fix card spacing during creation

### DIFF
--- a/src/board/CardProcessor.ts
+++ b/src/board/CardProcessor.ts
@@ -21,6 +21,8 @@ export class CardProcessor {
   private static readonly CARD_HEIGHT = 88;
   /** Spacing margin applied around cards and frames. */
   private static readonly CARD_MARGIN = 50;
+  /** Gap between cards when arranged in a grid. */
+  private static readonly CARD_GAP = 24;
   private lastCreated: Array<Card | Frame> = [];
   /** Cached board cards when processing updates. */
   private cardsCache: Card[] | undefined;
@@ -82,8 +84,12 @@ export class CardProcessor {
         toCreate.map((def, i) =>
           this.createCardWidget(
             def,
-            startX + (i % columns) * CardProcessor.CARD_WIDTH,
-            startY + Math.floor(i / columns) * CardProcessor.CARD_HEIGHT,
+            startX +
+              (i % columns) *
+                (CardProcessor.CARD_WIDTH + CardProcessor.CARD_GAP),
+            startY +
+              Math.floor(i / columns) *
+                (CardProcessor.CARD_HEIGHT + CardProcessor.CARD_GAP),
             tagMap,
           ),
         ),
@@ -248,9 +254,13 @@ export class CardProcessor {
     const cols = Math.max(1, Math.min(columns, count));
     const rows = Math.ceil(count / cols);
     const totalWidth =
-      CardProcessor.CARD_WIDTH * cols + CardProcessor.CARD_MARGIN * 2;
+      CardProcessor.CARD_WIDTH * cols +
+      CardProcessor.CARD_GAP * (cols - 1) +
+      CardProcessor.CARD_MARGIN * 2;
     const totalHeight =
-      CardProcessor.CARD_HEIGHT * rows + CardProcessor.CARD_MARGIN * 2;
+      CardProcessor.CARD_HEIGHT * rows +
+      CardProcessor.CARD_GAP * (rows - 1) +
+      CardProcessor.CARD_MARGIN * 2;
     const spot = await this.builder.findSpace(totalWidth, totalHeight);
     const startX = this.computeStartCoordinate(
       spot.x,

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -170,10 +170,10 @@ describe('CardProcessor', () => {
       { columns: 2 },
     );
     const calls = (global.miro.board.createCard as jest.Mock).mock.calls;
-    expect(calls[0][0]).toEqual(expect.objectContaining({ x: -160, y: -44 }));
-    expect(calls[1][0]).toEqual(expect.objectContaining({ x: 160, y: -44 }));
-    expect(calls[2][0]).toEqual(expect.objectContaining({ x: -160, y: 44 }));
-    expect(calls[3][0]).toEqual(expect.objectContaining({ x: 160, y: 44 }));
+    expect(calls[0][0]).toEqual(expect.objectContaining({ x: -172, y: -56 }));
+    expect(calls[1][0]).toEqual(expect.objectContaining({ x: 172, y: -56 }));
+    expect(calls[2][0]).toEqual(expect.objectContaining({ x: -172, y: 56 }));
+    expect(calls[3][0]).toEqual(expect.objectContaining({ x: 172, y: 56 }));
   });
 
   test('throws on invalid input', async () => {


### PR DESCRIPTION
## Summary
- ensure new cards are created with a gap between them
- adjust layout calculation accordingly
- update unit tests

## Testing
- `npm test --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6859493a185c832b9da51e0c9aab1bdf