### PR TITLE
Add resize scaling controls

### DIFF
--- a/src/board/resize-tools.ts
+++ b/src/board/resize-tools.ts
@@ -63,3 +63,24 @@ export async function applySizeToSelection(
     }
   }, board);
 }
+
+/**
+ * Scale all currently selected widgets by a factor.
+ *
+ * Both the width and height of each widget are multiplied by the provided
+ * factor. Widgets lacking numeric dimensions are ignored.
+ *
+ * @param factor - Scale multiplier to apply.
+ * @param board - Optional board API overriding `miro.board` for testing.
+ */
+export async function scaleSelection(
+  factor: number,
+  board?: BoardLike,
+): Promise<void> {
+  await forEachSelection(async (item: Record<string, unknown>) => {
+    const target = item as { width?: number; height?: number } & Syncable;
+    if (typeof target.width === 'number') target.width *= factor;
+    if (typeof target.height === 'number') target.height *= factor;
+    await maybeSync(target);
+  }, board);
+}

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -12,6 +12,7 @@ import {
 import {
   applySizeToSelection,
   copySizeFromSelection,
+  scaleSelection,
   Size,
 } from '../../board/resize-tools';
 import { useSelection } from '../hooks/use-selection';
@@ -33,6 +34,13 @@ const PRESET_SIZES: Record<'S' | 'M' | 'L', Size> = {
   M: { width: 200, height: 150 },
   L: { width: 400, height: 300 },
 };
+
+/** Scale options for quick resizing by factors. */
+const SCALE_OPTIONS = [
+  { label: '×½', factor: 0.5 },
+  { label: '×2', factor: 2 },
+  { label: '×3', factor: 3 },
+] as const;
 
 /** UI for the Resize tab. */
 export const ResizeTab: React.FC = () => {
@@ -69,6 +77,12 @@ export const ResizeTab: React.FC = () => {
     }
     await applySizeToSelection(target);
   }, [copiedSize, size]);
+
+  const scale = React.useCallback(async (factor: number): Promise<void> => {
+    await scaleSelection(factor);
+    const updated = await copySizeFromSelection();
+    if (updated) setSize(updated);
+  }, []);
 
   React.useEffect(() => {
     const first = selection[0] as
@@ -156,6 +170,16 @@ export const ResizeTab: React.FC = () => {
             onClick={() => setSize(PRESET_SIZES[p])}
             variant='secondary'>
             {p}
+          </Button>
+        ))}
+      </div>
+      <div className='buttons'>
+        {SCALE_OPTIONS.map((s) => (
+          <Button
+            key={s.label}
+            onClick={() => scale(s.factor)}
+            variant='secondary'>
+            {s.label}
           </Button>
         ))}
       </div>

--- a/tests/resize-tools.test.ts
+++ b/tests/resize-tools.test.ts
@@ -1,6 +1,7 @@
 import {
   applySizeToSelection,
   copySizeFromSelection,
+  scaleSelection,
 } from '../src/board/resize-tools';
 
 describe('resize-tools', () => {
@@ -47,5 +48,23 @@ describe('resize-tools', () => {
     await expect(applySizeToSelection({ width: 1, height: 1 })).rejects.toThrow(
       'Miro board not available',
     );
+  });
+
+  test('scaleSelection multiplies widget dimensions', async () => {
+    const item = { width: 10, height: 5, sync: jest.fn() };
+    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    await scaleSelection(2, board);
+    expect(item.width).toBe(20);
+    expect(item.height).toBe(10);
+    expect(item.sync).toHaveBeenCalled();
+  });
+
+  test('scaleSelection ignores unsupported items', async () => {
+    const items = [{ width: 4, height: 4, sync: jest.fn() }, { foo: 'bar' }];
+    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    await scaleSelection(0.5, board);
+    expect(items[0].width).toBe(2);
+    expect(items[0].height).toBe(2);
+    expect(items[1]).toEqual({ foo: 'bar' });
   });
 });

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -104,6 +104,17 @@ describe('tab components', () => {
     expect(heightInput.value).toBe('90');
   });
 
+  test('ResizeTab scaling buttons apply factor', async () => {
+    const spy = jest
+      .spyOn(resizeTools, 'scaleSelection')
+      .mockResolvedValue(undefined as unknown as void);
+    render(React.createElement(ResizeTab));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /×2/i }));
+    });
+    expect(spy).toHaveBeenCalledWith(2);
+  });
+
   test('StyleTab tweaks fill colour', async () => {
     const spy = jest
       .spyOn(styleTools, 'tweakFillColor')


### PR DESCRIPTION
## Summary
- add `scaleSelection` helper to adjust widget dimensions
- add ×½, ×2 and ×3 controls in ResizeTab
- test board scaling helper and new UI actions

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68623db95e94832b8ba1713424269c81