### PR TITLE
Refactor helpers to lower complexity

### DIFF
--- a/src/core/data-mapper.ts
+++ b/src/core/data-mapper.ts
@@ -34,34 +34,39 @@ export interface CardDefinition {
  * @param rows - Parsed rows from {@link ExcelLoader}.
  * @param mapping - Column mapping configuration.
  */
+export function mapRowToNode(
+  row: Record<string, unknown>,
+  mapping: ColumnMapping,
+  index: number,
+): NodeDefinition {
+  const metadata: Record<string, unknown> = {};
+  if (mapping.textColumn && row[mapping.textColumn] != null) {
+    metadata.text = row[mapping.textColumn];
+  }
+  const metaCols = mapping.metadataColumns ?? {};
+  Object.entries(metaCols).forEach(([key, col]) => {
+    const value = row[col];
+    if (value != null) metadata[key] = value;
+  });
+  const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
+  metadata.rowId = idVal != null ? String(idVal) : String(index);
+  const typeVal = mapping.templateColumn
+    ? row[mapping.templateColumn]
+    : undefined;
+  const labelVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
+  return {
+    id: idVal != null ? String(idVal) : String(index),
+    label: labelVal != null ? String(labelVal) : '',
+    type: typeVal != null ? String(typeVal) : 'default',
+    metadata: Object.keys(metadata).length ? metadata : undefined,
+  };
+}
+
 export function mapRowsToNodes(
   rows: Array<Record<string, unknown>>,
   mapping: ColumnMapping,
 ): NodeDefinition[] {
-  return rows.map((row, index) => {
-    const metadata: Record<string, unknown> = {};
-    if (mapping.textColumn && row[mapping.textColumn] != null) {
-      metadata.text = row[mapping.textColumn];
-    }
-    const metaCols = mapping.metadataColumns ?? {};
-    Object.keys(metaCols).forEach((key) => {
-      const col = metaCols[key];
-      const value = row[col];
-      if (value != null) metadata[key] = value;
-    });
-    const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
-    metadata.rowId = idVal != null ? String(idVal) : String(index);
-    const typeVal = mapping.templateColumn
-      ? row[mapping.templateColumn]
-      : undefined;
-    const labelVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
-    return {
-      id: idVal != null ? String(idVal) : String(index),
-      label: labelVal != null ? String(labelVal) : '',
-      type: typeVal != null ? String(typeVal) : 'default',
-      metadata: Object.keys(metadata).length ? metadata : undefined,
-    };
-  });
+  return rows.map((row, index) => mapRowToNode(row, mapping, index));
 }
 
 /**
@@ -70,23 +75,28 @@ export function mapRowsToNodes(
  * @param rows - Parsed rows from {@link ExcelLoader}.
  * @param mapping - Column mapping configuration.
  */
+export function mapRowToCard(
+  row: Record<string, unknown>,
+  mapping: ColumnMapping,
+): CardDefinition {
+  const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
+  const titleVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
+  const descVal = mapping.textColumn ? row[mapping.textColumn] : undefined;
+  const themeVal = mapping.templateColumn
+    ? row[mapping.templateColumn]
+    : undefined;
+  const card: CardDefinition = {
+    title: titleVal != null ? String(titleVal) : '',
+  };
+  if (idVal != null) card.id = String(idVal);
+  if (descVal != null) card.description = String(descVal);
+  if (themeVal != null) card.style = { cardTheme: String(themeVal) };
+  return card;
+}
+
 export function mapRowsToCards(
   rows: Array<Record<string, unknown>>,
   mapping: ColumnMapping,
 ): CardDefinition[] {
-  return rows.map((row) => {
-    const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
-    const titleVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
-    const descVal = mapping.textColumn ? row[mapping.textColumn] : undefined;
-    const themeVal = mapping.templateColumn
-      ? row[mapping.templateColumn]
-      : undefined;
-    const card: CardDefinition = {
-      title: titleVal != null ? String(titleVal) : '',
-    };
-    if (idVal != null) card.id = String(idVal);
-    if (descVal != null) card.description = String(descVal);
-    if (themeVal != null) card.style = { cardTheme: String(themeVal) };
-    return card;
-  });
+  return rows.map((row) => mapRowToCard(row, mapping));
 }

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -81,27 +81,12 @@ export function Modal({
 
   if (!isOpen) return null;
 
-  // Close the modal when the backdrop is activated via mouse or keyboard.
-  const handleBackdropClick = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-  ): void => {
-    if (e.target === e.currentTarget) onClose();
-  };
-
-  const handleBackdropKeyDown = (
-    e: React.KeyboardEvent<HTMLDivElement>,
-  ): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onClose();
-    }
-  };
-
   return (
     <div
       role='button'
       tabIndex={0}
       className='modal-backdrop'
+      aria-label='Close modal'
       style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
       onClick={onClose}
       onKeyDown={(e) => {

--- a/src/ui/style-presets.ts
+++ b/src/ui/style-presets.ts
@@ -27,21 +27,33 @@ const DEFAULT_PRESET: StylePreset = {
 /**
  * Derive a style preset from the first element of a template.
  */
+function valueOrDefault<T>(val: T | undefined, def: T): T {
+  return val === undefined ? def : val;
+}
+
 function templateToPreset(
   name: string,
   tpl: { elements?: TemplateElement[] },
 ): StylePreset {
   const el = tpl.elements?.[0];
-  const style = el?.style ?? {};
+  const style = (el?.style ?? {}) as Record<string, unknown>;
+  const fill =
+    (style.fillColor as string | undefined) ?? (el?.fill as string | undefined);
   return {
     label: name,
-    fontColor: (style.fontColor as string) ?? DEFAULT_PRESET.fontColor,
-    borderWidth: (style.borderWidth as number) ?? DEFAULT_PRESET.borderWidth,
-    borderColor: (style.borderColor as string) ?? DEFAULT_PRESET.borderColor,
-    fillColor:
-      (style.fillColor as string) ??
-      (el?.fill as string) ??
-      DEFAULT_PRESET.fillColor,
+    fontColor: valueOrDefault(
+      style.fontColor as string | undefined,
+      DEFAULT_PRESET.fontColor,
+    ),
+    borderWidth: valueOrDefault(
+      style.borderWidth as number | undefined,
+      DEFAULT_PRESET.borderWidth,
+    ),
+    borderColor: valueOrDefault(
+      style.borderColor as string | undefined,
+      DEFAULT_PRESET.borderColor,
+    ),
+    fillColor: valueOrDefault(fill, DEFAULT_PRESET.fillColor),
   };
 }
 

--- a/tests/card-normalize.test.ts
+++ b/tests/card-normalize.test.ts
@@ -1,4 +1,8 @@
-import { cardLoader, CardLoader } from '../src/core/utils/cards';
+import {
+  cardLoader,
+  CardLoader,
+  parseCardStyle,
+} from '../src/core/utils/cards';
 
 interface ReaderEvent {
   target: { result?: string | null } | null;
@@ -54,5 +58,10 @@ describe('CardLoader normalization', () => {
     const second = CardLoader.getInstance();
     expect(second).toBe(first);
     (CardLoader as unknown as { instance?: CardLoader }).instance = original;
+  });
+
+  test('parseCardStyle normalises booleans', () => {
+    const style = parseCardStyle({ cardTheme: 'blue', fillBackground: 'true' });
+    expect(style).toEqual({ cardTheme: 'blue', fillBackground: true });
   });
 });

--- a/tests/data-mapper.test.ts
+++ b/tests/data-mapper.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from 'vitest';
-import { mapRowsToNodes, mapRowsToCards } from '../src/core/data-mapper';
+import {
+  mapRowsToNodes,
+  mapRowsToCards,
+  mapRowToNode,
+  mapRowToCard,
+} from '../src/core/data-mapper';
 
 describe('data mapper', () => {
   test('maps rows to nodes with metadata', () => {
@@ -34,5 +39,25 @@ describe('data mapper', () => {
     expect(result).toEqual([
       { id: 'a', title: 'T', description: 'D', style: { cardTheme: 'blue' } },
     ]);
+  });
+
+  test('row helper functions map single entries', () => {
+    const row = { ID: '7', Title: 'One', Theme: 'red' };
+    const opts = {
+      idColumn: 'ID',
+      labelColumn: 'Title',
+      templateColumn: 'Theme',
+    } as const;
+    expect(mapRowToNode(row, opts, 0)).toEqual({
+      id: '7',
+      label: 'One',
+      type: 'red',
+      metadata: { rowId: '7' },
+    });
+    expect(mapRowToCard(row, opts)).toEqual({
+      id: '7',
+      title: 'One',
+      style: { cardTheme: 'red' },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extract `mapRowToNode` and `mapRowToCard` helpers from data mapper
- add `parseCardStyle` for card normalisation
- refactor search helpers to reuse small functions
- label modal backdrop for accessibility
- simplify preset generator
- add unit tests for new helpers

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint` *(fails: complexity errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_686148a893ac832b851b71379570d85c