### PR TITLE
Fix linting errors after refactor

### DIFF
--- a/src/core/excel-sync-service.ts
+++ b/src/core/excel-sync-service.ts
@@ -2,6 +2,7 @@ import { mapRowsToNodes, ColumnMapping } from './data-mapper';
 import type { ExcelRow } from './utils/excel-loader';
 import { templateManager } from '../board/templates';
 import { BoardBuilder } from '../board/board-builder';
+import { applyElementToItem } from '../board/element-utils';
 import type { BaseItem, Group, Json } from '@mirohq/websdk-types';
 
 /** Metadata key used to store Excel row identifiers. */
@@ -14,7 +15,7 @@ const META_KEY = 'app.miro.excel';
 export class ExcelSyncService {
   private rowMap: Record<string, string> = {};
 
-  constructor(private builder: BoardBuilder = new BoardBuilder()) {}
+  constructor(_builder: BoardBuilder = new BoardBuilder()) {}
 
   /** Clear the internal row mapping. */
   public reset(): void {
@@ -147,7 +148,7 @@ export class ExcelSyncService {
         : [widget];
     template.elements.forEach((el, idx) => {
       if (items[idx]) {
-        this.builder.applyElementToItem(items[idx] as BaseItem, el, label);
+        applyElementToItem(items[idx] as BaseItem, el, label);
       }
     });
     const meta = { ...metadata };

--- a/src/core/graph/graph-processor.ts
+++ b/src/core/graph/graph-processor.ts
@@ -31,6 +31,8 @@ export interface ProcessOptions {
 }
 
 export class GraphProcessor extends UndoableProcessor {
+  /** Map of processed node IDs to created widget IDs. */
+  private nodeIdMap: Record<string, string> = {};
   constructor(builder: BoardBuilder = graphService.getBuilder()) {
     super(builder);
   }
@@ -145,6 +147,7 @@ export class GraphProcessor extends UndoableProcessor {
       const adjPos = { ...pos, x: pos.x + offsetX, y: pos.y + offsetY };
       const widget = await this.builder.createNode(node, adjPos);
       nodeMap[node.id] = widget;
+      this.nodeIdMap[node.id] = widget.id;
       this.registerCreated(widget);
     }
     return nodeMap;

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -159,10 +159,15 @@ export const ExcelTab: React.FC = () => {
     }
   };
 
-  const style = React.useMemo(
-    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
-    [dropzone.isDragAccept, dropzone.isDragReject],
-  );
+  const style = React.useMemo(() => {
+    let state: Parameters<typeof getDropzoneStyle>[0] = 'base';
+    if (dropzone.isDragReject) {
+      state = 'reject';
+    } else if (dropzone.isDragAccept) {
+      state = 'accept';
+    }
+    return getDropzoneStyle(state);
+  }, [dropzone.isDragAccept, dropzone.isDragReject]);
 
   return (
     <div style={{ marginTop: tokens.space.small }}>


### PR DESCRIPTION
## Summary
- import element utils directly in Excel sync service
- record node to widget mapping in GraphProcessor
- update ExcelTab dropzone styling logic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861363abd54832ba6535179fb966d3a