### PR TITLE
Fix Modal tests for accessible close button

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -81,7 +81,6 @@ export function Modal({
 
   if (!isOpen) return null;
 
-
   // Close the modal when the backdrop is activated via mouse or keyboard
   return (
     <div
@@ -89,7 +88,6 @@ export function Modal({
       tabIndex={0}
       aria-label='Close modal'
       className='modal-backdrop'
-      aria-label='Close modal'
       style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();

--- a/tests/modal.test.tsx
+++ b/tests/modal.test.tsx
@@ -56,7 +56,7 @@ describe('Modal', () => {
 
   test('clicking the backdrop triggers onClose', () => {
     const spy = vi.fn();
-    const { container } = render(
+    render(
       <Modal
         title='B'
         isOpen
@@ -64,14 +64,14 @@ describe('Modal', () => {
         <button>Inside</button>
       </Modal>,
     );
-    const backdrop = container.querySelector('.modal-backdrop') as HTMLElement;
+    const backdrop = screen.getByRole('button', { name: /close modal/i });
     fireEvent.click(backdrop);
     expect(spy).toHaveBeenCalled();
   });
 
   test('pressing Enter on the backdrop triggers onClose', () => {
     const spy = vi.fn();
-    const { container } = render(
+    render(
       <Modal
         title='C'
         isOpen
@@ -79,7 +79,7 @@ describe('Modal', () => {
         <button>Inner</button>
       </Modal>,
     );
-    const backdrop = container.querySelector('.modal-backdrop') as HTMLElement;
+    const backdrop = screen.getByRole('button', { name: /close modal/i });
     fireEvent.keyDown(backdrop, { key: 'Enter' });
     expect(spy).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- update `Modal` close overlay markup
- use accessible label for overlay in tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors)*
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68614c7bbd98832b8b6fa59bd7715ad0