### PR TITLE
Move element helpers

### DIFF
--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -1,4 +1,4 @@
-import type { ConnectorTemplate, TemplateElement } from './templates';
+import type { ConnectorTemplate } from './templates';
 import { templateManager } from './templates';
 import type {
   BaseItem,
@@ -8,10 +8,7 @@ import type {
   Group,
   GroupableItem,
   Shape,
-  ShapeStyle,
-  Text,
   TextAlignVertical,
-  TextStyle,
 } from '@mirohq/websdk-types';
 import type {
   EdgeData,
@@ -254,70 +251,6 @@ export class BoardBuilder {
       }),
     );
     return matches.find(Boolean);
-  }
-
-  /**
-   * Apply template values for a shape element to an existing item.
-   * This updates geometry, text content and style attributes in place.
-   */
-  public applyShapeElement(
-    item: BaseItem,
-    element: TemplateElement,
-    label: string,
-  ): void {
-    const shape = item as Shape;
-    if (element.shape) shape.shape = element.shape as Shape['shape'];
-    if (element.rotation !== undefined) shape.rotation = element.rotation;
-    if (element.width)
-      (shape as unknown as { width: number }).width = element.width;
-    if (element.height)
-      (shape as unknown as { height: number }).height = element.height;
-    shape.content = (element.text ?? '{{label}}').replace('{{label}}', label);
-    const existing = (shape.style ?? {}) as Partial<ShapeStyle>;
-    const style: Partial<ShapeStyle> & Record<string, unknown> = {
-      ...existing,
-      ...templateManager.resolveStyle(element.style ?? {}),
-    };
-    if (element.fill && !('fillColor' in style)) {
-      style.fillColor = templateManager.resolveStyle({
-        fillColor: element.fill,
-      }).fillColor as string;
-    }
-    shape.style = style as ShapeStyle;
-  }
-
-  /**
-   * Apply text element properties such as content and style to a widget.
-   */
-  public applyTextElement(
-    item: BaseItem,
-    element: TemplateElement,
-    label: string,
-  ): void {
-    const text = item as Text;
-    text.content = (element.text ?? '{{label}}').replace('{{label}}', label);
-    if (element.style) {
-      text.style = {
-        ...(text.style ?? ({} as Partial<TextStyle>)),
-        ...(templateManager.resolveStyle(element.style) as Partial<TextStyle>),
-      } as TextStyle;
-    }
-  }
-
-  /**
-   * Route element application based on widget type.
-   * Shapes and text widgets share most properties but are handled separately.
-   */
-  public applyElementToItem(
-    item: BaseItem,
-    element: TemplateElement,
-    label: string,
-  ): void {
-    if (item.type === 'shape') {
-      this.applyShapeElement(item, element, label);
-    } else if (item.type === 'text') {
-      this.applyTextElement(item, element, label);
-    }
   }
 
   /**

--- a/src/board/element-utils.ts
+++ b/src/board/element-utils.ts
@@ -1,0 +1,84 @@
+import { templateManager } from './templates';
+import type {
+  BaseItem,
+  Shape,
+  ShapeStyle,
+  Text,
+  TextStyle,
+} from '@mirohq/websdk-types';
+import type { TemplateElement } from './templates';
+
+/**
+ * Apply template values for a shape element to an existing widget.
+ *
+ * This updates geometry, text content and style attributes in place.
+ *
+ * @param item - Board item expected to be of type `shape`.
+ * @param element - Template description containing default values.
+ * @param label - Label text substituted into the template.
+ */
+export function applyShapeElement(
+  item: BaseItem,
+  element: TemplateElement,
+  label: string,
+): void {
+  const shape = item as Shape;
+  if (element.shape) shape.shape = element.shape as Shape['shape'];
+  if (element.rotation !== undefined) shape.rotation = element.rotation;
+  if (element.width)
+    (shape as unknown as { width: number }).width = element.width;
+  if (element.height)
+    (shape as unknown as { height: number }).height = element.height;
+  shape.content = (element.text ?? '{{label}}').replace('{{label}}', label);
+  const existing = (shape.style ?? {}) as Partial<ShapeStyle>;
+  const style: Partial<ShapeStyle> & Record<string, unknown> = {
+    ...existing,
+    ...templateManager.resolveStyle(element.style ?? {}),
+  };
+  if (element.fill && !('fillColor' in style)) {
+    style.fillColor = templateManager.resolveStyle({ fillColor: element.fill })
+      .fillColor as string;
+  }
+  shape.style = style as ShapeStyle;
+}
+
+/**
+ * Apply text element properties such as content and style to a widget.
+ *
+ * @param item - Board item of type `text`.
+ * @param element - Template description for the text element.
+ * @param label - Label text substituted into the template.
+ */
+export function applyTextElement(
+  item: BaseItem,
+  element: TemplateElement,
+  label: string,
+): void {
+  const text = item as Text;
+  text.content = (element.text ?? '{{label}}').replace('{{label}}', label);
+  if (element.style) {
+    text.style = {
+      ...(text.style ?? ({} as Partial<TextStyle>)),
+      ...(templateManager.resolveStyle(element.style) as Partial<TextStyle>),
+    } as TextStyle;
+  }
+}
+
+/**
+ * Route element application based on widget type.
+ *
+ * @param item - Target widget which must be a shape or text.
+ * @param element - Element description from a template.
+ * @param label - Label text substituted into the template.
+ */
+export function applyElementToItem(
+  item: BaseItem,
+  element: TemplateElement,
+  label: string,
+): void {
+  if (item.type === 'shape') {
+    applyShapeElement(item, element, label);
+  } else if (item.type === 'text') {
+    applyTextElement(item, element, label);
+  }
+}

