### PR TITLE
Refactor card mapping helper

### DIFF
--- a/src/core/data-mapper.ts
+++ b/src/core/data-mapper.ts
@@ -29,6 +29,34 @@ export interface CardDefinition {
 }
 
 /**
+ * Add a property to the target object when the provided value is defined.
+ *
+ * @param target - Object to modify.
+ * @param key - Property key.
+ * @param value - Value to assign if defined.
+ */
+function assignIfDefined<T extends object, K extends PropertyKey, V>(
+  target: T,
+  key: K,
+  value: V | undefined,
+): void {
+  if (value != null) {
+    (target as Record<PropertyKey, V>)[key] = value;
+  }
+}
+
+/**
+ * Retrieve a cell value from a row based on the provided column header.
+ *
+ * @param row - Data row parsed from Excel.
+ * @param column - Column header to read.
+ * @returns The cell value or `undefined` when no column is mapped.
+ */
+function readColumn(row: Record<string, unknown>, column?: string): unknown {
+  return column ? row[column] : undefined;
+}
+
+/**
  * Convert an array of Excel rows into {@link NodeDefinition} objects.
  *
  * @param rows - Parsed rows from {@link ExcelLoader}.
@@ -79,18 +107,24 @@ export function mapRowToCard(
   row: Record<string, unknown>,
   mapping: ColumnMapping,
 ): CardDefinition {
-  const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
-  const titleVal = mapping.labelColumn ? row[mapping.labelColumn] : undefined;
-  const descVal = mapping.textColumn ? row[mapping.textColumn] : undefined;
-  const themeVal = mapping.templateColumn
-    ? row[mapping.templateColumn]
-    : undefined;
+  const idVal = readColumn(row, mapping.idColumn);
+  const titleVal = readColumn(row, mapping.labelColumn);
+  const descVal = readColumn(row, mapping.textColumn);
+  const themeVal = readColumn(row, mapping.templateColumn);
   const card: CardDefinition = {
     title: titleVal != null ? String(titleVal) : '',
   };
-  if (idVal != null) card.id = String(idVal);
-  if (descVal != null) card.description = String(descVal);
-  if (themeVal != null) card.style = { cardTheme: String(themeVal) };
+  assignIfDefined(card, 'id', idVal != null ? String(idVal) : undefined);
+  assignIfDefined(
+    card,
+    'description',
+    descVal != null ? String(descVal) : undefined,
+  );
+  assignIfDefined(
+    card,
+    'style',
+    themeVal != null ? { cardTheme: String(themeVal) } : undefined,
+  );
   return card;
 }
 

--- a/tests/data-mapper.test.ts
+++ b/tests/data-mapper.test.ts
@@ -60,4 +60,10 @@ describe('data mapper', () => {
       style: { cardTheme: 'red' },
     });
   });
+
+  test('mapRowToCard omits undefined fields', () => {
+    const row = { Title: 'Only Title' };
+    const opts = { labelColumn: 'Title' } as const;
+    expect(mapRowToCard(row, opts)).toEqual({ title: 'Only Title' });
+  });
 });


### PR DESCRIPTION
## Summary
- reduce conditional logic when mapping card data
- add helper functions for building card objects
- cover new mapping scenario in tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors)*
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861e7b39f44832ba08e524cf436bf3a