### PR TITLE
fix(ui): resolve template colors in style presets

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -85,7 +85,7 @@ export function Modal({
   return (
     <div
       tabIndex={0}
-      role="button"
+      role='button'
       aria-label='Close modal'
       data-testid='modal-backdrop'
       className='modal-backdrop'

--- a/src/ui/style-presets.ts
+++ b/src/ui/style-presets.ts
@@ -1,4 +1,5 @@
 import templatesJson from '../../templates/shapeTemplates.json';
+import { templateManager } from '../board/templates';
 import type { TemplateElement } from '../board/templates';
 
 /** Definition of a named style preset. */
@@ -36,23 +37,28 @@ function templateToPreset(
   tpl: { elements?: TemplateElement[] },
 ): StylePreset {
   const el = tpl.elements?.[0];
-  const style = el?.style ?? {};
+  const resolved = templateManager.resolveStyle(el?.style ?? {});
   const fill = valueOrDefault(
-    style.fillColor as string | undefined,
-    valueOrDefault(el?.fill as string | undefined, ''),
+    resolved.fillColor as string | undefined,
+    valueOrDefault(
+      templateManager.resolveStyle({ fillColor: el?.fill ?? '' }).fillColor as
+        | string
+        | undefined,
+      '',
+    ),
   );
   return {
     label: name,
     fontColor: valueOrDefault(
-      style.fontColor as string | undefined,
+      resolved.fontColor as string | undefined,
       DEFAULT_PRESET.fontColor,
     ),
     borderWidth: valueOrDefault(
-      style.borderWidth as number | undefined,
+      resolved.borderWidth as number | undefined,
       DEFAULT_PRESET.borderWidth,
     ),
     borderColor: valueOrDefault(
-      style.borderColor as string | undefined,
+      resolved.borderColor as string | undefined,
       DEFAULT_PRESET.borderColor,
     ),
     fillColor: valueOrDefault(fill, DEFAULT_PRESET.fillColor),

--- a/tests/style-presets.test.ts
+++ b/tests/style-presets.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest';
 import '@testing-library/jest-dom';
 import templatesJson from '../templates/shapeTemplates.json';
 import { stylePresets, STYLE_PRESET_NAMES } from '../src/ui/style-presets';
+import { templateManager } from '../src/board/templates';
 import type { TemplateDefinition } from '../src/board/templates';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
@@ -12,7 +13,8 @@ describe('style-presets', () => {
   test('presets derived from templates', () => {
     const tpl = (templatesJson as Record<string, TemplateDefinition>)
       .BusinessService;
-    const fill = tpl.elements[0].style.fillColor;
+    const fill = templateManager.resolveStyle(tpl.elements[0].style)
+      .fillColor as string;
     expect(stylePresets.BusinessService.fillColor).toBe(fill);
     expect(STYLE_PRESET_NAMES).toContain('BusinessService');
   });


### PR DESCRIPTION
## Summary
- resolve color tokens when deriving style presets
- update style preset test
- fix attribute quotes in Modal backdrop

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686237bd3bf4832ba9647c1ec78f5cb1