### PR TITLE
Fix base64 encoding regex

### DIFF
--- a/src/core/utils/base64.ts
+++ b/src/core/utils/base64.ts
@@ -2,7 +2,7 @@
  * Encode a string as Base64URL in a UTF-8 safe manner.
  *
  * Uses `Buffer` when running in Node and falls back to
- * `btoa(unescape(encodeURIComponent()))` in the browser.
+ * a `TextEncoder`-based implementation in the browser.
  *
  * @param input - Raw string to encode.
  * @returns Base64URL encoded representation.
@@ -12,10 +12,11 @@ export function encodeBase64(input: string): string {
     typeof Buffer !== 'undefined' &&
     (typeof window === 'undefined' || typeof window.btoa !== 'function')
       ? Buffer.from(input, 'utf8').toString('base64')
-      : btoa(
-          encodeURIComponent(input).replace(/%([0-9A-F]{2})/g, (_, p) =>
-            String.fromCharCode(parseInt(p, 16)),
-          ),
-        );
+      : (() => {
+          const bytes = new TextEncoder().encode(input);
+          let binary = '';
+          for (const byte of bytes) binary += String.fromCharCode(byte);
+          return btoa(binary);
+        })();
   return base64.replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
 }

--- a/tests/base64.test.ts
+++ b/tests/base64.test.ts
@@ -1,0 +1,19 @@
+import { encodeBase64 } from '../src/core/utils/base64';
+
+function expected(input: string): string {
+  return Buffer.from(input, 'utf8')
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+describe('encodeBase64', () => {
+  test.each([
+    'hello',
+    'https://миру',
+    'https://example.com/тест+file/?q=a/b+c',
+  ])('encodes %s', (value) => {
+    expect(encodeBase64(value)).toBe(expected(value));
+  });
+});


### PR DESCRIPTION
## Summary
- rewrite `encodeBase64` without regex backtracking risk
- add unit tests for new implementation

## Testing
- `npx eslint src/core/utils/base64.ts tests/base64.test.ts`
- `npx vitest run tests/base64.test.ts`
- `npm run typecheck --silent` *(fails: JSX elements cannot have multiple attributes with the same name)*
- `npm run lint --silent` *(fails: 16 complexity errors)*


------
https://chatgpt.com/codex/tasks/task_e_68614d08d704832bb3caaa7aa0ccb857