### PR TITLE
Add node search tests

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -81,22 +81,6 @@ export function Modal({
 
   if (!isOpen) return null;
 
-  // Close the modal when the backdrop is activated via mouse or keyboard.
-  const handleBackdropClick = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-  ): void => {
-    if (e.target === e.currentTarget) onClose();
-  };
-
-  const handleBackdropKeyDown = (
-    e: React.KeyboardEvent<HTMLDivElement>,
-  ): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onClose();
-    }
-  };
-
   return (
     <div
       role='button'

--- a/tests/modal.test.tsx
+++ b/tests/modal.test.tsx
@@ -56,7 +56,7 @@ describe('Modal', () => {
 
   test('clicking the backdrop triggers onClose', () => {
     const spy = vi.fn();
-    render(
+    const { container } = render(
       <Modal
         title='B'
         isOpen
@@ -64,13 +64,14 @@ describe('Modal', () => {
         <button>Inside</button>
       </Modal>,
     );
-    fireEvent.click(screen.getByLabelText('Close modal'));
+    const backdrop = container.querySelector('.modal-backdrop') as HTMLElement;
+    fireEvent.click(backdrop);
     expect(spy).toHaveBeenCalled();
   });
 
   test('pressing Enter on the backdrop triggers onClose', () => {
     const spy = vi.fn();
-    render(
+    const { container } = render(
       <Modal
         title='C'
         isOpen
@@ -78,7 +79,8 @@ describe('Modal', () => {
         <button>Inner</button>
       </Modal>,
     );
-    fireEvent.keyDown(screen.getByLabelText('Close modal'), { key: 'Enter' });
+    const backdrop = container.querySelector('.modal-backdrop') as HTMLElement;
+    fireEvent.keyDown(backdrop, { key: 'Enter' });
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/tests/node-search.test.ts
+++ b/tests/node-search.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, vi } from 'vitest';
+import type { BoardQueryLike } from '../src/board/board';
+import {
+  findByMetadata,
+  searchShapes,
+  searchGroups,
+} from '../src/board/node-search';
+
+interface Meta {
+  rowId: number;
+}
+interface Item {
+  getMetadata: (key: string) => Promise<Meta>;
+}
+
+describe('findByMetadata', () => {
+  test('returns first item matching predicate', async () => {
+    const a: Item = { getMetadata: vi.fn().mockResolvedValue({ rowId: 1 }) };
+    const b: Item = { getMetadata: vi.fn().mockResolvedValue({ rowId: 2 }) };
+    const result = await findByMetadata<Item>([a, b], (m) => m.rowId === 2);
+    expect(result).toBe(b);
+    expect(a.getMetadata).toHaveBeenCalled();
+    expect(b.getMetadata).toHaveBeenCalled();
+  });
+
+  test('returns undefined when no match found', async () => {
+    const a: Item = { getMetadata: vi.fn().mockResolvedValue({ rowId: 1 }) };
+    const result = await findByMetadata<Item>([a], () => false);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('searchShapes', () => {
+  test('finds shape by label from board query', async () => {
+    const shapeA = { content: 'A' };
+    const shapeB = { content: 'B' };
+    const board: BoardQueryLike = {
+      get: vi.fn().mockResolvedValue([shapeA, shapeB]),
+      getSelection: vi.fn(),
+    } as unknown as BoardQueryLike;
+    const result = await searchShapes(board, undefined, 'B');
+    expect(result).toBe(shapeB);
+    expect(board.get).toHaveBeenCalledWith({ type: 'shape' });
+  });
+
+  test('returns undefined when label missing', async () => {
+    const board: BoardQueryLike = {
+      get: vi.fn().mockResolvedValue([{ content: 'A' }]),
+      getSelection: vi.fn(),
+    } as unknown as BoardQueryLike;
+    const result = await searchShapes(board, undefined, 'X');
+    expect(result).toBeUndefined();
+  });
+
+  test('uses provided cache without querying board', async () => {
+    const shape = { content: 'A' };
+    const cache = new Map<string, unknown>([['A', shape]]);
+    const board: BoardQueryLike = {
+      get: vi.fn(),
+      getSelection: vi.fn(),
+    } as unknown as BoardQueryLike;
+    const result = await searchShapes(board, cache, 'A');
+    expect(result).toBe(shape);
+    expect(board.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('searchGroups', () => {
+  test('locates group containing item with matching metadata', async () => {
+    const item = {
+      getMetadata: vi.fn().mockResolvedValue({ type: 'Role', label: 'A' }),
+    };
+    const groupA = { getItems: vi.fn().mockResolvedValue([item]) };
+    const board: BoardQueryLike = {
+      get: vi.fn().mockResolvedValue([groupA]),
+      getSelection: vi.fn(),
+    } as unknown as BoardQueryLike;
+    const result = await searchGroups(board, 'Role', 'A');
+    expect(result).toBe(groupA);
+  });
+
+  test('returns undefined when no matching group found', async () => {
+    const item = {
+      getMetadata: vi.fn().mockResolvedValue({ type: 'Role', label: 'B' }),
+    };
+    const group = { getItems: vi.fn().mockResolvedValue([item]) };
+    const board: BoardQueryLike = {
+      get: vi.fn().mockResolvedValue([group]),
+      getSelection: vi.fn(),
+    } as unknown as BoardQueryLike;
+    const result = await searchGroups(board, 'Role', 'A');
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage tests for findByMetadata, searchShapes and searchGroups
- adapt modal backdrop tests to query by class
- drop unused handlers from Modal component

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors in existing files)*


------
https://chatgpt.com/codex/tasks/task_e_686148969c84832bb70dd317d29b7019