### PR TITLE
Add getFirstSelection helper

### DIFF
--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -57,6 +57,23 @@ export function getBoardWithQuery(board?: BoardQueryLike): BoardQueryLike {
 }
 
 /**
+ * Fetch the first item from the current board selection.
+ *
+ * Convenience wrapper for {@link getBoard} that resolves the active board and
+ * reads the first selected widget.
+ *
+ * @param board - Optional board API overriding `miro.board` for testing.
+ * @returns The first selected item or `undefined` when nothing is selected.
+ */
+export async function getFirstSelection(
+  board?: BoardLike,
+): Promise<Record<string, unknown> | undefined> {
+  const b = getBoard(board);
+  const selection = await b.getSelection();
+  return selection[0] as Record<string, unknown> | undefined;
+}
+
+/**
  * Invoke a callback for every selected widget.
  *
  * Abstracts the common pattern of fetching the current selection and applying

--- a/src/board/resize-tools.ts
+++ b/src/board/resize-tools.ts
@@ -14,7 +14,7 @@ export interface Size {
 import {
   BoardLike,
   forEachSelection,
-  getBoard,
+  getFirstSelection,
   maybeSync,
   Syncable,
 } from './board';
@@ -28,9 +28,9 @@ import {
 export async function copySizeFromSelection(
   board?: BoardLike,
 ): Promise<Size | null> {
-  const b = getBoard(board);
-  const selection = await b.getSelection();
-  const first = selection[0] as { width?: number; height?: number } | undefined;
+  const first = (await getFirstSelection(board)) as
+    | { width?: number; height?: number }
+    | undefined;
   if (
     !first ||
     typeof first.width !== 'number' ||

--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -11,7 +11,7 @@ import {
 import {
   BoardLike,
   forEachSelection,
-  getBoard,
+  getFirstSelection,
   maybeSync,
   Syncable,
 } from './board';
@@ -114,9 +114,8 @@ export function extractFillColor(
 export async function copyFillFromSelection(
   board?: BoardLike,
 ): Promise<string | null> {
-  const b = getBoard(board);
-  const selection = await b.getSelection();
-  return extractFillColor(selection[0]);
+  const item = await getFirstSelection(board);
+  return extractFillColor(item);
 }
 
 /**

--- a/tests/board-utils.test.ts
+++ b/tests/board-utils.test.ts
@@ -1,4 +1,8 @@
-import { forEachSelection, maybeSync } from '../src/board/board';
+import {
+  forEachSelection,
+  getFirstSelection,
+  maybeSync,
+} from '../src/board/board';
 
 describe('forEachSelection', () => {
   describe('callback invocation', () => {
@@ -34,5 +38,20 @@ describe('maybeSync', () => {
 
   test('resolves when sync missing', async () => {
     await expect(maybeSync({})).resolves.toBeUndefined();
+  });
+});
+
+describe('getFirstSelection', () => {
+  test('returns first selected item', async () => {
+    const items = [{ a: 1 }, { b: 2 }];
+    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const result = await getFirstSelection(board);
+    expect(result).toBe(items[0]);
+  });
+
+  test('returns undefined when selection empty', async () => {
+    const board = { getSelection: jest.fn().mockResolvedValue([]) };
+    const result = await getFirstSelection(board);
+    expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add `getFirstSelection` to query the first selected widget
- refactor resize- and style-tools to use the helper
- extend board utilities tests for new helper

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68611e217b80832ba769c90004dc139f