### PR TITLE
feat(layout): extract dimension helper

### DIFF
--- a/tests/layout-engine.test.ts
+++ b/tests/layout-engine.test.ts
@@ -33,7 +33,7 @@ describe('LayoutEngine', () => {
         layoutOptions: expect.objectContaining({
           'elk.algorithm': 'force',
           'elk.direction': 'LEFT',
-          'elk.spacing.nodeNode': 50,
+          'elk.spacing.nodeNode': '50',
         }),
       }),
     );


### PR DESCRIPTION
## Summary
- simplify width & height logic with getNodeDimensions
- add buildElkGraphOptions helper
- update layout tests for coverage

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: complexity errors)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861e7b5349c832b97b1d3f851fa2da4