### PR TITLE
Add commitlint verification docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,15 @@ please follow the formatting rules in [docs/CODE_STYLE.md](docs/CODE_STYLE.md).
 Aim for at least **90 % line and branch test coverage** and keep cyclomatic
 complexity below eight as described in
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Commit messages
+
+Verify that your commit message follows the Conventional Commits format by
+running:
+
+```bash
+npm run commitlint -- --edit $(git rev-parse --verify HEAD)
+```
+
+Our CI also checks commit messages in
+[`\.github/workflows/commitlint.yml`](.github/workflows/commitlint.yml).

--- a/README.md
+++ b/README.md
@@ -273,6 +273,18 @@ With `package-lock.json` checked in you can run `npm audit` after each install
 to scan dependencies for vulnerabilities. Include the lock file in commits so
 everyone uses the exact dependency versions when installing.
 
+## Commit message checks
+
+Commit messages must follow the Conventional Commits specification. Verify the
+latest commit locally by running:
+
+```bash
+npm run commitlint -- --edit $(git rev-parse --verify HEAD)
+```
+
+The CI pipeline also enforces commitlint via
+[`\.github/workflows/commitlint.yml`](.github/workflows/commitlint.yml).
+
 ## 🗂️ Folder structure <a name="folder"></a>
 
 ```


### PR DESCRIPTION
## Summary
- document how to validate commit messages
- mention commitlint workflow in CI

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68614375e89c832b9722bb37b79ea82b