### PR TITLE
Add shared grid layout helper

### DIFF
--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -2,6 +2,7 @@ import { BoardBuilder } from './board-builder';
 import { clearActiveFrame, registerFrame } from './frame-utils';
 import { UndoableProcessor } from '../core/graph/undoable-processor';
 import { CardData, cardLoader } from '../core/utils/cards';
+import { calculateGrid } from '../core/layout/grid-layout';
 import type { Card, CardStyle, Frame, Tag } from '@mirohq/websdk-types';
 
 export interface CardProcessOptions {
@@ -273,15 +274,18 @@ export class CardProcessor extends UndoableProcessor<Card | Frame> {
   }> {
     const autoCols = columns ?? Math.ceil(Math.sqrt(count));
     const cols = Math.max(1, Math.min(autoCols, count));
-    const rows = Math.ceil(count / cols);
+    const grid = calculateGrid(
+      count,
+      { cols, padding: CardProcessor.CARD_GAP },
+      CardProcessor.CARD_WIDTH,
+      CardProcessor.CARD_HEIGHT,
+    );
+    const maxX = grid.reduce((m, p) => Math.max(m, p.x), 0);
+    const maxY = grid.reduce((m, p) => Math.max(m, p.y), 0);
     const totalWidth =
-      CardProcessor.CARD_WIDTH * cols +
-      CardProcessor.CARD_GAP * (cols - 1) +
-      CardProcessor.CARD_MARGIN * 2;
+      maxX + CardProcessor.CARD_WIDTH + CardProcessor.CARD_MARGIN * 2;
     const totalHeight =
-      CardProcessor.CARD_HEIGHT * rows +
-      CardProcessor.CARD_GAP * (rows - 1) +
-      CardProcessor.CARD_MARGIN * 2;
+      maxY + CardProcessor.CARD_HEIGHT + CardProcessor.CARD_MARGIN * 2;
     const spot = await this.builder.findSpace(totalWidth, totalHeight);
     const startX = this.computeStartCoordinate(
       spot.x,

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -25,6 +25,10 @@ export interface Position {
  */
 import { BoardLike, getBoard, maybeSync, Syncable } from './board';
 import { getTextFields } from './search-tools';
+import {
+  calculateGrid,
+  GridConfig as LayoutGridConfig,
+} from '../core/layout/grid-layout';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {
@@ -41,18 +45,12 @@ export function calculateGridPositions(
   cellWidth: number,
   cellHeight: number,
 ): Position[] {
-  const positions: Position[] = [];
-  const vertical = opts.sortOrientation === 'vertical';
-  const rows = Math.ceil(count / opts.cols);
-  for (let i = 0; i < count; i += 1) {
-    const c = vertical ? Math.floor(i / rows) : i % opts.cols;
-    const r = vertical ? i % rows : Math.floor(i / opts.cols);
-    positions.push({
-      x: c * (cellWidth + opts.padding),
-      y: r * (cellHeight + opts.padding),
-    });
-  }
-  return positions;
+  const config: LayoutGridConfig = {
+    cols: opts.cols,
+    padding: opts.padding,
+    vertical: opts.sortOrientation === 'vertical',
+  };
+  return calculateGrid(count, config, cellWidth, cellHeight);
 }
 
 /**

--- a/src/core/layout/grid-layout.ts
+++ b/src/core/layout/grid-layout.ts
@@ -1,0 +1,39 @@
+/**
+ * Grid layout helper to compute item positions.
+ *
+ * @param count - Total number of items.
+ * @param config - Grid settings including columns, padding and optional vertical order.
+ * @param width - Width of each item.
+ * @param height - Height of each item.
+ * @returns Array of relative positions for each item.
+ */
+export interface GridConfig {
+  cols: number;
+  padding: number;
+  vertical?: boolean;
+}
+
+export interface GridPosition {
+  x: number;
+  y: number;
+}
+
+export function calculateGrid(
+  count: number,
+  config: GridConfig,
+  width: number,
+  height: number,
+): GridPosition[] {
+  const positions: GridPosition[] = [];
+  const cols = Math.max(1, config.cols);
+  const rows = Math.ceil(count / cols);
+  for (let i = 0; i < count; i += 1) {
+    const col = config.vertical ? Math.floor(i / rows) : i % cols;
+    const row = config.vertical ? i % rows : Math.floor(i / cols);
+    positions.push({
+      x: col * (width + config.padding),
+      y: row * (height + config.padding),
+    });
+  }
+  return positions;
+}

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -1,4 +1,5 @@
 import { CardProcessor } from '../src/board/card-processor';
+import { calculateGrid } from '../src/core/layout/grid-layout';
 import * as cardModule from '../src/core/utils/cards';
 
 interface GlobalWithMiro {
@@ -273,6 +274,35 @@ describe('CardProcessor', () => {
       processor as unknown as { loadCardMap: () => Promise<void> }
     ).loadCardMap();
     expect(global.miro.board.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('calculateLayoutArea computes dimensions using grid helper', async () => {
+    const builder = (processor as unknown as { builder: unknown }).builder as {
+      findSpace: jest.Mock;
+    };
+    builder.findSpace = jest.fn().mockResolvedValue({ x: 0, y: 0 });
+    const width = (CardProcessor as unknown as { CARD_WIDTH: number })
+      .CARD_WIDTH;
+    const height = (CardProcessor as unknown as { CARD_HEIGHT: number })
+      .CARD_HEIGHT;
+    const gap = (CardProcessor as unknown as { CARD_GAP: number }).CARD_GAP;
+    const margin = (CardProcessor as unknown as { CARD_MARGIN: number })
+      .CARD_MARGIN;
+    const area = await (
+      processor as unknown as {
+        calculateLayoutArea: (
+          c: number,
+          col?: number,
+        ) => Promise<{ totalWidth: number; totalHeight: number }>;
+      }
+    ).calculateLayoutArea(4, 2);
+    const grid = calculateGrid(4, { cols: 2, padding: gap }, width, height);
+    const expectedWidth =
+      Math.max(...grid.map((p) => p.x)) + width + margin * 2;
+    const expectedHeight =
+      Math.max(...grid.map((p) => p.y)) + height + margin * 2;
+    expect(area.totalWidth).toBe(expectedWidth);
+    expect(area.totalHeight).toBe(expectedHeight);
   });
 
   test('computeStartCoordinate derives correct origin', () => {

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -2,19 +2,27 @@ import {
   applyGridLayout,
   calculateGridPositions,
 } from '../src/board/grid-tools';
+import { calculateGrid } from '../src/core/layout/grid-layout';
 import { BoardLike } from '../src/board/board';
 
 describe('grid-tools', () => {
+  test('calculateGrid computes grid positions', () => {
+    const positions = calculateGrid(3, { cols: 2, padding: 5 }, 10, 10);
+    expect(positions).toEqual([
+      { x: 0, y: 0 },
+      { x: 15, y: 0 },
+      { x: 0, y: 15 },
+    ]);
+  });
   test('calculateGridPositions computes offsets', () => {
+    const expected = calculateGrid(4, { cols: 2, padding: 5 }, 10, 10);
     const positions = calculateGridPositions(
       { cols: 2, padding: 5 },
       4,
       10,
       10,
     );
-    expect(positions).toHaveLength(4);
-    expect(positions[1]).toEqual({ x: 15, y: 0 });
-    expect(positions[2]).toEqual({ x: 0, y: 15 });
+    expect(positions).toEqual(expected);
   });
 
   test('applyGridLayout positions widgets', async () => {


### PR DESCRIPTION
## Summary
- add `grid-layout.ts` for computing grid offsets
- refactor board utilities to reuse `calculateGrid`
- use grid helper in card layout calculations
- test the new module and behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68613d4b4570832bb31b89f7a2117a7a