### PR TITLE
Fix lint issue in ExcelSyncService

### DIFF
--- a/docs/EXCEL_IMPORT.md
+++ b/docs/EXCEL_IMPORT.md
@@ -60,7 +60,7 @@ workflow is identical.
 Each row is converted into a node or card definition by `mapRowsToNodes` in
 `data-mapper.ts`. A `ColumnMapping` object describes which headers supply
 identifiers, labels, templates and metadata. Templates are looked up via
-`templateManager` and applied by `BoardBuilder`.
+`templateManager` and applied directly to the widgets.
 
 ```ts
 const mapping = {
@@ -82,8 +82,7 @@ when creating widgets.
 import `registerMapping` stores the row identifier alongside the created widget
 ID. `updateShapesFromExcel` applies template and text changes from Excel to
 existing widgets, while `pushChangesToExcel` extracts widget content back into
-rows. The service relies on `BoardBuilder` and `templateManager` to handle
-widget updates.
+rows. The service relies on `templateManager` to handle widget updates.
 
 `RowInspector` surfaces the values of the selected widget's row inside the
 sidebar, allowing quick edits. Changes invoke the callback provided by

--- a/src/core/excel-sync-service.ts
+++ b/src/core/excel-sync-service.ts
@@ -1,7 +1,6 @@
 import { mapRowsToNodes, ColumnMapping } from './data-mapper';
 import type { ExcelRow } from './utils/excel-loader';
 import { templateManager } from '../board/templates';
-import { BoardBuilder } from '../board/board-builder';
 import { applyElementToItem } from '../board/element-utils';
 import type { BaseItem, Group, Json } from '@mirohq/websdk-types';
 
@@ -15,7 +14,7 @@ const META_KEY = 'app.miro.excel';
 export class ExcelSyncService {
   private rowMap: Record<string, string> = {};
 
-  constructor(_builder: BoardBuilder = new BoardBuilder()) {}
+  constructor() {}
 
   /** Clear the internal row mapping. */
   public reset(): void {

--- a/tests/excel-sync-service.test.ts
+++ b/tests/excel-sync-service.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { ExcelSyncService } from '../src/core/excel-sync-service';
 import { templateManager } from '../src/board/templates';
-import { BoardBuilder } from '../src/board/board-builder';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };
@@ -34,7 +33,7 @@ describe('ExcelSyncService', () => {
     vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
       elements: [{ text: '{{label}}' }],
     } as never);
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     await service.updateShapesFromExcel(
       [{ ID: '1', Name: 'A', Type: 'Role', Notes: 'meta' }],
       {
@@ -61,7 +60,7 @@ describe('ExcelSyncService', () => {
       setMetadata: vi.fn().mockResolvedValue(undefined),
     } as unknown as Record<string, unknown>;
     (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([shape]);
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
       idColumn: 'ID',
       labelColumn: 'Name',
@@ -88,7 +87,7 @@ describe('ExcelSyncService', () => {
         .mockResolvedValue({ rowId: '1', notes: 'meta', text: 'desc' }),
     } as unknown as Record<string, unknown>;
     (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([shape]);
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
       idColumn: 'ID',
       labelColumn: 'Name',
@@ -113,7 +112,7 @@ describe('ExcelSyncService', () => {
     (global.miro!.board!.get as vi.Mock)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([group]);
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
       idColumn: 'ID',
       labelColumn: 'Name',
@@ -126,7 +125,7 @@ describe('ExcelSyncService', () => {
 describe('ExcelSyncService additional cases', () => {
   test('updateShapesFromExcel skips missing widgets', async () => {
     (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([]);
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     await service.updateShapesFromExcel([{ ID: '1', Name: 'A' }], {
       idColumn: 'ID',
       labelColumn: 'Name',
@@ -136,7 +135,7 @@ describe('ExcelSyncService additional cases', () => {
 
   test('pushChangesToExcel leaves rows when widget absent', async () => {
     (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([]);
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
       idColumn: 'ID',
       labelColumn: 'Name',
@@ -155,7 +154,7 @@ describe('ExcelSyncService additional cases', () => {
     vi.spyOn(templateManager, 'getTemplate').mockReturnValue(
       undefined as never,
     );
-    const service = new ExcelSyncService(new BoardBuilder());
+    const service = new ExcelSyncService();
     await service.updateShapesFromExcel(
       [{ ID: '1', Name: 'A', Type: 'Role' }],
       { idColumn: 'ID', labelColumn: 'Name', templateColumn: 'Type' },


### PR DESCRIPTION
## Summary
- clean up unused BoardBuilder parameter and import
- update ExcelSyncService unit tests
- document updated sync workflow

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_68613862d26c832b83da125e2b3d68fe