### PR TITLE
Load ExcelJS dynamically from CDN

### DIFF
--- a/docs/CORE_MODULES.md
+++ b/docs/CORE_MODULES.md
@@ -65,6 +65,7 @@ src/core/
 | utils/base64.ts              | Encode data in Base64 without regex backtracking.   |
 | utils/cards.ts               | Format card content for widgets.                    |
 | utils/color-utils.ts         | Map semantic color names to Miro tokens.            |
+| utils/exceljs-loader.ts      | Dynamically load ExcelJS from the CDN.              |
 | utils/excel-loader.ts        | Parse Excel files into row objects.                 |
 | utils/file-utils.ts          | Read and write local files for import/export.       |
 | utils/graph-auth.ts          | Handle OAuth login for the graph service.           |

--- a/docs/EXCEL_IMPORT.md
+++ b/docs/EXCEL_IMPORT.md
@@ -14,9 +14,10 @@ and two-way updates using existing services.
 
 Use `ExcelLoader` to parse `.xlsx`/`.xls` files. The loader exposes
 `listSheets`, `listNamedTables`, `loadSheet` and `loadNamedTable` helpers for
-accessing worksheet rows. Files are read via the
-[exceljs](https://github.com/exceljs/exceljs) library and converted to objects
-keyed by column headers.
+accessing worksheet rows. The heavy
+[exceljs](https://github.com/exceljs/exceljs) library is loaded dynamically from
+jsDelivr to keep bundle size small and then converted to objects keyed by column
+headers.
 
 ```ts
 import { excelLoader } from '../core/utils/excel-loader';

--- a/src/core/utils/excel-loader.ts
+++ b/src/core/utils/excel-loader.ts
@@ -1,4 +1,5 @@
-import ExcelJS from 'exceljs';
+import type ExcelJS from 'exceljs';
+import { loadExcelJS } from './exceljs-loader';
 import { fileUtils } from './file-utils';
 import { GraphClient, graphClient } from './graph-client';
 
@@ -18,7 +19,8 @@ export class ExcelLoader {
 
   /** Parse a workbook from raw array buffer data. */
   public async loadArrayBuffer(buffer: ArrayBuffer): Promise<void> {
-    const wb = new ExcelJS.Workbook();
+    const Excel = await loadExcelJS();
+    const wb = new Excel.Workbook();
     await wb.xlsx.load(buffer);
     this.workbook = wb;
   }

--- a/src/core/utils/exceljs-loader.ts
+++ b/src/core/utils/exceljs-loader.ts
@@ -1,0 +1,26 @@
+import type ExcelJS from 'exceljs';
+
+/**
+ * Dynamically load the ExcelJS library.
+ *
+ * The module is fetched from node_modules when running in Node (tests)
+ * and from jsDelivr CDN when executed in the browser to avoid bundling it.
+ */
+let excelPromise: Promise<typeof ExcelJS> | null = null;
+
+/** Retrieve the ExcelJS constructor. Cached after the first call. */
+export async function loadExcelJS(): Promise<typeof ExcelJS> {
+  if (excelPromise) return excelPromise;
+
+  const isNode =
+    typeof process !== 'undefined' && process.release?.name === 'node';
+  const dynamic = (p: string) => import(/* @vite-ignore */ p);
+
+  excelPromise = isNode
+    ? dynamic('exceljs').then((m) => (m.default ?? m) as typeof ExcelJS)
+    : dynamic('https://cdn.jsdelivr.net/npm/exceljs@4.4.0/+esm').then(
+        (m) => (m.default ?? m) as typeof ExcelJS,
+      );
+
+  return excelPromise;
+}

--- a/src/core/utils/workbook-writer.ts
+++ b/src/core/utils/workbook-writer.ts
@@ -1,4 +1,4 @@
-import ExcelJS from 'exceljs';
+import { loadExcelJS } from './exceljs-loader';
 import type { ExcelRow } from './excel-loader';
 
 /**
@@ -31,7 +31,8 @@ export async function downloadWorkbook(
   rows: ExcelRow[],
   fileName: string,
 ): Promise<void> {
-  const wb = new ExcelJS.Workbook();
+  const Excel = await loadExcelJS();
+  const wb = new Excel.Workbook();
   const ws = wb.addWorksheet('Sheet1');
   if (rows.length) {
     ws.addRow(Object.keys(rows[0]));

--- a/tests/exceljs-loader.test.ts
+++ b/tests/exceljs-loader.test.ts
@@ -1,0 +1,15 @@
+import { loadExcelJS } from '../src/core/utils/exceljs-loader';
+import ExcelJS from 'exceljs';
+
+describe('loadExcelJS', () => {
+  test('loads ExcelJS from node_modules in Node', async () => {
+    const mod = await loadExcelJS();
+    expect(mod).toBe(ExcelJS);
+  });
+
+  test('caches subsequent calls', async () => {
+    const first = await loadExcelJS();
+    const second = await loadExcelJS();
+    expect(first).toBe(second);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: allHtmlEntries,
-      external: ['elkjs/lib/elk.bundled.js'],
+      external: ['elkjs/lib/elk.bundled.js', 'exceljs'],
     },
   },
   plugins: [react()],


### PR DESCRIPTION
## Summary
- add exceljs-loader to fetch ExcelJS dynamically
- reference loader from ExcelLoader and workbook-writer
- mark ExcelJS as external in vite config
- document dynamic loading in docs and add tests for the loader

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863359821f8832b9e135fcc768c151e