### PR TITLE
Add meta-constants module

### DIFF
--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -2,6 +2,7 @@ import { templateManager } from './templates';
 import { searchGroups, searchShapes } from './node-search';
 import { createConnector } from './connector-utils';
 export { updateConnector } from './connector-utils';
+import { STRUCT_GRAPH_KEY } from './meta-constants';
 import type {
   BaseItem,
   Connector,
@@ -21,7 +22,7 @@ import { maybeSync } from './board';
 /** Union type representing a single widget or a group of widgets. */
 export type BoardItem = BaseItem | Group;
 
-const META_KEY = 'app.miro.structgraph';
+const META_KEY = STRUCT_GRAPH_KEY;
 
 /**
  * Helper responsible for finding, creating and updating widgets on the board.

--- a/src/board/connector-utils.ts
+++ b/src/board/connector-utils.ts
@@ -7,8 +7,9 @@ import type {
 } from '@mirohq/websdk-types';
 import type { ConnectorTemplate } from './templates';
 import type { EdgeData, EdgeHint } from '../core/graph';
+import { STRUCT_GRAPH_KEY } from './meta-constants';
 
-const META_KEY = 'app.miro.structgraph';
+const META_KEY = STRUCT_GRAPH_KEY;
 
 /**
  * Update an existing connector with style, label and hint data.

--- a/src/board/meta-constants.ts
+++ b/src/board/meta-constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared metadata keys for widgets on the board.
+ */
+
+/** Metadata key storing structural graph information. */
+export const STRUCT_GRAPH_KEY = 'app.miro.structgraph';

--- a/src/board/node-search.ts
+++ b/src/board/node-search.ts
@@ -1,7 +1,8 @@
 import type { BaseItem, Group, Shape } from '@mirohq/websdk-types';
 import type { BoardQueryLike } from './board';
+import { STRUCT_GRAPH_KEY } from './meta-constants';
 
-const META_KEY = 'app.miro.structgraph';
+const META_KEY = STRUCT_GRAPH_KEY;
 
 /**
  * Concurrently fetch metadata for items and return the first that matches.

--- a/tests/boardbuilder-extra.test.ts
+++ b/tests/boardbuilder-extra.test.ts
@@ -1,5 +1,6 @@
 import { BoardBuilder } from '../src/board/board-builder';
 import { templateManager } from '../src/board/templates';
+import { STRUCT_GRAPH_KEY } from '../src/board/meta-constants';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };
@@ -124,7 +125,7 @@ describe('BoardBuilder additional cases', () => {
       } as Record<string, unknown>,
       { x: 0, y: 0, width: 1, height: 1 },
     );
-    expect(shape.setMetadata).toHaveBeenCalledWith('app.miro.structgraph', {
+    expect(shape.setMetadata).toHaveBeenCalledWith(STRUCT_GRAPH_KEY, {
       type: 'Role',
       label: 'A',
       rowId: '42',

--- a/tests/meta-constants.test.ts
+++ b/tests/meta-constants.test.ts
@@ -1,0 +1,7 @@
+import { STRUCT_GRAPH_KEY } from '../src/board/meta-constants';
+
+describe('meta-constants', () => {
+  test('STRUCT_GRAPH_KEY has expected value', () => {
+    expect(STRUCT_GRAPH_KEY).toBe('app.miro.structgraph');
+  });
+});


### PR DESCRIPTION
## Summary
- provide `STRUCT_GRAPH_KEY` constant in new `meta-constants` module
- import and use constant in `board-builder`, `connector-utils` and `node-search`
- update tests and add coverage for the new constant

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68613fdca688832bb5df6da31a121520