### PR TITLE
Fix tab tests and class naming

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -78,6 +78,6 @@ button {
 .form-example {
 	grid-auto-rows: 1fr auto
 }
-.form-example--main-content {
-	align-self: flex-start
+.form-example-main-content {
+        align-self: flex-start
 }

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -27,64 +27,65 @@ export const StyleTab: React.FC = () => {
   };
   return (
     <div className='grid form-example'>
-      <form className='cs1 ce12 form-example--main-content'>
-          <InputField label='Adjust fill'>
-            <input
-              data-testid='adjust-slider'
-              type='range'
-              min='-100'
-              max='100'
-              list='adjust-marks'
-              value={adjust}
-              onChange={(e) => setAdjust(Number(e.target.value))}
-            />
-            <datalist id='adjust-marks'>
-              {[-100, -50, 0, 50, 100].map((n) => (
-                <option
-                  key={n}
-                  value={n}
-                />
-              ))}
-            </datalist>
-            <span
-              data-testid='adjust-preview'
-              style={{
-                display: 'inline-block',
-                width: '24px',
-                height: '24px',
-                marginLeft: tokens.space.small,
-                border: `1px solid ${tokens.color.gray[200]}`,
-                backgroundColor: preview,
-              }}
-            />
-            <code
-              data-testid='color-hex'
-              style={{ marginLeft: tokens.space.xxsmall }}>
-              {preview}
-            </code>
-          </InputField>
-          <InputField label='Adjust value'>
-            <input
-              className='input input-small'
-              data-testid='adjust-input'
-              type='number'
-              min='-100'
-              max='100'
-              value={String(adjust)}
-              onChange={(e) => setAdjust(Number(e.target.value))}
-              placeholder='Adjust (-100–100)'
-            />
-          </InputField>
-          <div className='buttons'>
-            <Button
-              onClick={apply}
-              variant='primary' className="button-small">
-              <React.Fragment>
-                <Icon name='parameters' />
-                <Text>Apply</Text>
-              </React.Fragment>
-            </Button>
-          </div>
+      <form className='cs1 ce12 form-example-main-content'>
+        <InputField label='Adjust fill'>
+          <input
+            data-testid='adjust-slider'
+            type='range'
+            min='-100'
+            max='100'
+            list='adjust-marks'
+            value={adjust}
+            onChange={(e) => setAdjust(Number(e.target.value))}
+          />
+          <datalist id='adjust-marks'>
+            {[-100, -50, 0, 50, 100].map((n) => (
+              <option
+                key={n}
+                value={n}
+              />
+            ))}
+          </datalist>
+          <span
+            data-testid='adjust-preview'
+            style={{
+              display: 'inline-block',
+              width: '24px',
+              height: '24px',
+              marginLeft: tokens.space.small,
+              border: `1px solid ${tokens.color.gray[200]}`,
+              backgroundColor: preview,
+            }}
+          />
+          <code
+            data-testid='color-hex'
+            style={{ marginLeft: tokens.space.xxsmall }}>
+            {preview}
+          </code>
+        </InputField>
+        <InputField label='Adjust value'>
+          <input
+            className='input input-small'
+            data-testid='adjust-input'
+            type='number'
+            min='-100'
+            max='100'
+            value={String(adjust)}
+            onChange={(e) => setAdjust(Number(e.target.value))}
+            placeholder='Adjust (-100–100)'
+          />
+        </InputField>
+        <div className='buttons'>
+          <Button
+            onClick={apply}
+            variant='primary'
+            className='button-small'>
+            <React.Fragment>
+              <Icon name='parameters' />
+              <Text>Apply</Text>
+            </React.Fragment>
+          </Button>
+        </div>
         <fieldset className='form-group-small'>
           <legend className='p-medium'>Style presets</legend>
           <div className='buttons'>

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -249,7 +249,7 @@ describe('tab components', () => {
       });
     });
     await act(async () => {
-      fireEvent.click(screen.getByText(/rename frames/i));
+      fireEvent.click(screen.getByRole('button', { name: /rename frames/i }));
     });
     expect(spy).toHaveBeenCalledWith({ prefix: 'A-' });
   });
@@ -260,7 +260,7 @@ describe('tab components', () => {
       .mockResolvedValue(undefined as unknown as void);
     render(React.createElement(FramesTab));
     await act(async () => {
-      fireEvent.click(screen.getByText(/lock selected/i));
+      fireEvent.click(screen.getByRole('button', { name: /lock selected/i }));
     });
     expect(spy).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- rename StyleTab CSS class to satisfy stylelint
- adjust StyleTab markup
- fix FramesTab test selectors

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863a3402c34832b99424b3bcab7fae9