### PR TITLE
feat(utils): add color mixing function

### DIFF
--- a/src/core/utils/color-utils.ts
+++ b/src/core/utils/color-utils.ts
@@ -102,3 +102,24 @@ export function ensureContrast(bg: string, fg: string): string {
     ? resolveColor(tokens.color.black, colors.black)
     : resolveColor(tokens.color.white, colors.white);
 }
+
+/**
+ * Blend two colours by linearly mixing their RGB values.
+ *
+ * @param a - Hex colour string used as the base.
+ * @param b - Hex colour string that is mixed in.
+ * @param weight - Amount of colour `b` from 0 to 1.
+ * @returns Hex colour between `a` and `b`.
+ */
+export function mixColors(a: string, b: string, weight: number): string {
+  const w = Math.min(Math.max(weight, 0), 1);
+  const rgbA = hexToRgb(a);
+  const rgbB = hexToRgb(b);
+  const mix = (va: number, vb: number): number =>
+    Math.round(va * (1 - w) + vb * w);
+  return rgbToHex({
+    r: mix(rgbA.r, rgbB.r),
+    g: mix(rgbA.g, rgbB.g),
+    b: mix(rgbA.b, rgbB.b),
+  });
+}

--- a/tests/color-utils.test.ts
+++ b/tests/color-utils.test.ts
@@ -6,6 +6,7 @@ import {
   resolveColor,
   hexToRgb,
   rgbToHex,
+  mixColors,
 } from '../src/core/utils/color-utils';
 
 describe('color-utils', () => {
@@ -36,4 +37,9 @@ test('resolveColor reads CSS variable', () => {
 test('hexToRgb and rgbToHex roundtrip', () => {
   const rgb = hexToRgb('#abcdef');
   expect(rgbToHex(rgb)).toBe('#abcdef');
+});
+
+test('mixColors blends values', () => {
+  expect(mixColors('#ff0000', '#0000ff', 0.5)).toBe('#800080');
+  expect(mixColors('#000000', '#ffffff', 0.25)).toBe('#404040');
 });


### PR DESCRIPTION
## Summary
- add `mixColors` utility for blending RGB values
- test new color mixing helper

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863ad3b075c832b9ec1e4e509d93d3a