### PR TITLE
Add data mapper for Excel rows

### DIFF
--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -335,11 +335,13 @@ export class BoardBuilder {
     );
     if ((widget as Group).type === 'group') {
       const items = await (widget as Group).getItems();
-      await Promise.all(
-        items.map((item) =>
-          item.setMetadata(META_KEY, { type: node.type, label: node.label }),
-        ),
-      );
+      const meta = { type: node.type, label: node.label };
+      const master = templateManager.getTemplate(node.type)?.masterElement;
+      if (master !== undefined && items[master]) {
+        await items[master].setMetadata(META_KEY, meta);
+      } else {
+        await Promise.all(items.map((i) => i.setMetadata(META_KEY, meta)));
+      }
       return widget as Group;
     }
     await (widget as BaseItem).setMetadata(META_KEY, {

--- a/src/board/templates.ts
+++ b/src/board/templates.ts
@@ -31,6 +31,11 @@ export interface TemplateElement {
 
 export interface TemplateDefinition {
   elements: TemplateElement[];
+  /**
+   * Optional index of the element that stores metadata when grouped.
+   * If omitted, metadata is applied to every element.
+   */
+  masterElement?: number;
 }
 
 export interface TemplateCollection {

--- a/src/core/data-mapper.ts
+++ b/src/core/data-mapper.ts
@@ -1,0 +1,91 @@
+/**
+ * Mapping configuration describing column headers for various fields.
+ */
+export interface ColumnMapping {
+  /** Column used for the optional unique identifier. */
+  idColumn?: string;
+  /** Column providing the template or type value. */
+  templateColumn?: string;
+  /** Column containing the node label or card title. */
+  labelColumn?: string;
+  /** Column used for free form text such as descriptions. */
+  textColumn?: string;
+  /** Mapping of metadata keys to column headers. */
+  metadataColumns?: Record<string, string>;
+}
+
+export interface NodeDefinition {
+  id: string;
+  label: string;
+  type: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CardDefinition {
+  id?: string;
+  title: string;
+  description?: string;
+  style?: { cardTheme?: string };
+}
+
+/**
+ * Convert an array of Excel rows into {@link NodeDefinition} objects.
+ *
+ * @param rows - Parsed rows from {@link ExcelLoader}.
+ * @param mapping - Column mapping configuration.
+ */
+export function mapRowsToNodes(
+  rows: Array<Record<string, unknown>>,
+  mapping: ColumnMapping,
+): NodeDefinition[] {
+  return rows.map((row, index) => {
+    const metadata: Record<string, unknown> = {};
+    if (mapping.textColumn && row[mapping.textColumn] != null) {
+      metadata.text = row[mapping.textColumn];
+    }
+    const metaCols = mapping.metadataColumns ?? {};
+    Object.keys(metaCols).forEach((key) => {
+      const col = metaCols[key];
+      const value = row[col];
+      if (value != null) metadata[key] = value;
+    });
+    const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
+    const typeVal = mapping.templateColumn
+      ? row[mapping.templateColumn]
+      : undefined;
+    const labelVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
+    return {
+      id: idVal != null ? String(idVal) : String(index),
+      label: labelVal != null ? String(labelVal) : '',
+      type: typeVal != null ? String(typeVal) : 'default',
+      metadata: Object.keys(metadata).length ? metadata : undefined,
+    };
+  });
+}
+
+/**
+ * Convert an array of Excel rows into {@link CardDefinition} objects.
+ *
+ * @param rows - Parsed rows from {@link ExcelLoader}.
+ * @param mapping - Column mapping configuration.
+ */
+export function mapRowsToCards(
+  rows: Array<Record<string, unknown>>,
+  mapping: ColumnMapping,
+): CardDefinition[] {
+  return rows.map((row) => {
+    const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
+    const titleVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
+    const descVal = mapping.textColumn ? row[mapping.textColumn] : undefined;
+    const themeVal = mapping.templateColumn
+      ? row[mapping.templateColumn]
+      : undefined;
+    const card: CardDefinition = {
+      title: titleVal != null ? String(titleVal) : '',
+    };
+    if (idVal != null) card.id = String(idVal);
+    if (descVal != null) card.description = String(descVal);
+    if (themeVal != null) card.style = { cardTheme: String(themeVal) };
+    return card;
+  });
+}

--- a/tests/boardbuilder-extra.test.ts
+++ b/tests/boardbuilder-extra.test.ts
@@ -84,7 +84,10 @@ describe('BoardBuilder additional cases', () => {
       } as unknown as { type: string; getItems: () => Promise<unknown[]> });
     jest
       .spyOn(templateManager, 'getTemplate')
-      .mockReturnValue({ elements: [{ shape: 'r' }, { text: 't' }] });
+      .mockReturnValue({
+        elements: [{ shape: 'r' }, { text: 't' }],
+        masterElement: 1,
+      });
     const builder = new BoardBuilder();
     const spy = jest.spyOn(builder, 'findNode');
     const node = { id: 'n1', label: 'A', type: 'multi' } as Record<
@@ -94,8 +97,9 @@ describe('BoardBuilder additional cases', () => {
     const pos = { x: 0, y: 0, width: 1, height: 1 };
     const result = await builder.createNode(node, pos);
     expect(result.type).toBe('group');
-    // Metadata should be written to child items
-    expect(items[0].setMetadata).toHaveBeenCalled();
+    // Metadata should be written only to the master element
+    expect(items[0].setMetadata).not.toHaveBeenCalled();
+    expect(items[1].setMetadata).toHaveBeenCalled();
     expect(spy).not.toHaveBeenCalled();
   });
 

--- a/tests/data-mapper.test.ts
+++ b/tests/data-mapper.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'vitest';
+import { mapRowsToNodes, mapRowsToCards } from '../src/core/data-mapper';
+
+describe('data mapper', () => {
+  test('maps rows to nodes with metadata', () => {
+    const rows = [{ ID: '1', Type: 'Role', Name: 'A', Note: 'n', Extra: 'x' }];
+    const opts = {
+      idColumn: 'ID',
+      templateColumn: 'Type',
+      labelColumn: 'Name',
+      textColumn: 'Note',
+      metadataColumns: { extra: 'Extra' },
+    } as const;
+    const result = mapRowsToNodes(rows, opts);
+    expect(result).toEqual([
+      {
+        id: '1',
+        label: 'A',
+        type: 'Role',
+        metadata: { text: 'n', extra: 'x' },
+      },
+    ]);
+  });
+
+  test('maps rows to cards with style', () => {
+    const rows = [{ ID: 'a', Title: 'T', Desc: 'D', Theme: 'blue' }];
+    const opts = {
+      idColumn: 'ID',
+      labelColumn: 'Title',
+      textColumn: 'Desc',
+      templateColumn: 'Theme',
+    } as const;
+    const result = mapRowsToCards(rows, opts);
+    expect(result).toEqual([
+      { id: 'a', title: 'T', description: 'D', style: { cardTheme: 'blue' } },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- convert Excel rows into NodeData and CardData
- allow specifying master metadata element in widget templates
- apply masterElement when setting node metadata
- test new data-mapper utilities
- adjust existing tests for updated metadata logic

## Testing
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d4f4f5ff4832ba21de7deaf6360f8