### PR TITLE
Fix ResizeTab tests

### DIFF
--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -87,9 +87,13 @@ describe('tab components', () => {
   test('ResizeTab aspect ratio adjusts height', async () => {
     render(React.createElement(ResizeTab));
     const widthInput = screen.getByPlaceholderText(/width/i);
-    fireEvent.change(widthInput, { target: { value: '160' } });
-    fireEvent.change(screen.getByTestId('ratio-select'), {
-      target: { value: '16:9' },
+    await act(async () => {
+      fireEvent.change(widthInput, { target: { value: '160' } });
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('ratio-select'), {
+        target: { value: '16:9' },
+      });
     });
     const heightInput = screen.getByPlaceholderText(
       /height/i,


### PR DESCRIPTION
## Summary
- fix React act warnings by wrapping state updates in `tabs.test.ts`

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68613dc4b1e0832bbe8c469ab64e1512