--- a/tests/boardbuilder-branches.test.ts
+++ b/tests/boardbuilder-branches.test.ts
@@ -1,5 +1,10 @@
 import { BoardBuilder } from '../src/board/board-builder';
 import { templateManager } from '../src/board/templates';
+import {
+  applyElementToItem,
+  applyShapeElement,
+  applyTextElement,
+} from '../src/board/element-utils';
 
 interface GlobalWithMiro {
   miro?: { board: Record<string, unknown> };
@@ -58,11 +63,7 @@ describe('BoardBuilder branch coverage', () => {
     jest
       .spyOn(templateManager, 'createFromTemplate')
       .mockImplementation(async () => {
-        (
-          builder as unknown as {
-            applyShapeElement: (i: unknown, e: unknown, l: string) => void;
-          }
-        ).applyShapeElement(shape, el, 'L');
+        applyShapeElement(shape as unknown as Record<string, unknown>, el, 'L');
         return shape;
       });
     await builder.createNode(
@@ -77,7 +78,6 @@ describe('BoardBuilder branch coverage', () => {
   });
 
   test('applyTextElement merges style when provided', () => {
-    const builder = new BoardBuilder();
     const item: Record<string, unknown> = {
       type: 'text',
       style: { fontSize: 10 },
@@ -87,11 +87,7 @@ describe('BoardBuilder branch coverage', () => {
       unknown
     >;
     // Applying a text element should merge the style properties
-    (
-      builder as unknown as {
-        applyTextElement: (i: unknown, e: unknown, l: string) => void;
-      }
-    ).applyTextElement(item, el, 'L');
+    applyTextElement(item as unknown as Record<string, unknown>, el, 'L');
     expect(item.style.color).toBe('red');
     expect(item.style.fontSize).toBe(10);
   });
@@ -156,29 +152,19 @@ describe('BoardBuilder branch coverage', () => {
   });
 
   test('applyShapeElement preserves existing fillColor', () => {
-    const builder = new BoardBuilder();
     const item: Record<string, unknown> = {
       type: 'shape',
       style: { fillColor: '#abc' },
     };
     const el = { shape: 'rect', fill: '#fff', width: 1, height: 1 };
-    (
-      builder as unknown as {
-        applyShapeElement: (i: unknown, e: unknown, l: string) => void;
-      }
-    ).applyShapeElement(item, el, 'L');
+    applyShapeElement(item as unknown as Record<string, unknown>, el, 'L');
     expect(item.style.fillColor).toBe('#abc');
   });
 
   test('applyElementToItem handles text widgets', () => {
-    const builder = new BoardBuilder();
     const item: Record<string, unknown> = { type: 'text', style: {} };
     const el = { text: 'Name' } as Record<string, unknown>;
-    (
-      builder as unknown as {
-        applyElementToItem: (i: unknown, e: unknown, l: string) => void;
-      }
-    ).applyElementToItem(item, el, 'Label');
+    applyElementToItem(item as unknown as Record<string, unknown>, el, 'Label');
     expect(item.content).toBe('Name');
   });
 


### PR DESCRIPTION
## Summary
- extract `applyShapeElement`, `applyTextElement`, and `applyElementToItem` to `element-utils`
- update `BoardBuilder` to import helpers
- adjust unit tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68612b9f3364832b954723344742bf03