### PR TITLE
Introduce tools tab with subtabs

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -34,63 +34,27 @@ ambiguity.
 
 ---
 
-## 2\u00a0 Frames Tab
+## 2  Tools Tab
 
-| Control           | Details                                         |
-| ----------------- | ----------------------------------------------- |
-| **Prefix Input**  | Text prefix used for renaming                   |
-| **Rename Button** | Applies prefix in left\u2011to\u2011right order |
-| **Lock Button**   | Locks selected frames and their contents        |
+Combines resizing, style tweaks, arranging widgets and frame utilities. Tabs
+within this section mirror the previous individual tabs.
 
-Flow: select frames, type prefix, press **Rename Frames** → titles become
-`<prefix>0`, `<prefix>1`, ... Press **Lock Selected** to prevent modifications.
-Widgets receive the undocumented `locked` flag used by the Web‑SDK.
+### 2.1 Resize
 
----
+As per the former **Resize Tab** with width/height inputs, aspect ratio and copy
+functions.
 
-## 3  Resize Tab
+### 2.2 Colours
 
-Panel split vertically **(Stack space="lg")**
+Brightness slider and preset buttons from the old **Style Tab**.
 
-| Section               | UI Elements                                   | Copy                                       | Interaction                                   |
-| --------------------- | --------------------------------------------- | ------------------------------------------ | --------------------------------------------- | --------------- |
-| **Current Selection** | `<Text>` size readout (W × H px)              | “Selection: 180 × 120 px”                  | Updates on `selection:update`                 | `selectionSize` |
-| **Copied Size**       | `<Text>` (grey if none)                       | “Copied: (none)” OR “Copied: 280 × 160 px” | Shows last copied dimensions                  | `copiedSize`    |
-| **Presets**           | Buttons S/M/L, `<InputField>` Width + Height  | “Apply”                                    | Click preset or enter numbers → preview ghost | –               |
-| **Aspect Ratio**      | `<Select>` Golden, 16:9, 16:10, 4:3           | “Free” default                             | Changing width or ratio updates height        | `ratio`         |
-| **Copy Size**         | `<Button variant="secondary">Copy size`       | Copies `selectionSize` → `copiedSize`      | –                                             |
-| **Apply Copied**      | `<Button variant="primary">Apply copied size` | Disabled if `!copiedSize`                  | Iterates selection; sets dimensions           |
+### 2.3 Arrange
 
-Validation: warn if width/height > 10 000 px (“That’s bigger than your board
-viewport”). Shortcut: **⌥C** copies size, **⌥V** applies.
+Grid and spacing controls previously found in the **Arrange Tab**.
 
----
+### 2.4 Frames
 
-## 4  Style Tab
-
-Layout: single column Stack.
-
-- **Brightness Slider** (−100 %–100 %) – down/up arrow changes by 1 %.
-- Numeric input mirrors slider value.
-- **Apply** button calls `tweakFillColor` with the selected adjustment.
-
-This tab no longer exposes border or text options; use native Miro style tools
-instead.
-
----
-
-## 5  Grid Tab
-
-| Control               | Details                          |
-| --------------------- | -------------------------------- |
-| **Columns Input**     | Numeric; min 1, max 20           |
-| **Gap**               | Numeric spacing in px            |
-| **Frame Title Input** | Optional; enables frame creation |
-| **Preview Overlay**   | CSS grid lines, `opacity: 0.3`   |
-| **Group Checkbox**    | “Group items into Frame”         |
-
-Flow: Change value → overlay updates real‑time. Press **Arrange** creates frame
-if enabled.
+Prefix rename and locking options from the old **Frames Tab**.
 
 ---
 

--- a/src/ui/components/SubTabBar.tsx
+++ b/src/ui/components/SubTabBar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export interface SubTab {
+  id: string;
+  label: string;
+}
+
+/**
+ * Small tab bar component used inside a parent tab.
+ */
+export const SubTabBar: React.FC<{
+  tabs: SubTab[];
+  tab: string;
+  onChange: (id: string) => void;
+}> = ({ tabs, tab, onChange }) => (
+  <div className='tabs tabs-small'>
+    <div className='tabs-header-list'>
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          type='button'
+          role='tab'
+          className={`tab ${tab === t.id ? 'tab-active' : ''}`}
+          onClick={() => onChange(t.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onChange(t.id);
+            }
+          }}>
+          <span className='tab-text'>{t.label}</span>
+        </button>
+      ))}
+    </div>
+  </div>
+);

