### PR TITLE
fix(auth): use secure random generator

### DIFF
--- a/src/core/utils/graph-auth.ts
+++ b/src/core/utils/graph-auth.ts
@@ -9,12 +9,13 @@ export class GraphAuth {
   private static readonly STATE = 'graph.state';
 
   /**
-   * Generate and persist a random state token used for OAuth validation.
+   * Generate and persist a cryptographically secure state token used for OAuth
+   * validation.
    *
    * @returns Newly created state value.
    */
   public generateState(): string {
-    const state = Math.random().toString(36).slice(2);
+    const state = crypto.randomUUID();
     sessionStorage.setItem(GraphAuth.STATE, state);
     return state;
   }


### PR DESCRIPTION
## Summary
- ensure OAuth state uses crypto.randomUUID

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: Async method has a complexity of 9...)*

------
https://chatgpt.com/codex/tasks/task_e_68614d2aca9c832b9b61b78647a8c981