### PR TITLE
Remove redundant type assertion

### DIFF
--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -232,7 +232,7 @@ export class BoardBuilder {
     );
     const rowId =
       node.metadata && 'rowId' in node.metadata
-        ? String((node.metadata as Record<string, unknown>).rowId)
+        ? String(node.metadata['rowId'])
         : undefined;
     if ((widget as Group).type === 'group') {
       const items = await (widget as Group).getItems();


### PR DESCRIPTION
## Summary
- simplify `BoardBuilder` by removing a useless type assertion

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686140df483c832bacaee912c0497e56