### PR TITLE
Implement tag caching for CardProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ placement.
 Each card entry must specify a `title`. All other properties are optional:
 
 - `description`: Markdown or plain text body
-- `tags`: array of tag names to assign
+- `tags`: array of tag names to assign. These are mapped to the widget's
+  `tagIds` field when cards are created or updated
 - `style`: card appearance (theme and background)
 - `fields`: custom preview fields shown on the card
 - `taskStatus`: Kanban status such as `to-do`

--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -31,6 +31,8 @@ export class CardProcessor {
   private cardsCache: Card[] | undefined;
   /** Cached map from card identifier to card widget. */
   private cardMap: Map<string, Card> | undefined;
+  /** Cached board tags when processing updates. */
+  private tagsCache: Tag[] | undefined;
 
   constructor(private builder: BoardBuilder = new BoardBuilder()) {}
 
@@ -57,6 +59,7 @@ export class CardProcessor {
     // Reset per-run caches to ensure fresh board state
     this.cardsCache = undefined;
     this.cardMap = undefined;
+    this.tagsCache = undefined;
 
     const boardTags = await this.getBoardTags();
     const tagMap = new Map(boardTags.map((t) => [t.title, t]));
@@ -121,8 +124,12 @@ export class CardProcessor {
     }
   }
 
+  /** Retrieve all tags on the board, cached for the current run. */
   private async getBoardTags(): Promise<Tag[]> {
-    return (await miro.board.get({ type: 'tag' })) as Tag[];
+    if (!this.tagsCache) {
+      this.tagsCache = (await miro.board.get({ type: 'tag' })) as Tag[];
+    }
+    return this.tagsCache;
   }
 
   /** Retrieve all cards on the board, cached for the current run. */

--- a/tests/card-processor-branches2.test.ts
+++ b/tests/card-processor-branches2.test.ts
@@ -27,6 +27,19 @@ describe('CardProcessor branches', () => {
     expect(board.get).toHaveBeenCalledTimes(1);
   });
 
+  test('getBoardTags caches board fetches', async () => {
+    const board = { get: jest.fn().mockResolvedValue([]) };
+    global.miro = { board };
+    const cp = new CardProcessor();
+    await (
+      cp as unknown as { getBoardTags: () => Promise<unknown[]> }
+    ).getBoardTags();
+    await (
+      cp as unknown as { getBoardTags: () => Promise<unknown[]> }
+    ).getBoardTags();
+    expect(board.get).toHaveBeenCalledTimes(1);
+  });
+
   test('loadCardMap ignores cards without id metadata', async () => {
     const card = {
       getMetadata: jest.fn().mockResolvedValue({}),


### PR DESCRIPTION
## Summary
- add cached tag retrieval in `CardProcessor`
- reset tag cache when processing cards
- test caching behaviour for board tags
- clarify tag usage in documentation

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` (with a React version warning)
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685be3b9e638832baa30daf6d2ffe10c