### PR TITLE
feat(board): share grid layout calculation

### DIFF
--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -2,7 +2,7 @@ import { BoardBuilder } from './board-builder';
 import { clearActiveFrame, registerFrame } from './frame-utils';
 import { UndoableProcessor } from '../core/graph/undoable-processor';
 import { CardData, cardLoader } from '../core/utils/cards';
-import { calculateGrid } from '../core/layout/grid-layout';
+import { calculateGrid } from './grid-layout';
 import type { Card, CardStyle, Frame, Tag } from '@mirohq/websdk-types';
 
 export interface CardProcessOptions {

--- a/src/board/grid-layout.ts
+++ b/src/board/grid-layout.ts
@@ -1,0 +1,42 @@
+/**
+ * Grid layout helper for board items.
+ *
+ * Calculates relative cell coordinates for an item grid.
+ *
+ * @param count - Number of items to position.
+ * @param config - Grid settings with column count, cell padding and optional
+ * vertical ordering flag.
+ * @param width - Width of each item.
+ * @param height - Height of each item.
+ * @returns Array of cell positions relative to the first item.
+ */
+export interface GridConfig {
+  cols: number;
+  padding: number;
+  vertical?: boolean;
+}
+
+export interface GridPosition {
+  x: number;
+  y: number;
+}
+
+export function calculateGrid(
+  count: number,
+  config: GridConfig,
+  width: number,
+  height: number,
+): GridPosition[] {
+  const positions: GridPosition[] = [];
+  const cols = Math.max(1, config.cols);
+  const rows = Math.ceil(count / cols);
+  for (let i = 0; i < count; i += 1) {
+    const col = config.vertical ? Math.floor(i / rows) : i % cols;
+    const row = config.vertical ? i % rows : Math.floor(i / cols);
+    positions.push({
+      x: col * (width + config.padding),
+      y: row * (height + config.padding),
+    });
+  }
+  return positions;
+}

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -25,10 +25,7 @@ export interface Position {
  */
 import { BoardLike, getBoard, maybeSync, Syncable } from './board';
 import { getTextFields } from './search-tools';
-import {
-  calculateGrid,
-  GridConfig as LayoutGridConfig,
-} from '../core/layout/grid-layout';
+import { calculateGrid, GridConfig as LayoutGridConfig } from './grid-layout';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -1,5 +1,5 @@
 import { CardProcessor } from '../src/board/card-processor';
-import { calculateGrid } from '../src/core/layout/grid-layout';
+import { calculateGrid } from '../src/board/grid-layout';
 import * as cardModule from '../src/core/utils/cards';
 
 interface GlobalWithMiro {

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -2,7 +2,7 @@ import {
   applyGridLayout,
   calculateGridPositions,
 } from '../src/board/grid-tools';
-import { calculateGrid } from '../src/core/layout/grid-layout';
+import { calculateGrid } from '../src/board/grid-layout';
 import { BoardLike } from '../src/board/board';
 
 describe('grid-tools', () => {


### PR DESCRIPTION
## Summary
- create board-level grid layout helper
- reuse calculateGrid helper in grid-tools and card-processor
- update corresponding tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68613fcfc7d0832b902a77113729d2ab