### PR TITLE
Refactor ExcelSyncService helpers

### DIFF
--- a/tests/excel-sync-service.test.ts
+++ b/tests/excel-sync-service.test.ts
@@ -97,6 +97,34 @@ describe('ExcelSyncService', () => {
     expect(rows[0].Desc).toBe('desc');
   });
 
+  test('extractWidgetData returns widget values', async () => {
+    const shape = {
+      type: 'shape',
+      id: 's1',
+      content: 'Z',
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '1', notes: 'meta' }),
+    } as unknown as Record<string, unknown>;
+    const service = new ExcelSyncService();
+    const data = await (service as never)['extractWidgetData'](shape);
+    expect(data.content).toBe('Z');
+    expect(data.meta).toEqual({ rowId: '1', notes: 'meta' });
+  });
+
+  test('updateRowFromWidget merges values', () => {
+    const service = new ExcelSyncService();
+    const result = (service as never)['updateRowFromWidget'](
+      { ID: '1', Name: '' },
+      {
+        idColumn: 'ID',
+        labelColumn: 'Name',
+        metadataColumns: { notes: 'Notes' },
+      },
+      { content: 'A', meta: { notes: 'm' } },
+    );
+    expect(result.Name).toBe('A');
+    expect(result.Notes).toBe('m');
+  });
+
   test('findWidget locates groups by metadata', async () => {
     const shape = {
       type: 'shape',


### PR DESCRIPTION
## Summary
- refactor pushChangesToExcel in ExcelSyncService
- add widget data extraction and row update helpers
- extend excel-sync-service tests for new helper methods

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity violations)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861e7b46224832b96160b61aa35655e