### PR TITLE
Fix resize tab act wrapping

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -81,26 +81,11 @@ export function Modal({
 
   if (!isOpen) return null;
 
-  // Close the modal when the backdrop is activated via mouse or keyboard.
-  const handleBackdropClick = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-  ): void => {
-    if (e.target === e.currentTarget) onClose();
-  };
-
-  const handleBackdropKeyDown = (
-    e: React.KeyboardEvent<HTMLDivElement>,
-  ): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onClose();
-    }
-  };
-
   return (
     <div
       role='button'
       tabIndex={0}
+      aria-label='Close modal'
       className='modal-backdrop'
       style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
       onClick={onClose}

--- a/tests/resize-tab-extra.test.tsx
+++ b/tests/resize-tab-extra.test.tsx
@@ -26,8 +26,10 @@ describe('ResizeTab extra coverage', () => {
       .spyOn(resizeTools, 'applySizeToSelection')
       .mockResolvedValue(undefined as unknown as void);
     render(React.createElement(ResizeTab));
-    fireEvent.change(screen.getByPlaceholderText(/width/i), {
-      target: { value: '15000' },
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText(/width/i), {
+        target: { value: '15000' },
+      });
     });
     await act(async () => {
       fireEvent.click(screen.getByText(/apply size/i));


### PR DESCRIPTION
## Summary
- wrap `fireEvent.change` for width input in `act`
- restore `Close modal` label in `Modal` backdrop

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity over 8)*
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68614887fe3c832b95f120de16a17e00