### PR TITLE
Add generic row mapper utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial creation of changelog.
 - Automatically convert hierarchical and flat graph files when imported.
 - Refactor tab pages to use dedicated hooks for diagram, Excel and search logic.
+- Consolidate row mapping into `mapRowsWith` utility.

--- a/src/core/data-mapper.ts
+++ b/src/core/data-mapper.ts
@@ -121,7 +121,7 @@ export function mapRowsToNodes(
   rows: Array<Record<string, unknown>>,
   mapping: ColumnMapping,
 ): NodeDefinition[] {
-  return rows.map((row, index) => mapRowToNode(row, mapping, index));
+  return mapRowsWith(rows, mapping, mapRowToNode);
 }
 
 /**
@@ -159,5 +159,27 @@ export function mapRowsToCards(
   rows: Array<Record<string, unknown>>,
   mapping: ColumnMapping,
 ): CardDefinition[] {
-  return rows.map((row) => mapRowToCard(row, mapping));
+  return mapRowsWith(rows, mapping, (row, map) => mapRowToCard(row, map));
+}
+
+/**
+ * Generic helper mapping rows into arbitrary objects using the provided
+ * mapping function. The mapping configuration is forwarded to each call.
+ *
+ * @typeParam T - Resulting object type produced by the mapper.
+ * @param rows - Parsed rows from {@link ExcelLoader}.
+ * @param mapping - Column mapping configuration.
+ * @param mapper - Row conversion function.
+ * @returns Array of mapped objects.
+ */
+export function mapRowsWith<T>(
+  rows: Array<Record<string, unknown>>,
+  mapping: ColumnMapping,
+  mapper: (
+    row: Record<string, unknown>,
+    map: ColumnMapping,
+    index: number,
+  ) => T,
+): T[] {
+  return rows.map((row, index) => mapper(row, mapping, index));
 }

--- a/tests/data-mapper.test.ts
+++ b/tests/data-mapper.test.ts
@@ -4,6 +4,7 @@ import {
   mapRowsToCards,
   mapRowToNode,
   mapRowToCard,
+  mapRowsWith,
   buildMetadata,
   resolveIdLabelType,
 } from '../src/core/data-mapper';
@@ -73,5 +74,11 @@ describe('data mapper', () => {
     const row = { Title: 'Only Title' };
     const opts = { labelColumn: 'Title' } as const;
     expect(mapRowToCard(row, opts)).toEqual({ title: 'Only Title' });
+  });
+
+  test('mapRowsWith delegates mapping logic', () => {
+    const rows = [{ id: '1' }, { id: '2' }];
+    const ids = mapRowsWith(rows, {}, (r) => r.id as string);
+    expect(ids).toEqual(['1', '2']);
   });
 });


### PR DESCRIPTION
## Summary
- add `mapRowsWith` to consolidate row mapping logic
- use the new helper in `mapRowsToNodes` and `mapRowsToCards`
- test the helper in `data-mapper.test.ts`
- document the new helper in the changelog

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686249c2e104832b97944ee2ea41e3be