--- a/src/ui/pages/ToolsTab.tsx
+++ b/src/ui/pages/ToolsTab.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { SubTabBar, SubTab } from '../components/SubTabBar';
+import { ResizeTab } from './ResizeTab';
+import { StyleTab } from './StyleTab';
+import { ArrangeTab } from './ArrangeTab';
+import { FramesTab } from './FramesTab';
+import type { TabTuple } from './tab-definitions';
+
+const SUB_TABS: SubTab[] = [
+  { id: 'resize', label: 'Resize' },
+  { id: 'style', label: 'Colours' },
+  { id: 'arrange', label: 'Arrange' },
+  { id: 'frames', label: 'Frames' },
+];
+
+/**
+ * Combines editing tools into a single tab with sub navigation.
+ */
+export const ToolsTab: React.FC = () => {
+  const [sub, setSub] = React.useState<string>('resize');
+  let Current: React.FC;
+  switch (sub) {
+    case 'style':
+      Current = StyleTab;
+      break;
+    case 'arrange':
+      Current = ArrangeTab;
+      break;
+    case 'frames':
+      Current = FramesTab;
+      break;
+    default:
+      Current = ResizeTab;
+  }
+  return (
+    <div>
+      <SubTabBar
+        tabs={SUB_TABS}
+        tab={sub}
+        onChange={setSub}
+      />
+      <Current />
+    </div>
+  );
+};
+
+export const tabDef: TabTuple = [
+  5,
+  'tools',
+  'Tools',
+  'Resize, style, arrange and frame utilities',
+  ToolsTab,
+];

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -3,6 +3,7 @@ import type React from 'react';
 
 export type TabId =
   | 'create'
+  | 'tools'
   | 'resize'
   | 'style'
   | 'arrange'

--- a/src/ui/pages/tabs.ts
+++ b/src/ui/pages/tabs.ts
@@ -10,7 +10,12 @@ const modules = import.meta.glob<{ tabDef: TabTuple }>('./*Tab.tsx', {
 export const TAB_DATA: TabTuple[] = Object.values(modules)
   .filter((m): m is { tabDef: TabTuple } => 'tabDef' in m)
   .map((m) => m.tabDef)
-  .filter((t) => (process.env.NODE_ENV === 'test' ? true : t[1] !== 'dummy'))
+  .filter((t) =>
+    process.env.NODE_ENV === 'test'
+      ? true
+      : t[1] !== 'dummy' &&
+        !['resize', 'style', 'arrange', 'frames'].includes(t[1]),
+  )
   .sort((a, b) => a[0] - b[0]);
 
 export type Tab = TabId;

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -380,4 +380,12 @@ describe('tab auto-registration', () => {
       process.env.NODE_ENV = prev;
     }
   });
+
+  test('includes ToolsTab by default', async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+    const { TAB_DATA } = await import('../src/ui/pages/tabs.ts?test');
+    expect(TAB_DATA.some((t) => t[1] === 'tools')).toBe(true);
+    process.env.NODE_ENV = prev;
+  });
 });

--- a/tests/tools-tab.test.tsx
+++ b/tests/tools-tab.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ToolsTab } from '../src/ui/pages/ToolsTab';
+
+describe('ToolsTab', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).miro = {
+      board: {
+        getSelection: jest.fn().mockResolvedValue([]),
+        ui: { on: jest.fn() },
+      },
+    };
+  });
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).miro;
+  });
+
+  test('switches between subtabs', async () => {
+    render(<ToolsTab />);
+    expect(screen.getByText(/apply size/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /colours/i }));
+    expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /arrange/i }));
+    expect(screen.getByText(/arrange grid/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /frames/i }));
+    expect(
+      screen.getByRole('button', { name: /rename frames/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ToolsTab` component with resize, style, arrange and frames subtabs
- implement `SubTabBar` component
- register new tab in `tab-definitions` and filter old tabs
- update tab auto-registration tests and add new tests
- document Tools Tab in sidebar tabs blueprint

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863b00add0c832bb51b7bd2568748f2