### PR TITLE
fix: css semicolons

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -76,8 +76,8 @@ button {
 }
 
 .form-example {
-	grid-auto-rows: 1fr auto
+        grid-auto-rows: 1fr auto;
 }
 .form-example-main-content {
-        align-self: flex-start
+        align-self: flex-start;
 }


### PR DESCRIPTION
## Summary
- add missing semicolons to `.form-example` styles

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863abc61b5c832b84e10a3ae04e00c8