### PR TITLE
Refactor data mapper helpers

### DIFF
--- a/tests/data-mapper.test.ts
+++ b/tests/data-mapper.test.ts
@@ -4,6 +4,8 @@ import {
   mapRowsToCards,
   mapRowToNode,
   mapRowToCard,
+  buildMetadata,
+  resolveIdLabelType,
 } from '../src/core/data-mapper';
 
 describe('data mapper', () => {
@@ -48,6 +50,12 @@ describe('data mapper', () => {
       labelColumn: 'Title',
       templateColumn: 'Theme',
     } as const;
+    expect(resolveIdLabelType(row, opts, 0)).toEqual({
+      id: '7',
+      label: 'One',
+      type: 'red',
+    });
+    expect(buildMetadata(row, opts, 0)).toEqual({ rowId: '7' });
     expect(mapRowToNode(row, opts, 0)).toEqual({
       id: '7',
       label: 'One',


### PR DESCRIPTION
## Summary
- simplify helper functions in data-mapper
- expose `buildMetadata` and `resolveIdLabelType`
- update unit tests for new helpers

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity over 8)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861e7b1f8d0832b82f9bd4c2432adc8