### PR TITLE
Add tests for diagram, cards and arrange tabs

### DIFF
--- a/tests/arrange-tab-grid.test.tsx
+++ b/tests/arrange-tab-grid.test.tsx
@@ -1,0 +1,44 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ArrangeTab } from '../src/ui/pages/ArrangeTab';
+import * as gridTools from '../src/board/grid-tools';
+
+vi.mock('../src/board/grid-tools');
+
+describe('ArrangeTab grid branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('updates grid settings and orientation', async () => {
+    const spy = vi
+      .spyOn(gridTools, 'applyGridLayout')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<ArrangeTab />);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Columns'), {
+        target: { value: '3' },
+      });
+      fireEvent.change(screen.getByLabelText('Gap'), {
+        target: { value: '30' },
+      });
+    });
+    fireEvent.click(screen.getByLabelText('Sort by name'));
+    fireEvent.change(screen.getByLabelText('Order'), {
+      target: { value: 'vertical' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText(/arrange grid/i));
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cols: 3,
+        padding: 30,
+        sortByName: true,
+        sortOrientation: 'vertical',
+      }),
+    );
+  });
+});

--- a/tests/cards-tab-undo.test.tsx
+++ b/tests/cards-tab-undo.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CardsTab } from '../src/ui/pages/CardsTab';
+import { CardProcessor } from '../src/board/card-processor';
+import * as uiUtils from '../src/ui/hooks/ui-utils';
+
+vi.mock('../src/board/card-processor');
+
+describe('CardsTab undo paths', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).miro = {
+      board: { ui: { on: vi.fn() }, notifications: { showError: vi.fn() } },
+    };
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).miro;
+    vi.useRealTimers();
+  });
+
+  test('undo via keyboard shortcut', async () => {
+    vi.spyOn(CardProcessor.prototype, 'processFile').mockResolvedValue(
+      undefined as unknown as void,
+    );
+    const undoSpy = vi
+      .spyOn(uiUtils, 'undoLastImport')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<CardsTab />);
+    const file = new File(['{}'], 'cards.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create cards/i }));
+    });
+    fireEvent.keyDown(window, { key: 'z', metaKey: true });
+    expect(undoSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/diagram-tab-branches.test.tsx
+++ b/tests/diagram-tab-branches.test.tsx
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DiagramTab } from '../src/ui/pages/DiagramTab';
+import { DEFAULT_LAYOUT_OPTIONS } from '../src/core/layout/elk-options';
+import type { GraphProcessor } from '../src/core/graph/graph-processor';
+vi.mock('../src/core/graph/graph-processor');
+
+describe('DiagramTab additional branches', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).miro = {
+      board: { ui: { on: vi.fn() }, notifications: { showError: vi.fn() } },
+    };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).miro;
+  });
+
+  test('keyboard shortcut toggles advanced options', async () => {
+    render(<DiagramTab />);
+    const file = new File(['{}'], 'graph.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    expect(screen.getByLabelText('Algorithm')).not.toBeVisible();
+    fireEvent.keyDown(window, { key: '/', ctrlKey: true });
+    expect(screen.getByLabelText('Algorithm')).toBeVisible();
+  });
+
+  test('all conditional elements render with preset state', () => {
+    const orig = React.useState;
+    vi.spyOn(React, 'useState')
+      .mockImplementationOnce(() => [[new File([], 'a.json')], vi.fn()])
+      .mockImplementationOnce(() => ['Layered', vi.fn()])
+      .mockImplementationOnce(() => [true, vi.fn()])
+      .mockImplementationOnce(() => [true, vi.fn()])
+      .mockImplementationOnce(() => ['Title', vi.fn()])
+      .mockImplementationOnce(() => [
+        { ...DEFAULT_LAYOUT_OPTIONS, algorithm: 'rectpacking' },
+        vi.fn(),
+      ])
+      .mockImplementationOnce(() => [50, vi.fn()])
+      .mockImplementationOnce(() => ['err', vi.fn()])
+      .mockImplementationOnce(() => [{} as GraphProcessor, vi.fn()]);
+    render(<DiagramTab />);
+    expect(screen.getByText('a.json')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Frame title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Algorithm')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.getByText('err')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /undo last import/i }),
+    ).toBeInTheDocument();
+    (React.useState as unknown as vi.Mock).mockRestore();
+  });
+
+  test.each([
+    ['mrtree', 'Routing mode'],
+    ['layered', 'Edge routing'],
+    ['rectpacking', 'Optimisation goal'],
+    ['box', null],
+  ])('option visibility for %s', (alg, label) => {
+    vi.spyOn(React, 'useState')
+      .mockImplementationOnce(() => [[new File([], 'a.json')], vi.fn()])
+      .mockImplementationOnce(() => ['Layered', vi.fn()])
+      .mockImplementationOnce(() => [true, vi.fn()])
+      .mockImplementationOnce(() => [false, vi.fn()])
+      .mockImplementationOnce(() => ['', vi.fn()])
+      .mockImplementationOnce(() => [
+        { ...DEFAULT_LAYOUT_OPTIONS, algorithm: alg as any },
+        vi.fn(),
+      ])
+      .mockImplementationOnce(() => [0, vi.fn()])
+      .mockImplementationOnce(() => [null, vi.fn()])
+      .mockImplementationOnce(() => [undefined, vi.fn()]);
+    render(<DiagramTab />);
+    if (label) {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    } else {
+      expect(screen.queryByLabelText('Edge routing')).toBeNull();
+      expect(screen.queryByLabelText('Routing mode')).toBeNull();
+      expect(screen.queryByLabelText('Optimisation goal')).toBeNull();
+    }
+    (React.useState as unknown as vi.Mock).mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- expand `DiagramTab` branch tests
- test keyboard undo on `CardsTab`
- test grid option paths in `ArrangeTab`

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863ad339120832baa22ac7e30fef1ca