### PR TITLE
Refactor connector helpers

### DIFF
--- a/src/board/connector-utils.ts
+++ b/src/board/connector-utils.ts
@@ -19,22 +19,22 @@ const META_KEY = STRUCT_GRAPH_KEY;
  * @param template - Connector template describing style defaults.
  * @param hint - Optional hint for start and end positions.
  */
-export function updateConnector(
-  connector: Connector,
+function buildCaptions(
   edge: EdgeData,
   template?: ConnectorTemplate,
-  hint?: EdgeHint,
-): void {
-  if (edge.label) {
-    connector.captions = [
-      {
-        content: edge.label,
-        position: template?.caption?.position,
-        textAlignVertical: template?.caption
-          ?.textAlignVertical as TextAlignVertical,
-      },
-    ];
-  }
+): Connector['captions'] {
+  if (!edge.label) return undefined;
+  return [
+    {
+      content: edge.label,
+      position: template?.caption?.position,
+      textAlignVertical: template?.caption
+        ?.textAlignVertical as TextAlignVertical,
+    },
+  ];
+}
+
+function mergeStyle(connector: Connector, template?: ConnectorTemplate): void {
   if (template?.style) {
     connector.style = {
       ...connector.style,
@@ -42,6 +42,9 @@ export function updateConnector(
     } as ConnectorStyle;
   }
   connector.shape = template?.shape ?? connector.shape;
+}
+
+function applyHint(connector: Connector, hint?: EdgeHint): void {
   if (hint?.startPosition) {
     connector.start = {
       ...(connector.start ?? {}),
@@ -54,6 +57,18 @@ export function updateConnector(
       position: hint.endPosition,
     } as Connector['end'];
   }
+}
+
+export function updateConnector(
+  connector: Connector,
+  edge: EdgeData,
+  template?: ConnectorTemplate,
+  hint?: EdgeHint,
+): void {
+  const captions = buildCaptions(edge, template);
+  if (captions) connector.captions = captions;
+  mergeStyle(connector, template);
+  applyHint(connector, hint);
 }
 
 /**
@@ -77,16 +92,7 @@ export async function createConnector(
     start: { item: from.id, position: hint?.startPosition },
     end: { item: to.id, position: hint?.endPosition },
     shape: template?.shape ?? 'curved',
-    captions: edge.label
-      ? [
-          {
-            content: edge.label,
-            position: template?.caption?.position,
-            textAlignVertical: template?.caption
-              ?.textAlignVertical as TextAlignVertical,
-          },
-        ]
-      : undefined,
+    captions: buildCaptions(edge, template),
     style: template?.style as ConnectorStyle | undefined,
   });
   await connector.setMetadata(META_KEY, { from: edge.from, to: edge.to });


### PR DESCRIPTION
## Summary
- split connector update logic into smaller helpers
- simplify createConnector to keep complexity down

## Testing
- `npm install --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`
- `npx eslint 'src/board/connector-utils.ts' --rule 'complexity: [1, 8]'

------
https://chatgpt.com/codex/tasks/task_e_68614370c718832bab4ce296891224d9