### PR TITLE
Add flexible graph loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 - Initial creation of changelog.
+- Automatically convert hierarchical and flat graph files when imported.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ Nodes are sorted alphabetically by default or via a custom metadata key. A
 three‑level sample dataset is available at
 [tests/fixtures/sample-hier.json](tests/fixtures/sample-hier.json). Simply
 select **Nested** and import this file to see parent widgets sized to fit their
-children. If a standard flat graph is supplied instead, the importer will raise
-an error indicating an invalid hierarchy.
+children. Flat graph data is automatically converted when necessary.
 
 ## Accessibility
 

--- a/src/core/graph/graph-processor.ts
+++ b/src/core/graph/graph-processor.ts
@@ -50,8 +50,8 @@ export class GraphProcessor extends UndoableProcessor {
     options: ProcessOptions = {},
   ): Promise<void> {
     fileUtils.validateFile(file);
-    const graph = await graphService.loadGraph(file);
-    await this.processGraph(graph, options);
+    const data = await graphService.loadAnyGraph(file);
+    await this.processGraph(data, options);
   }
 
   /**

--- a/tests/graph-load-any.test.ts
+++ b/tests/graph-load-any.test.ts
@@ -1,0 +1,62 @@
+import { defaultBuilder, graphService } from '../src/core/graph';
+
+interface ReaderEvent {
+  target: { result?: string | null } | null;
+}
+
+describe('loadAnyGraph', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as { FileReader?: unknown }).FileReader;
+  });
+
+  test('parses graph data and resets cache', async () => {
+    const resetSpy = jest.spyOn(defaultBuilder, 'reset');
+    class FR {
+      onload: ((e: ReaderEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        this.onload?.({
+          target: { result: '{"nodes":[],"edges":[]}' },
+        } as ReaderEvent);
+      }
+    }
+    (global as { FileReader?: unknown }).FileReader = FR;
+    const file = { name: 'g.json' } as unknown as File;
+    const data = await graphService.loadAnyGraph(file);
+    expect(data).toEqual({ nodes: [], edges: [] });
+    expect(resetSpy).toHaveBeenCalled();
+  });
+
+  test('parses hierarchy data', async () => {
+    class FR {
+      onload: ((e: ReaderEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        this.onload?.({
+          target: { result: '[{"id":"n","label":"L","type":"Role"}]' },
+        } as ReaderEvent);
+      }
+    }
+    (global as { FileReader?: unknown }).FileReader = FR;
+    const file = { name: 'h.json' } as unknown as File;
+    const data = await graphService.loadAnyGraph(file);
+    expect(Array.isArray(data)).toBe(true);
+    if (Array.isArray(data)) {
+      expect(data[0]).toMatchObject({ id: 'n', label: 'L', type: 'Role' });
+    }
+  });
+
+  test('throws on malformed JSON', async () => {
+    class FR {
+      onload: ((e: ReaderEvent) => void) | null = null;
+      readAsText() {
+        this.onload?.({ target: { result: 'null' } } as ReaderEvent);
+      }
+    }
+    (global as { FileReader?: unknown }).FileReader = FR;
+    await expect(
+      graphService.loadAnyGraph({ name: 'bad.json' } as unknown as File),
+    ).rejects.toThrow('Invalid graph data');
+  });
+});

--- a/tests/processor-file.test.ts
+++ b/tests/processor-file.test.ts
@@ -24,8 +24,8 @@ describe('GraphProcessor.processFile', () => {
     const mockGraph = { nodes: [], edges: [] } as Parameters<
       GraphProcessor['processGraph']
     >[0];
-    // Stub out loadGraph and internal processGraph
-    jest.spyOn(graphService, 'loadGraph').mockResolvedValue(mockGraph);
+    // Stub out loadAnyGraph and internal processGraph
+    jest.spyOn(graphService, 'loadAnyGraph').mockResolvedValue(mockGraph);
     const processSpy = jest
       .spyOn(
         gp as unknown as {
@@ -36,7 +36,7 @@ describe('GraphProcessor.processFile', () => {
       .mockResolvedValue(undefined);
     const file = { name: 'g.json' } as unknown as File;
     await gp.processFile(file);
-    expect(graphService.loadGraph).toHaveBeenCalledWith(file);
+    expect(graphService.loadAnyGraph).toHaveBeenCalledWith(file);
     expect(processSpy).toHaveBeenCalledWith(mockGraph, {});
   });
 });


### PR DESCRIPTION
## Summary
- load hierarchical or flat data via `loadAnyGraph`
- delegate file imports to the new helper
- document automatic conversion in the README
- add regression test for the new loader
- update processor-file test
- note change in changelog

## Testing
- `npm install --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors)*
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861ddf178c0832b8aa3b86a33102481