### PR TITLE
Fix loader regex and modal accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # [1.11.0](https://github.com/fenrick/MiroDiagramming/compare/v1.10.0...v1.11.0) (2025-06-30)
 
-
 ### Bug Fixes
 
-* **app:** prefix custom event ([e995a1c](https://github.com/fenrick/MiroDiagramming/commit/e995a1c2041caf47cfeaa87d1f86273f6accde06))
-* **core:** replace xlsx with exceljs ([68e81c5](https://github.com/fenrick/MiroDiagramming/commit/68e81c57bf20e9e47aba539cf303a1252a89c112))
-
+- **app:** prefix custom event
+  ([e995a1c](https://github.com/fenrick/MiroDiagramming/commit/e995a1c2041caf47cfeaa87d1f86273f6accde06))
+- **core:** replace xlsx with exceljs
+  ([68e81c5](https://github.com/fenrick/MiroDiagramming/commit/68e81c57bf20e9e47aba539cf303a1252a89c112))
 
 ### Features
 
-* **resize:** add scaling controls ([6a639d1](https://github.com/fenrick/MiroDiagramming/commit/6a639d1644bdd3cb2aa239bb586268d628f291d8))
-* **ui:** add frame locking option ([b173648](https://github.com/fenrick/MiroDiagramming/commit/b17364825236314b31a08de91a5a7ce2e1309273))
+- **resize:** add scaling controls
+  ([6a639d1](https://github.com/fenrick/MiroDiagramming/commit/6a639d1644bdd3cb2aa239bb586268d628f291d8))
+- **ui:** add frame locking option
+  ([b173648](https://github.com/fenrick/MiroDiagramming/commit/b17364825236314b31a08de91a5a7ce2e1309273))
 
 # [1.10.0](https://github.com/fenrick/MiroDiagramming/compare/v1.9.0...v1.10.0) (2025-06-30)
 

--- a/src/core/utils/excel-loader.ts
+++ b/src/core/utils/excel-loader.ts
@@ -97,6 +97,13 @@ export class ExcelLoader {
     return rows;
   }
 
+  /**
+   * Convert an Excel range reference into numeric row and column indices.
+   *
+   * @param ref - Standard range string like "A1:B2" or undefined for entire sheet.
+   * @param ws - Worksheet used to determine default bounds when `ref` is empty.
+   * @returns Coordinates for the start and end of the range.
+   */
   private parseRange(
     ref: string | undefined,
     ws: ExcelJS.Worksheet,

--- a/src/core/utils/excel-loader.ts
+++ b/src/core/utils/excel-loader.ts
@@ -111,7 +111,8 @@ export class ExcelLoader {
       };
     }
     const clean = ref.replace(/\$/g, '');
-    const match = clean.match(/([A-Z]+)(\d+):([A-Z]+)(\d+)/i);
+    const rangeRegex = /([A-Z]+)(\d+):([A-Z]+)(\d+)/i;
+    const match = rangeRegex.exec(clean);
     if (!match) throw new Error(`Invalid range: ${ref}`);
     const [, sCol, sRow, eCol, eRow] = match;
     const colNum = (col: string) =>

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -83,24 +83,25 @@ export function Modal({
 
   // Close the modal when the backdrop is activated via mouse or keyboard
   return (
-    <div
-      tabIndex={0}
-      role='button'
-      aria-label='Close modal'
-      data-testid='modal-backdrop'
-      className='modal-backdrop'
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-      onKeyDown={(e) => {
-        if (
-          e.target === e.currentTarget &&
-          (e.key === 'Enter' || e.key === ' ')
-        ) {
-          e.preventDefault();
-          onClose();
-        }
-      }}>
+    <div className='modal-container'>
+      <button
+        type='button'
+        aria-label='Close modal'
+        data-testid='modal-backdrop'
+        className='modal-backdrop'
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+        onKeyDown={(e) => {
+          if (
+            e.target === e.currentTarget &&
+            (e.key === 'Enter' || e.key === ' ')
+          ) {
+            e.preventDefault();
+            onClose();
+          }
+        }}
+      />
       <dialog
         open
         aria-label={title}

--- a/src/ui/hooks/use-row-data.ts
+++ b/src/ui/hooks/use-row-data.ts
@@ -5,6 +5,12 @@ import type { BaseItem, Group } from '@mirohq/websdk-types';
 
 const META_KEY = 'app.miro.excel';
 
+/**
+ * Narrow a board item to the Group type.
+ *
+ * @param item - Widget or group from the Miro SDK.
+ * @returns True when the item exposes a `getItems` method.
+ */
 function isGroup(item: BaseItem | Group): item is Group {
   return typeof (item as Group).getItems === 'function';
 }

--- a/src/ui/hooks/use-row-data.ts
+++ b/src/ui/hooks/use-row-data.ts
@@ -5,6 +5,10 @@ import type { BaseItem, Group } from '@mirohq/websdk-types';
 
 const META_KEY = 'app.miro.excel';
 
+function isGroup(item: BaseItem | Group): item is Group {
+  return typeof (item as Group).getItems === 'function';
+}
+
 /**
  * Extract the row identifier from a widget or group.
  *
@@ -14,10 +18,10 @@ const META_KEY = 'app.miro.excel';
 async function extractRowId(
   item: BaseItem | Group,
 ): Promise<string | undefined> {
-  if (item.type === 'group') {
-    const items = await (item as Group).getItems();
+  if (isGroup(item)) {
+    const items = await item.getItems();
     for (const child of items) {
-      const meta = (await (child as BaseItem).getMetadata(META_KEY)) as {
+      const meta = (await child.getMetadata(META_KEY)) as {
         rowId?: string;
       } | null;
       if (meta?.rowId) return String(meta.rowId);
@@ -25,9 +29,7 @@ async function extractRowId(
     /* c8 ignore next */
     return undefined;
   }
-  const meta = (await (item as BaseItem).getMetadata(META_KEY)) as {
-    rowId?: string;
-  } | null;
+  const meta = (await item.getMetadata(META_KEY)) as { rowId?: string } | null;
   return meta?.rowId ? String(meta.rowId) : undefined;
 }
 

--- a/tests/excel-loader.test.ts
+++ b/tests/excel-loader.test.ts
@@ -116,4 +116,15 @@ describe('excel loader', () => {
       'Missing sheet for table: Bad',
     );
   });
+
+  test('parseRange rejects malformed references', async () => {
+    const loader = new ExcelLoader();
+    await loader.loadWorkbook(file);
+    const helper = loader as unknown as {
+      getSheet: (name: string) => ExcelJS.Worksheet;
+      parseRange: (ref: string, ws: ExcelJS.Worksheet) => unknown;
+    };
+    const ws = helper.getSheet('Sheet1');
+    expect(() => helper.parseRange('A1B2', ws)).toThrow('Invalid range: A1B2');
+  });
 });


### PR DESCRIPTION
## Summary
- use `RegExp.exec` in Excel loader
- add a type guard in `use-row-data`
- make modal backdrop a real button for accessibility

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68628ecbc3b8832b8959523e755b5f55