### PR TITLE
Fix custom event name for Edit Metadata

### DIFF
--- a/src/app/diagram-app.ts
+++ b/src/app/diagram-app.ts
@@ -22,7 +22,7 @@ export class DiagramApp {
     miro.board.ui.on('icon:click', async () => {
       await miro.board.ui.openPanel({ url: 'app.html' });
     });
-    miro.board.ui.on('edit-metadata', async () => {
+    miro.board.ui.on('custom:edit-metadata', async () => {
       await miro.board.ui.openPanel({ url: 'app.html?command=edit-metadata' });
     });
   }

--- a/tests/diagram-app.test.ts
+++ b/tests/diagram-app.test.ts
@@ -24,12 +24,15 @@ describe('DiagramApp', () => {
   test('init registers handlers and opens panel for commands', async () => {
     const openPanel = jest.fn().mockResolvedValue(undefined);
     const on = jest.fn((e: string, cb: () => Promise<void>) => {
-      if (e === 'icon:click' || e === 'edit-metadata') cb();
+      if (e === 'icon:click' || e === 'custom:edit-metadata') cb();
     });
     global.miro = { board: { ui: { on, openPanel } } };
     await DiagramApp.getInstance().init();
     expect(on).toHaveBeenCalledWith('icon:click', expect.any(Function));
-    expect(on).toHaveBeenCalledWith('edit-metadata', expect.any(Function));
+    expect(on).toHaveBeenCalledWith(
+      'custom:edit-metadata',
+      expect.any(Function),
+    );
     expect(openPanel).toHaveBeenCalledWith({ url: 'app.html' });
     expect(openPanel).toHaveBeenCalledWith({
       url: 'app.html?command=edit-metadata',


### PR DESCRIPTION
## Summary
- fix edit metadata board command event name
- align unit tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68623d74e18c832ba165215d9a878e4c