### PR TITLE
Add npm audit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
+      - name: Audit dependencies
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Prettier
         run: npm run prettier:check
       - name: ESLint
@@ -45,6 +47,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
+      - name: Audit dependencies
+        run: npm audit --omit=dev --audit-level=moderate
       - run: npm test
       - name: SonarCloud Scan
         uses: sonarsource/sonarqube-scan-action@v5
@@ -65,6 +69,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
+      - name: Audit dependencies
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Build
         run: npm run build
       - name: Build Storybook
@@ -90,6 +96,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
+      - name: Audit dependencies
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Download artefact
         uses: actions/download-artifact@v4
         with:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -92,7 +92,9 @@ vercel deploy --prod --confirm
 ```
 
 The GitHub Actions workflow in **.github/workflows/ci.yml** performs the same
-steps automatically on merge to `main`.
+steps automatically on merge to `main`. It also audits production dependencies
+with `npm audit --omit=dev` and fails the build when a moderate or higher
+severity vulnerability is found.
 
 ---
 


### PR DESCRIPTION
## Summary
- audit dependencies in CI workflow and fail on moderate vulnerabilities
- document the audit step in the deployment guide

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_68625970fcf8832bac3506ab847c58d5