### PR TITLE
Refactor shape element style builder

### DIFF
--- a/tests/element-utils.test.ts
+++ b/tests/element-utils.test.ts
@@ -1,0 +1,28 @@
+import { buildShapeStyle } from '../src/board/element-utils';
+import { templateManager } from '../src/board/templates';
+
+describe('buildShapeStyle', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('merges existing style with template style', () => {
+    jest
+      .spyOn(templateManager, 'resolveStyle')
+      .mockImplementation((style) => style);
+    const result = buildShapeStyle(
+      { borderWidth: 1 },
+      { style: { fillColor: '#fff' } },
+    );
+    expect(result.borderWidth).toBe(1);
+    expect(result.fillColor).toBe('#fff');
+  });
+
+  test('applies fill when fillColor missing', () => {
+    jest
+      .spyOn(templateManager, 'resolveStyle')
+      .mockImplementation((style) => style);
+    const result = buildShapeStyle(undefined, { fill: '#abc', style: {} });
+    expect(result.fillColor).toBe('#abc');
+  });
+});


### PR DESCRIPTION
## Summary
- centralize shape style creation with `buildShapeStyle`
- simplify `applyShapeElement` using mapping table
- add unit tests for `buildShapeStyle`

## Testing
- `npm run prettier --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity issues in unrelated files)*
- `npm run stylelint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861e5be55f8832babb9f9c73dae37d6