### PR TITLE
Add Excel import documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ committing so code conforms to the repository guidelines.
 - [Design Foundation](docs/FOUNDATION.md) explains tokens and theming rules.
 - [Code Style](docs/CODE_STYLE.md) outlines formatting and naming rules.
 - [UI Patterns](docs/PATTERNS.md) shows common layouts and best practices.
+- [Excel Import](docs/EXCEL_IMPORT.md) details workbook loading and sync.
 
 ## Docker Image
 


### PR DESCRIPTION
## Summary
- document how Excel workbooks are imported and synchronised
- link the new design doc from the README

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e62ed5fd8832ba8ac7b7edf081084