### PR TITLE
Update README testing section and add pretest

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ scopes:
 
 ## Testing
 
-Before running the checks make sure dependencies are installed:
+The root `AGENTS.md` lists the commands to run before committing. Be sure to
+install dependencies first:
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "prettier '**/*.{js,jsx,ts,tsx,md,json,yml,yaml,html}' --write",
     "prettier:check": "prettier '**/*.{js,jsx,ts,tsx,md,json,yml,yaml,html}' --check",
     "typecheck": "tsc --noEmit",
+    "pretest": "npm install",
     "test": "vitest run --coverage",
     "lint": "eslint 'src/**/*.{ts,tsx}' 'tests/**/*.{ts,tsx}'",
     "stylelint": "stylelint 'src/**/*.css'",


### PR DESCRIPTION
## Summary
- clarify in README that AGENTS.md requires `npm install` before running tests
- add a `pretest` script to automatically install dependencies

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861358d6000832ba030bd15dfb31ea1