### PR TITLE
Implement styled preset buttons

### DIFF
--- a/src/board/format-tools.ts
+++ b/src/board/format-tools.ts
@@ -2,6 +2,29 @@ import { resolveColor } from '../core/utils/color-utils';
 import { BoardLike, getBoard } from './board';
 import type { StylePreset } from '../ui/style-presets';
 
+/** Resolved preset style attributes. */
+export interface PresetStyle {
+  color: string;
+  borderColor: string;
+  borderWidth: number;
+  fillColor: string;
+}
+
+/**
+ * Convert a style preset into widget style attributes.
+ *
+ * @param preset - Preset definition.
+ * @returns Widget style object with resolved colours.
+ */
+export function presetStyle(preset: StylePreset): PresetStyle {
+  return {
+    color: resolveColor(preset.fontColor, '#000000'),
+    borderColor: resolveColor(preset.borderColor, '#000000'),
+    borderWidth: preset.borderWidth,
+    fillColor: resolveColor(preset.fillColor, '#ffffff'),
+  };
+}
+
 /**
  * Apply a style preset to all selected widgets.
  */
@@ -13,11 +36,12 @@ export async function applyStylePreset(
   const selection = await b.getSelection();
   await Promise.all(
     selection.map(async (item: Record<string, unknown>) => {
-      const style = (item.style ?? {}) as Record<string, unknown>;
-      style.color = resolveColor(preset.fontColor, '#000000');
-      style.borderColor = resolveColor(preset.borderColor, '#000000');
-      style.borderWidth = preset.borderWidth;
-      style.fillColor = resolveColor(preset.fillColor, '#ffffff');
+      const style = { ...(item.style ?? {}) } as Record<string, unknown>;
+      const resolved = presetStyle(preset);
+      style.color = resolved.color;
+      style.borderColor = resolved.borderColor;
+      style.borderWidth = resolved.borderWidth;
+      style.fillColor = resolved.fillColor;
       item.style = style;
       if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
         await (item as { sync: () => Promise<void> }).sync();

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Icon, InputField, Text } from '../components/legacy';
 import { tweakFillColor, extractFillColor } from '../../board/style-tools';
-import { applyStylePreset } from '../../board/format-tools';
+import { applyStylePreset, presetStyle } from '../../board/format-tools';
 import { STYLE_PRESETS } from '../style-presets';
 import { adjustColor } from '../../core/utils/color-utils';
 import { useSelection } from '../hooks/use-selection';
@@ -85,14 +85,24 @@ export const StyleTab: React.FC = () => {
         </Button>
       </div>
       <div className='buttons'>
-        {STYLE_PRESETS.map((p) => (
-          <Button
-            key={p.id}
-            onClick={() => applyStylePreset(p)}
-            variant='secondary'>
-            {p.label}
-          </Button>
-        ))}
+        {STYLE_PRESETS.map((p) => {
+          const style = presetStyle(p);
+          return (
+            <Button
+              key={p.id}
+              onClick={() => applyStylePreset(p)}
+              variant='secondary'
+              style={{
+                color: style.color,
+                backgroundColor: style.fillColor,
+                borderColor: style.borderColor,
+                borderWidth: style.borderWidth,
+                borderStyle: 'solid',
+              }}>
+              {p.label}
+            </Button>
+          );
+        })}
       </div>
     </div>
   );

--- a/tests/format-tools.test.ts
+++ b/tests/format-tools.test.ts
@@ -1,4 +1,4 @@
-import { applyStylePreset } from '../src/board/format-tools';
+import { applyStylePreset, presetStyle } from '../src/board/format-tools';
 import type { StylePreset } from '../src/ui/style-presets';
 
 describe('format-tools', () => {
@@ -28,5 +28,29 @@ describe('format-tools', () => {
     await expect(applyStylePreset(preset)).rejects.toThrow(
       'Miro board not available',
     );
+  });
+
+  test('presetStyle resolves colours', () => {
+    const style = document.documentElement.style;
+    style.setProperty('--test-font', '#111111');
+    style.setProperty('--test-border', '#222222');
+    style.setProperty('--test-fill', '#333333');
+    const presetToken: StylePreset = {
+      id: 'tok',
+      label: 'Token',
+      fontColor: 'var(--test-font)',
+      borderWidth: 3,
+      borderColor: 'var(--test-border)',
+      fillColor: 'var(--test-fill)',
+    };
+    expect(presetStyle(presetToken)).toEqual({
+      color: '#111111',
+      borderColor: '#222222',
+      borderWidth: 3,
+      fillColor: '#333333',
+    });
+    style.removeProperty('--test-font');
+    style.removeProperty('--test-border');
+    style.removeProperty('--test-fill');
   });
 });

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -22,7 +22,11 @@ vi.mock('../src/board/style-tools', async () => {
     await vi.importActual('../src/board/style-tools');
   return { ...actual, tweakFillColor: jest.fn() };
 });
-vi.mock('../src/board/format-tools');
+vi.mock('../src/board/format-tools', async () => {
+  const actual: typeof import('../src/board/format-tools') =
+    await vi.importActual('../src/board/format-tools');
+  return { ...actual, applyStylePreset: jest.fn() };
+});
 vi.mock('../src/board/grid-tools');
 vi.mock('../src/board/spacing-tools');
 vi.mock('../src/core/graph/graph-processor');
@@ -145,6 +149,25 @@ describe('tab components', () => {
       fireEvent.click(screen.getByRole('button', { name: /primary/i }));
     });
     expect(spy).toHaveBeenCalled();
+  });
+
+  test('Style preset button displays colours', async () => {
+    const style = document.documentElement.style;
+    style.setProperty('--colors-blue-150', '#111111');
+    style.setProperty('--colors-blue-200', '#222222');
+    style.setProperty('--white', '#ffffff');
+    await act(async () => {
+      render(React.createElement(StyleTab));
+    });
+    const btn = screen.getByRole('button', { name: /primary/i });
+    expect(btn).toHaveStyle({
+      backgroundColor: '#111111',
+      borderColor: '#222222',
+      color: '#ffffff',
+    });
+    style.removeProperty('--colors-blue-150');
+    style.removeProperty('--colors-blue-200');
+    style.removeProperty('--white');
   });
 
   test('GridTab applies layout', async () => {


### PR DESCRIPTION
## Summary
- add `presetStyle` helper to convert presets
- style preset buttons using resolved colours
- cover `presetStyle` with unit tests
- expand tabs test to verify button styling

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npx prettier '**/*.{js,jsx,ts,tsx,md,json,yml,yaml,html}' --write`

------
https://chatgpt.com/codex/tasks/task_e_685951b59108832b847597ebd7f53f29