### PR TITLE
Improve modal accessibility and drop handler

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -80,18 +80,28 @@ export function Modal({
   }, [isOpen, onClose, trapTab]);
 
   if (!isOpen) return null;
+
+  // Close the modal when the backdrop itself is clicked.
+  const handleBackdropClick = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ): void => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
   return (
     <div
+      role='button'
+      tabIndex={0}
+      aria-label='Close modal'
       className='modal-backdrop'
       style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
-      onMouseDown={onClose}>
+      onClick={handleBackdropClick}>
       <div
         role='dialog'
         aria-modal='true'
         aria-label={title}
         className={`modal modal-${size}`}
-        ref={ref}
-        onMouseDown={(e) => e.stopPropagation()}>
+        ref={ref}>
         <header className='modal-header'>
           <h3>{title}</h3>
           <button

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -61,6 +61,21 @@ export const ExcelTab: React.FC = () => {
     data?.setTemplateColumn(templateColumn);
   }, [templateColumn, data]);
 
+  // Load a local workbook dropped onto the dropzone.
+  const handleDrop = React.useCallback(async (files: File[]): Promise<void> => {
+    const f = files[0];
+    try {
+      await excelLoader.loadWorkbook(f);
+      setLoader(excelLoader);
+      setFile(f);
+      setSource('');
+      setRows([]);
+      setSelected(new Set());
+    } catch (e) {
+      await showError(String(e));
+    }
+  }, []);
+
   const dropzone = useDropzone({
     accept: {
       'application/vnd.ms-excel': ['.xls'],
@@ -69,18 +84,8 @@ export const ExcelTab: React.FC = () => {
       ],
     },
     maxFiles: 1,
-    onDrop: async (files: File[]) => {
-      const f = files[0];
-      try {
-        await excelLoader.loadWorkbook(f);
-        setLoader(excelLoader);
-        setFile(f);
-        setSource('');
-        setRows([]);
-        setSelected(new Set());
-      } catch (e) {
-        await showError(String(e));
-      }
+    onDrop: (files: File[]) => {
+      void handleDrop(files);
     },
   });
 

--- a/tests/modal.test.tsx
+++ b/tests/modal.test.tsx
@@ -44,13 +44,26 @@ describe('Modal', () => {
         <button>Second</button>
       </Modal>,
     );
-    const buttons = screen.getAllByRole('button');
-    const closeBtn = buttons[0];
-    const second = buttons[2];
+    const closeBtn = screen.getByLabelText('Close');
+    const second = screen.getByText('Second');
     second.focus();
     fireEvent.keyDown(window, { key: 'Tab' });
     expect(closeBtn).toHaveFocus();
     fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
     expect(second).toHaveFocus();
+  });
+
+  test('clicking the backdrop triggers onClose', () => {
+    const spy = vi.fn();
+    render(
+      <Modal
+        title='B'
+        isOpen
+        onClose={spy}>
+        <button>Inside</button>
+      </Modal>,
+    );
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    expect(spy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- fix accessible semantics for Modal backdrop
- prevent async return from ExcelTab drop handler
- update Modal tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686140c871ac832b92f91ba19ef897ae