### PR TITLE
Fix ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,10 @@
 /*jshint esversion: 6 */
-import tseslint from '@typescript-eslint/eslint-plugin';
-import parser from '@typescript-eslint/parser';
+import tseslint from 'typescript-eslint';
 import react from 'eslint-plugin-react';
 
-export default [
+export default tseslint.config(
   { ignores: ['node_modules/**', 'dist/**'] },
-  ...tseslint.configs['flat/recommended'],
+  ...tseslint.configs.recommended,
   {
     plugins: { react },
     ...react.configs.flat.recommended,
@@ -14,7 +13,7 @@ export default [
   {
     files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
-      parser,
+      parser: tseslint.parser,
       ecmaVersion: 'latest',
       sourceType: 'module',
       parserOptions: { project: './tsconfig.json' },
@@ -23,8 +22,12 @@ export default [
   },
   {
     files: ['tests/**/*.{ts,tsx}'],
-    languageOptions: { parser, ecmaVersion: 'latest', sourceType: 'module' },
+    languageOptions: {
+      parser: tseslint.parser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
     settings: { react: { version: 'detect' } },
     rules: {},
   },
-];
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "stylelint": "^16.21.0",
         "stylelint-config-standard": "^38.0.0",
         "typescript": "^5.8.3",
+        "typescript-eslint": "^7.18.0",
         "vite": "^7.0.0",
         "vitest": "^3.2.4"
       },
@@ -14363,6 +14364,33 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.18.0.tgz",
+      "integrity": "sha512-PonBkP603E3tt05lDkbOMyaxJjvKqQrXsnow72sVeOFINDE/qNmnnd+f9b4N+U7W6MXnnYyrhtmF2t08QWwUbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "7.18.0",
+        "@typescript-eslint/parser": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "typescript-eslint": "^7.18.0",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Summary
- update eslint.config.js to use the `typescript-eslint` package
- install the matching dev dependency

## Testing
- `npm run typecheck --silent` *(fails: Cannot find module '@mirohq/design-tokens')*
- `npm test --silent` *(fails to resolve module '@mirohq/design-tokens')*
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_68612addd4dc832bace1ed7a1fb86e53