### PR TITLE
Refactor template token resolution helpers

### DIFF
--- a/tests/templates-functions.test.ts
+++ b/tests/templates-functions.test.ts
@@ -17,3 +17,22 @@ test('template helpers return values or undefined', () => {
   expect(templateManager.getConnectorTemplate('missing')).toBeUndefined();
   delete (connectorTemplates as unknown as Record<string, unknown>).extra;
 });
+
+describe('token resolution', () => {
+  test('resolves color tokens to hex', () => {
+    const style = templateManager.resolveStyle({
+      fillColor: 'tokens.color.red[700]',
+    });
+    expect(style.fillColor).toBe('#6b1720');
+  });
+
+  test('returns raw value for unknown tokens', () => {
+    const style = templateManager.resolveStyle({ something: 'tokens.foo.bar' });
+    expect(style.something).toBe('tokens.foo.bar');
+  });
+
+  test('looks up generic tokens', () => {
+    const style = templateManager.resolveStyle({ gap: 'tokens.space.small' });
+    expect(style.gap).toBe('var(--space-small)');
+  });
+});


### PR DESCRIPTION
## Summary
- move token lookup helpers into reusable methods
- test color and generic token resolution paths

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861e7afe3a8832b9f2401fd7d27e9f7