### PR TITLE
feat(board): share text-field helper

### DIFF
--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -24,28 +24,12 @@ export interface Position {
  * Allows injection of a mock implementation in tests.
  */
 import { BoardLike, getBoard, maybeSync, Syncable } from './board';
+import { getTextFields } from './search-tools';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {
-  const rootText =
-    (item as { title?: string }).title ??
-    (item as { plainText?: string }).plainText ??
-    (item as { content?: string }).content ??
-    (item as { text?: string }).text;
-  if (typeof rootText === 'string') return rootText;
-
-  // Some widgets expose text inside an object e.g. { text: { plainText: '' } }
-  const textObj = (item as { text?: unknown }).text;
-  if (textObj && typeof textObj === 'object') {
-    const nested =
-      (textObj as { plainText?: string; content?: string; text?: string })
-        .plainText ??
-      (textObj as { plainText?: string; content?: string; text?: string })
-        .content ??
-      (textObj as { plainText?: string; content?: string; text?: string }).text;
-    if (typeof nested === 'string') return nested;
-  }
-  return '';
+  const first = getTextFields(item)[0];
+  return first ? first[1] : '';
 }
 
 /**

--- a/src/board/search-tools.ts
+++ b/src/board/search-tools.ts
@@ -56,7 +56,20 @@ function buildRegex(opts: SearchOptions): RegExp {
   return new RegExp(pattern, flags);
 }
 
-function getTextFields(item: Record<string, unknown>): Array<[string, string]> {
+/**
+ * Extract all textual fields from a widget-like object.
+ *
+ * The function inspects common properties such as `title`, `content`,
+ * `plainText` and `description`. When a `text` object is present nested
+ * strings are also included. The returned array preserves the discovery
+ * order of the fields.
+ *
+ * @param item - Record containing arbitrary widget properties.
+ * @returns Array of `[path, text]` tuples for each discovered field.
+ */
+export function getTextFields(
+  item: Record<string, unknown>,
+): Array<[string, string]> {
   const fields: Array<[string, string]> = [];
   if (typeof item.title === 'string') fields.push(['title', item.title]);
   if (typeof item.content === 'string') fields.push(['content', item.content]);

--- a/tests/search-tools.test.ts
+++ b/tests/search-tools.test.ts
@@ -1,6 +1,7 @@
 import {
   searchBoardContent,
   replaceBoardContent,
+  getTextFields,
 } from '../src/board/search-tools';
 import { BoardQueryLike } from '../src/board/board';
 
@@ -258,5 +259,24 @@ describe('search-tools', () => {
         board,
       ),
     ).rejects.toThrow(SyntaxError);
+  });
+
+  test('getTextFields extracts common text properties', () => {
+    const item = {
+      title: 't',
+      content: 'c',
+      plainText: 'p',
+      description: 'd',
+      text: { plainText: 'tp', content: 'tc' },
+    };
+    const fields = getTextFields(item);
+    expect(fields).toEqual([
+      ['title', 't'],
+      ['content', 'c'],
+      ['plainText', 'p'],
+      ['description', 'd'],
+      ['text.plainText', 'tp'],
+      ['text.content', 'tc'],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- export `getTextFields` helper
- rely on `getTextFields` inside grid name sorting
- verify helper behaviour in search tool tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861359c0464832baa0daa66b9dbde61