### PR TITLE
Refactor layout helpers into dedicated modules

### DIFF
--- a/src/board/grid-layout.ts
+++ b/src/board/grid-layout.ts
@@ -40,3 +40,29 @@ export function calculateGrid(
   }
   return positions;
 }
+
+/**
+ * Convenience wrapper building a grid configuration from {@link GridOptions}.
+ *
+ * @param opts - Layout options controlling columns and padding.
+ * @param count - Number of items to position.
+ * @param cellWidth - Width of each grid cell.
+ * @param cellHeight - Height of each grid cell.
+ */
+export function calculateGridPositions(
+  opts: {
+    cols: number;
+    padding: number;
+    sortOrientation?: 'horizontal' | 'vertical';
+  },
+  count: number,
+  cellWidth: number,
+  cellHeight: number,
+): GridPosition[] {
+  const config: GridConfig = {
+    cols: opts.cols,
+    padding: opts.padding,
+    vertical: opts.sortOrientation === 'vertical',
+  };
+  return calculateGrid(count, config, cellWidth, cellHeight);
+}

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -25,29 +25,12 @@ export interface Position {
  */
 import { BoardLike, getBoard, maybeSync, Syncable } from './board';
 import { getTextFields } from './search-tools';
-import { calculateGrid, GridConfig as LayoutGridConfig } from './grid-layout';
+import { calculateGridPositions } from './grid-layout';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {
   const first = getTextFields(item)[0];
   return first ? first[1] : '';
-}
-
-/**
- * Compute the relative offsets for each grid cell.
- */
-export function calculateGridPositions(
-  opts: GridOptions,
-  count: number,
-  cellWidth: number,
-  cellHeight: number,
-): Position[] {
-  const config: LayoutGridConfig = {
-    cols: opts.cols,
-    padding: opts.padding,
-    vertical: opts.sortOrientation === 'vertical',
-  };
-  return calculateGrid(count, config, cellWidth, cellHeight);
 }
 
 /**

--- a/src/board/spacing-layout.ts
+++ b/src/board/spacing-layout.ts
@@ -1,0 +1,44 @@
+/**
+ * Helper functions for calculating spacing layouts.
+ *
+ * These utilities operate purely on dimensions and coordinates without
+ * referencing the board API.
+ */
+
+/** Compute linear offsets for a given count and spacing. */
+export function calculateSpacingOffsets(
+  count: number,
+  spacing: number,
+): number[] {
+  return Array.from({ length: count }, (_, i) => i * spacing);
+}
+
+/** Plan widget positions and size when distributing by growth. */
+export function calculateGrowthPlan(
+  items: Array<Record<string, number>>,
+  axis: 'x' | 'y',
+  spacing: number,
+): { size: number; positions: number[] } {
+  const sizeKey = axis === 'x' ? 'width' : 'height';
+  const first = items[0];
+  const last = items[items.length - 1];
+  /* c8 ignore next */
+  const startEdge = (first[axis] ?? 0) - getDimension(first, sizeKey) / 2;
+  /* c8 ignore next */
+  const endEdge = (last[axis] ?? 0) + getDimension(last, sizeKey) / 2;
+  const total = endEdge - startEdge;
+  const size = (total - spacing * (items.length - 1)) / items.length;
+  const positions: number[] = [];
+  let pos = startEdge + size / 2;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for (const _ of items) {
+    positions.push(pos);
+    pos += size + spacing;
+  }
+  return { size, positions };
+}
+
+function getDimension(item: Record<string, number>, key: string): number {
+  const val = item[key];
+  return typeof val === 'number' ? val : 0;
+}

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -1,4 +1,5 @@
 import { BoardLike, getBoard, maybeSync, Syncable } from './board';
+import { calculateGrowthPlan } from './spacing-layout';
 
 /** Options for spacing layout. */
 export interface SpacingOptions {
@@ -12,39 +13,6 @@ export interface SpacingOptions {
    * - `grow` expands all widgets equally so outer edges remain fixed.
    */
   mode?: 'move' | 'grow';
-}
-
-/** Compute linear offsets for a given count and spacing. */
-export function calculateSpacingOffsets(
-  count: number,
-  spacing: number,
-): number[] {
-  return Array.from({ length: count }, (_, i) => i * spacing);
-}
-
-/** Plan widget positions and size when distributing by growth. */
-export function calculateGrowthPlan(
-  items: Array<Record<string, number>>,
-  axis: 'x' | 'y',
-  spacing: number,
-): { size: number; positions: number[] } {
-  const sizeKey = axis === 'x' ? 'width' : 'height';
-  const first = items[0];
-  const last = items[items.length - 1];
-  /* c8 ignore next */
-  const startEdge = (first[axis] ?? 0) - getDimension(first, sizeKey) / 2;
-  /* c8 ignore next */
-  const endEdge = (last[axis] ?? 0) + getDimension(last, sizeKey) / 2;
-  const total = endEdge - startEdge;
-  const size = (total - spacing * (items.length - 1)) / items.length;
-  const positions: number[] = [];
-  let pos = startEdge + size / 2;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  for (const _ of items) {
-    positions.push(pos);
-    pos += size + spacing;
-  }
-  return { size, positions };
 }
 
 /**

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -1,8 +1,8 @@
+import { applyGridLayout } from '../src/board/grid-tools';
 import {
-  applyGridLayout,
+  calculateGrid,
   calculateGridPositions,
-} from '../src/board/grid-tools';
-import { calculateGrid } from '../src/board/grid-layout';
+} from '../src/board/grid-layout';
 import { BoardLike } from '../src/board/board';
 
 describe('grid-tools', () => {

--- a/tests/spacing-tools.test.ts
+++ b/tests/spacing-tools.test.ts
@@ -1,7 +1,5 @@
-import {
-  applySpacingLayout,
-  calculateSpacingOffsets,
-} from '../src/board/spacing-tools';
+import { applySpacingLayout } from '../src/board/spacing-tools';
+import { calculateSpacingOffsets } from '../src/board/spacing-layout';
 import { BoardLike } from '../src/board/board';
 
 describe('spacing-tools', () => {


### PR DESCRIPTION
## Summary
- move spacing calculations into new `spacing-layout` module
- expose `calculateGridPositions` from `grid-layout`
- update tools to consume new helpers
- adjust tests for refactored imports

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68625922d1f8832bb58da408b4b348e6