### PR TITLE
Add complexity rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,7 +18,11 @@ export default tseslint.config(
       sourceType: 'module',
       parserOptions: { project: './tsconfig.json' },
     },
-    rules: { 'no-console': 'warn', 'react/react-in-jsx-scope': 'off' },
+    rules: {
+      'no-console': 'warn',
+      'react/react-in-jsx-scope': 'off',
+      'complexity': ['error', 8],
+    },
   },
   {
     files: ['tests/**/*.{ts,tsx}'],


### PR DESCRIPTION
## Summary
- enforce a cyclomatic complexity threshold of 8 in ESLint configuration

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors)*
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_686143a82e34832b98c17a77b483747d