### PR TITLE
Load ELK via dynamic import

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The layout step leverages the ELK algorithm to compute positions for all nodes.
 You can provide layout hints in each node's metadata to influence spacing or
 layering. The engine runs automatically when a graph is uploaded. For an
 overview of available layout algorithms see
-[docs/LAYOUT_OPTIONS.md](docs/LAYOUT_OPTIONS.md).
+[docs/LAYOUT_OPTIONS.md](docs/LAYOUT_OPTIONS.md). The ELK engine itself is
+loaded from the jsDelivr CDN at runtime to keep the application bundle small.
 
 ## Template‑Based Shapes
 

--- a/src/core/layout/elk-loader.ts
+++ b/src/core/layout/elk-loader.ts
@@ -1,0 +1,30 @@
+import type ELK from 'elkjs/lib/elk.bundled.js';
+
+/**
+ * Dynamically load the ELK layout engine.
+ *
+ * In Node-based environments (tests) the package is imported from
+ * `node_modules`. Browsers fetch the library from the jsDelivr CDN to
+ * avoid bundling it with the application.
+ */
+let elkPromise: Promise<typeof ELK> | null = null;
+
+/**
+ * Retrieve the ELK constructor. Subsequent calls return the cached value.
+ */
+export async function loadElk(): Promise<typeof ELK> {
+  if (elkPromise) return elkPromise;
+  const isNode =
+    typeof process !== 'undefined' && process.release?.name === 'node';
+  elkPromise = isNode
+    ? import('elkjs/lib/elk.bundled.js').then((m) => m.default)
+    : (async () => {
+        const url =
+          'https://cdn.jsdelivr.net/npm/elkjs@0.10.0/lib/elk.bundled.js';
+        const mod = (await import(/* @vite-ignore */ url)) as {
+          default?: typeof ELK;
+        };
+        return mod.default ?? (window as unknown as { ELK: typeof ELK }).ELK;
+      })();
+  return elkPromise;
+}

--- a/src/core/layout/layout-core.ts
+++ b/src/core/layout/layout-core.ts
@@ -1,4 +1,4 @@
-import ELK from 'elkjs/lib/elk.bundled.js';
+import { loadElk } from './elk-loader';
 import type { ElkNode } from 'elkjs/lib/elk-api';
 import { GraphData } from '../graph';
 import { templateManager } from '../../board/templates';
@@ -33,7 +33,8 @@ export async function performLayout(
   data: GraphData,
   opts: Partial<UserLayoutOptions> = {},
 ): Promise<LayoutResult> {
-  const elk = new ELK();
+  const Elk = await loadElk();
+  const elk = new Elk();
   const userOpts = validateLayoutOptions(opts);
   const elkGraph: ElkNode = {
     id: 'root',

--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -27,7 +27,7 @@ const LEAF_WIDTH = 120;
 const LEAF_HEIGHT = 30;
 const PADDING = 20;
 
-import ELK from 'elkjs/lib/elk.bundled.js';
+import { loadElk } from './elk-loader';
 import type { ElkNode } from 'elkjs/lib/elk-api';
 
 /**
@@ -104,7 +104,8 @@ export class NestedLayouter {
       },
       children: roots.map((r) => this.buildElkNode(r, opts.sortKey)),
     };
-    const elk = new ELK();
+    const Elk = await loadElk();
+    const elk = new Elk();
     const result = await elk.layout(elkRoot);
     const nodes: Record<string, PositionedNode> = {};
     for (const child of result.children || []) {

--- a/tests/elk-loader.test.ts
+++ b/tests/elk-loader.test.ts
@@ -1,0 +1,17 @@
+import { loadElk } from '../src/core/layout/elk-loader';
+import ELK from 'elkjs/lib/elk.bundled.js';
+
+/** Tests for the dynamic ELK loader. */
+describe('loadElk', () => {
+  test('returns the local ELK class when running in Node', async () => {
+    const mod = await loadElk();
+    expect(mod).toBe(ELK);
+    expect(typeof mod).toBe('function');
+  });
+
+  test('caches subsequent calls', async () => {
+    const first = await loadElk();
+    const second = await loadElk();
+    expect(first).toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary
- fetch ELK from jsDelivr in browsers using a new loader
- refactor layout modules to use the dynamic loader
- mention CDN loading in README
- add unit tests for the loader

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685cefd32ed0832b9bbdc40665014486