### PR TITLE
Improve tab accessibility

### DIFF
--- a/src/ui/components/SubTabBar.tsx
+++ b/src/ui/components/SubTabBar.tsx
@@ -12,25 +12,60 @@ export const SubTabBar: React.FC<{
   tabs: SubTab[];
   tab: string;
   onChange: (id: string) => void;
-}> = ({ tabs, tab, onChange }) => (
-  <div className='tabs tabs-small'>
-    <div className='tabs-header-list'>
-      {tabs.map((t) => (
-        <button
-          key={t.id}
-          type='button'
-          role='tab'
-          className={`tab ${tab === t.id ? 'tab-active' : ''}`}
-          onClick={() => onChange(t.id)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              onChange(t.id);
-            }
-          }}>
-          <span className='tab-text'>{t.label}</span>
-        </button>
-      ))}
+}> = ({ tabs, tab, onChange }) => {
+  const refs = React.useRef<HTMLButtonElement[]>([]);
+  const focusTab = (idx: number): void => {
+    refs.current[idx]?.focus();
+  };
+
+  return (
+    <div
+      role='tablist'
+      className='tabs tabs-small'>
+      <div className='tabs-header-list'>
+        {tabs.map((t, idx) => (
+          <button
+            key={t.id}
+            ref={(el) => {
+              if (el) refs.current[idx] = el;
+            }}
+            id={`tab-${t.id}`}
+            type='button'
+            role='tab'
+            className={`tab ${tab === t.id ? 'tab-active' : ''}`}
+            onClick={() => onChange(t.id)}
+            onKeyDown={(e) => {
+              switch (e.key) {
+                case 'ArrowRight':
+                  e.preventDefault();
+                  focusTab((idx + 1) % tabs.length);
+                  break;
+                case 'ArrowLeft':
+                  e.preventDefault();
+                  focusTab((idx - 1 + tabs.length) % tabs.length);
+                  break;
+                case 'Home':
+                  e.preventDefault();
+                  focusTab(0);
+                  break;
+                case 'End':
+                  e.preventDefault();
+                  focusTab(tabs.length - 1);
+                  break;
+                case 'Enter':
+                case ' ': {
+                  e.preventDefault();
+                  onChange(t.id);
+                  break;
+                }
+                default:
+                  break;
+              }
+            }}>
+            <span className='tab-text'>{t.label}</span>
+          </button>
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/ui/components/TabBar.tsx
+++ b/src/ui/components/TabBar.tsx
@@ -7,27 +7,61 @@ export const TabBar: React.FC<{
   tabs: TabTuple[];
   tab: Tab;
   onChange: (t: Tab) => void;
-}> = ({ tabs, tab, onChange }) => (
-  <div
-    className='tabs'
-    style={{ margin: tokens.space.xxsmall }}>
-    <div className='tabs-header-list'>
-      {tabs.map(([, id, label]) => (
-        <button
-          key={id}
-          type='button'
-          role='tab'
-          className={`tab ${tab === id ? 'tab-active' : ''}`}
-          onClick={() => onChange(id)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              onChange(id);
-            }
-          }}>
-          <span className='tab-text'>{label}</span>
-        </button>
-      ))}
+}> = ({ tabs, tab, onChange }) => {
+  const refs = React.useRef<HTMLButtonElement[]>([]);
+  /** Move focus to the target tab index. */
+  const focusTab = (idx: number): void => {
+    refs.current[idx]?.focus();
+  };
+
+  return (
+    <div
+      role='tablist'
+      className='tabs'
+      style={{ margin: tokens.space.xxsmall }}>
+      <div className='tabs-header-list'>
+        {tabs.map(([, id, label], idx) => (
+          <button
+            key={id}
+            ref={(el) => {
+              if (el) refs.current[idx] = el;
+            }}
+            type='button'
+            id={`tab-${id}`}
+            role='tab'
+            className={`tab ${tab === id ? 'tab-active' : ''}`}
+            onClick={() => onChange(id)}
+            onKeyDown={(e) => {
+              switch (e.key) {
+                case 'ArrowRight':
+                  e.preventDefault();
+                  focusTab((idx + 1) % tabs.length);
+                  break;
+                case 'ArrowLeft':
+                  e.preventDefault();
+                  focusTab((idx - 1 + tabs.length) % tabs.length);
+                  break;
+                case 'Home':
+                  e.preventDefault();
+                  focusTab(0);
+                  break;
+                case 'End':
+                  e.preventDefault();
+                  focusTab(tabs.length - 1);
+                  break;
+                case 'Enter':
+                case ' ': // Space
+                  e.preventDefault();
+                  onChange(id);
+                  break;
+                default:
+                  break;
+              }
+            }}>
+            <span className='tab-text'>{label}</span>
+          </button>
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/ui/components/TabPanel.tsx
+++ b/src/ui/components/TabPanel.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { TabId } from '../pages/tab-definitions';
+
+/**
+ * Wraps tab content with appropriate ARIA attributes.
+ */
+export const TabPanel: React.FC<{
+  /** Identifier of the tab controlling this panel. */
+  tabId: TabId;
+  /** Panel content. */
+  children: React.ReactNode;
+}> = ({ tabId, children }) => (
+  <div
+    id={`panel-${tabId}`}
+    role='tabpanel'
+    aria-labelledby={`tab-${tabId}`}>
+    {children}
+  </div>
+);

--- a/src/ui/pages/ArrangeTab.tsx
+++ b/src/ui/pages/ArrangeTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '../components/legacy';
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /**
@@ -58,108 +59,110 @@ export const ArrangeTab: React.FC = () => {
   };
 
   return (
-    <div>
-      <fieldset className='form-group-small'>
-        <InputField label='Columns'>
-          <input
-            className='input input-small'
-            type='number'
-            value={String(grid.cols)}
-            onChange={(e) => updateNumber('cols')(e.target.value)}
-            placeholder='Columns'
-          />
-        </InputField>
-        <InputField label='Gap'>
-          <input
-            className='input input-small'
-            type='number'
-            value={String(grid.padding)}
-            onChange={(e) => updateNumber('padding')(e.target.value)}
-            placeholder='Gap'
-          />
-        </InputField>
-        <Checkbox
-          label='Sort by name'
-          value={Boolean(grid.sortByName)}
-          onChange={toggle('sortByName')}
-        />
-        {grid.sortByName && (
-          <InputField label='Order'>
-            <Select
-              value={grid.sortOrientation}
-              onChange={setOrientation}
-              className='select-small'>
-              <SelectOption value='horizontal'>Horizontally</SelectOption>
-              <SelectOption value='vertical'>Vertically</SelectOption>
-            </Select>
-          </InputField>
-        )}
-        <Checkbox
-          label='Group items into Frame'
-          value={Boolean(grid.groupResult)}
-          onChange={toggle('groupResult')}
-        />
-        {grid.groupResult && (
-          <InputField label='Frame Title'>
+    <TabPanel tabId='arrange'>
+      <div>
+        <fieldset className='form-group-small'>
+          <InputField label='Columns'>
             <input
               className='input input-small'
-              value={frameTitle}
-              onChange={(e) => setFrameTitle(e.target.value)}
-              placeholder='Optional'
+              type='number'
+              value={String(grid.cols)}
+              onChange={(e) => updateNumber('cols')(e.target.value)}
+              placeholder='Columns'
             />
           </InputField>
-        )}
-        <div className='buttons'>
-          <Button
-            onClick={applyGrid}
-            variant='primary'>
-            <React.Fragment>
-              <Icon name='grid' />
-              <Text>Arrange Grid</Text>
-            </React.Fragment>
-          </Button>
-        </div>
-      </fieldset>
-      <fieldset className='form-group-small'>
-        <InputField label='Axis'>
-          <Select
-            value={spacing.axis}
-            onChange={updateAxis}
-            className='select-small'>
-            <SelectOption value='x'>Horizontal</SelectOption>
-            <SelectOption value='y'>Vertical</SelectOption>
-          </Select>
-        </InputField>
-        <InputField label='Mode'>
-          <Select
-            value={spacing.mode ?? 'move'}
-            onChange={updateMode}
-            className='select-small'>
-            <SelectOption value='move'>Move</SelectOption>
-            <SelectOption value='grow'>Expand</SelectOption>
-          </Select>
-        </InputField>
-        <InputField label='Spacing'>
-          <input
-            className='input input-small'
-            type='number'
-            value={String(spacing.spacing)}
-            onChange={(e) => updateSpacing(e.target.value)}
-            placeholder='Distance'
+          <InputField label='Gap'>
+            <input
+              className='input input-small'
+              type='number'
+              value={String(grid.padding)}
+              onChange={(e) => updateNumber('padding')(e.target.value)}
+              placeholder='Gap'
+            />
+          </InputField>
+          <Checkbox
+            label='Sort by name'
+            value={Boolean(grid.sortByName)}
+            onChange={toggle('sortByName')}
           />
-        </InputField>
-        <div className='buttons'>
-          <Button
-            onClick={applySpacing}
-            variant='primary'>
-            <React.Fragment>
-              <Icon name='arrow-right' />
-              <Text>Distribute</Text>
-            </React.Fragment>
-          </Button>
-        </div>
-      </fieldset>
-    </div>
+          {grid.sortByName && (
+            <InputField label='Order'>
+              <Select
+                value={grid.sortOrientation}
+                onChange={setOrientation}
+                className='select-small'>
+                <SelectOption value='horizontal'>Horizontally</SelectOption>
+                <SelectOption value='vertical'>Vertically</SelectOption>
+              </Select>
+            </InputField>
+          )}
+          <Checkbox
+            label='Group items into Frame'
+            value={Boolean(grid.groupResult)}
+            onChange={toggle('groupResult')}
+          />
+          {grid.groupResult && (
+            <InputField label='Frame Title'>
+              <input
+                className='input input-small'
+                value={frameTitle}
+                onChange={(e) => setFrameTitle(e.target.value)}
+                placeholder='Optional'
+              />
+            </InputField>
+          )}
+          <div className='buttons'>
+            <Button
+              onClick={applyGrid}
+              variant='primary'>
+              <React.Fragment>
+                <Icon name='grid' />
+                <Text>Arrange Grid</Text>
+              </React.Fragment>
+            </Button>
+          </div>
+        </fieldset>
+        <fieldset className='form-group-small'>
+          <InputField label='Axis'>
+            <Select
+              value={spacing.axis}
+              onChange={updateAxis}
+              className='select-small'>
+              <SelectOption value='x'>Horizontal</SelectOption>
+              <SelectOption value='y'>Vertical</SelectOption>
+            </Select>
+          </InputField>
+          <InputField label='Mode'>
+            <Select
+              value={spacing.mode ?? 'move'}
+              onChange={updateMode}
+              className='select-small'>
+              <SelectOption value='move'>Move</SelectOption>
+              <SelectOption value='grow'>Expand</SelectOption>
+            </Select>
+          </InputField>
+          <InputField label='Spacing'>
+            <input
+              className='input input-small'
+              type='number'
+              value={String(spacing.spacing)}
+              onChange={(e) => updateSpacing(e.target.value)}
+              placeholder='Distance'
+            />
+          </InputField>
+          <div className='buttons'>
+            <Button
+              onClick={applySpacing}
+              variant='primary'>
+              <React.Fragment>
+                <Icon name='arrow-right' />
+                <Text>Distribute</Text>
+              </React.Fragment>
+            </Button>
+          </div>
+        </fieldset>
+      </div>
+    </TabPanel>
   );
 };
 

--- a/src/ui/pages/CreateTab.tsx
+++ b/src/ui/pages/CreateTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Select, SelectOption, InputField } from '../components/legacy';
 import { DiagramTab } from './DiagramTab';
 import { CardsTab } from './CardsTab';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /**
@@ -10,18 +11,20 @@ import type { TabTuple } from './tab-definitions';
 export const CreateTab: React.FC = () => {
   const [mode, setMode] = React.useState<'diagram' | 'cards'>('diagram');
   return (
-    <div>
-      <InputField label='Create mode'>
-        <Select
-          value={mode}
-          onChange={(v) => setMode(v as 'diagram' | 'cards')}
-          className='select-small'>
-          <SelectOption value='diagram'>Diagram</SelectOption>
-          <SelectOption value='cards'>Cards</SelectOption>
-        </Select>
-      </InputField>
-      {mode === 'diagram' ? <DiagramTab /> : <CardsTab />}
-    </div>
+    <TabPanel tabId='create'>
+      <div>
+        <InputField label='Create mode'>
+          <Select
+            value={mode}
+            onChange={(v) => setMode(v as 'diagram' | 'cards')}
+            className='select-small'>
+            <SelectOption value='diagram'>Diagram</SelectOption>
+            <SelectOption value='cards'>Cards</SelectOption>
+          </Select>
+        </InputField>
+        {mode === 'diagram' ? <DiagramTab /> : <CardsTab />}
+      </div>
+    </TabPanel>
   );
 };
 

--- a/src/ui/pages/DummyTab.tsx
+++ b/src/ui/pages/DummyTab.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /** Dummy tab for testing auto-registration. */
-export const DummyTab: React.FC = () => {
-  return <div data-testid='dummy'>Dummy</div>;
-};
+export const DummyTab: React.FC = () => (
+  <TabPanel tabId='dummy'>
+    <div data-testid='dummy'>Dummy</div>
+  </TabPanel>
+);
 
 export const tabDef: TabTuple = [
   99,

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -18,6 +18,7 @@ import {
   GraphExcelLoader,
 } from '../../core/utils/excel-loader';
 import { templateManager } from '../../board/templates';
+import { TabPanel } from '../components/TabPanel';
 import { showError } from '../hooks/notifications';
 import { RowInspector } from '../components/RowInspector';
 import type { TabTuple } from './tab-definitions';
@@ -133,151 +134,153 @@ export const ExcelTab: React.FC = () => {
   });
 
   return (
-    <div style={{ marginTop: tokens.space.small }}>
-      <div
-        {...dropzone.getRootProps({ style })}
-        aria-label='Excel drop area'>
-        <InputField label='Excel file'>
+    <TabPanel tabId='excel'>
+      <div style={{ marginTop: tokens.space.small }}>
+        <div
+          {...dropzone.getRootProps({ style })}
+          aria-label='Excel drop area'>
+          <InputField label='Excel file'>
+            <input
+              data-testid='file-input'
+              {...dropzone.getInputProps()}
+            />
+          </InputField>
+        </div>
+        <InputField label='OneDrive/SharePoint file'>
           <input
-            data-testid='file-input'
-            {...dropzone.getInputProps()}
+            value={remote}
+            onChange={(e) => setRemote(e.target.value)}
+            aria-label='graph file'
           />
         </InputField>
-      </div>
-      <InputField label='OneDrive/SharePoint file'>
-        <input
-          value={remote}
-          onChange={(e) => setRemote(e.target.value)}
-          aria-label='graph file'
-        />
-      </InputField>
-      <Button
-        onClick={fetchRemote}
-        variant='secondary'>
-        Fetch File
-      </Button>
-      {loader.listSheets().length > 0 && (
-        <>
-          <InputField label='Data source'>
-            <Select
-              value={source}
-              onChange={setSource}
-              aria-label='Data source'>
-              <SelectOption value=''>Select…</SelectOption>
-              {loader.listSheets().map((s) => (
-                <SelectOption
-                  key={`s-${s}`}
-                  value={`sheet:${s}`}>
-                  Sheet: {s}
-                </SelectOption>
-              ))}
-              {loader.listNamedTables().map((t) => (
-                <SelectOption
-                  key={`t-${t}`}
-                  value={`table:${t}`}>
-                  Table: {t}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputField>
-          <Button
-            onClick={loadRows}
-            variant='secondary'>
-            Load Rows
-          </Button>
-        </>
-      )}
-      {rows.length > 0 && (
-        <>
-          <InputField label='Template'>
-            <Select
-              value={template}
-              onChange={setTemplate}
-              aria-label='Template'>
-              {Object.keys(templateManager.templates).map((tpl) => (
-                <SelectOption
-                  key={tpl}
-                  value={tpl}>
-                  {tpl}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputField>
-          <InputField label='Label column'>
-            <Select
-              value={labelColumn}
-              onChange={setLabelColumn}
-              aria-label='Label column'>
-              <SelectOption value=''>None</SelectOption>
-              {columns.map((c) => (
-                <SelectOption
-                  key={`l-${c}`}
-                  value={c}>
-                  {c}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputField>
-          <InputField label='Template column'>
-            <Select
-              value={templateColumn}
-              onChange={setTemplateColumn}
-              aria-label='Template column'>
-              <SelectOption value=''>None</SelectOption>
-              {columns.map((c) => (
-                <SelectOption
-                  key={`tcol-${c}`}
-                  value={c}>
-                  {c}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputField>
-          <InputField label='ID column'>
-            <Select
-              value={idColumn}
-              onChange={setIdColumn}
-              aria-label='ID column'>
-              <SelectOption value=''>None</SelectOption>
-              {columns.map((c) => (
-                <SelectOption
-                  key={`i-${c}`}
-                  value={c}>
-                  {c}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputField>
-          <ul style={{ maxHeight: 160, overflowY: 'auto' }}>
-            {rows.map((r, i) => (
-              <li key={idColumn ? String(r[idColumn]) : JSON.stringify(r)}>
-                <Checkbox
-                  label={`Row ${i + 1}`}
-                  value={selected.has(i)}
-                  onChange={() => toggle(i)}
-                />
-                <Paragraph>{JSON.stringify(r)}</Paragraph>
-              </li>
-            ))}
-          </ul>
-          <div className='buttons'>
+        <Button
+          onClick={fetchRemote}
+          variant='secondary'>
+          Fetch File
+        </Button>
+        {loader.listSheets().length > 0 && (
+          <>
+            <InputField label='Data source'>
+              <Select
+                value={source}
+                onChange={setSource}
+                aria-label='Data source'>
+                <SelectOption value=''>Select…</SelectOption>
+                {loader.listSheets().map((s) => (
+                  <SelectOption
+                    key={`s-${s}`}
+                    value={`sheet:${s}`}>
+                    Sheet: {s}
+                  </SelectOption>
+                ))}
+                {loader.listNamedTables().map((t) => (
+                  <SelectOption
+                    key={`t-${t}`}
+                    value={`table:${t}`}>
+                    Table: {t}
+                  </SelectOption>
+                ))}
+              </Select>
+            </InputField>
             <Button
-              onClick={handleCreate}
-              variant='primary'>
-              <React.Fragment key='.0'>
-                <Icon name='plus' />
-                <Text>Create Nodes</Text>
-              </React.Fragment>
+              onClick={loadRows}
+              variant='secondary'>
+              Load Rows
             </Button>
-          </div>
-        </>
-      )}
-      <RowInspector
-        rows={rows}
-        idColumn={idColumn || undefined}
-        onUpdate={updateRow}
-      />
-    </div>
+          </>
+        )}
+        {rows.length > 0 && (
+          <>
+            <InputField label='Template'>
+              <Select
+                value={template}
+                onChange={setTemplate}
+                aria-label='Template'>
+                {Object.keys(templateManager.templates).map((tpl) => (
+                  <SelectOption
+                    key={tpl}
+                    value={tpl}>
+                    {tpl}
+                  </SelectOption>
+                ))}
+              </Select>
+            </InputField>
+            <InputField label='Label column'>
+              <Select
+                value={labelColumn}
+                onChange={setLabelColumn}
+                aria-label='Label column'>
+                <SelectOption value=''>None</SelectOption>
+                {columns.map((c) => (
+                  <SelectOption
+                    key={`l-${c}`}
+                    value={c}>
+                    {c}
+                  </SelectOption>
+                ))}
+              </Select>
+            </InputField>
+            <InputField label='Template column'>
+              <Select
+                value={templateColumn}
+                onChange={setTemplateColumn}
+                aria-label='Template column'>
+                <SelectOption value=''>None</SelectOption>
+                {columns.map((c) => (
+                  <SelectOption
+                    key={`tcol-${c}`}
+                    value={c}>
+                    {c}
+                  </SelectOption>
+                ))}
+              </Select>
+            </InputField>
+            <InputField label='ID column'>
+              <Select
+                value={idColumn}
+                onChange={setIdColumn}
+                aria-label='ID column'>
+                <SelectOption value=''>None</SelectOption>
+                {columns.map((c) => (
+                  <SelectOption
+                    key={`i-${c}`}
+                    value={c}>
+                    {c}
+                  </SelectOption>
+                ))}
+              </Select>
+            </InputField>
+            <ul style={{ maxHeight: 160, overflowY: 'auto' }}>
+              {rows.map((r, i) => (
+                <li key={idColumn ? String(r[idColumn]) : JSON.stringify(r)}>
+                  <Checkbox
+                    label={`Row ${i + 1}`}
+                    value={selected.has(i)}
+                    onChange={() => toggle(i)}
+                  />
+                  <Paragraph>{JSON.stringify(r)}</Paragraph>
+                </li>
+              ))}
+            </ul>
+            <div className='buttons'>
+              <Button
+                onClick={handleCreate}
+                variant='primary'>
+                <React.Fragment key='.0'>
+                  <Icon name='plus' />
+                  <Text>Create Nodes</Text>
+                </React.Fragment>
+              </Button>
+            </div>
+          </>
+        )}
+        <RowInspector
+          rows={rows}
+          idColumn={idColumn || undefined}
+          onUpdate={updateRow}
+        />
+      </div>
+    </TabPanel>
   );
 };
 

--- a/src/ui/pages/FramesTab.tsx
+++ b/src/ui/pages/FramesTab.tsx
@@ -4,6 +4,7 @@ import {
   lockSelectedFrames,
   renameSelectedFrames,
 } from '../../board/frame-tools';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /** UI for renaming or locking selected frames. */
@@ -17,42 +18,44 @@ export const FramesTab: React.FC = () => {
     await lockSelectedFrames();
   };
   return (
-    <div>
-      <fieldset>
-        <legend>Rename Frames</legend>
-        <InputField label='Prefix'>
-          <input
-            className='input input-small'
-            value={prefix}
-            onChange={(e) => setPrefix(e.target.value)}
-            placeholder='Prefix'
-          />
-        </InputField>
-        <div className='buttons'>
-          <Button
-            onClick={rename}
-            variant='primary'>
-            <React.Fragment key='.0'>
-              <Icon name='edit' />
-              <Text>Rename Frames</Text>
-            </React.Fragment>
-          </Button>
-        </div>
-      </fieldset>
-      <fieldset>
-        <legend>Lock Frames</legend>
-        <div className='buttons'>
-          <Button
-            onClick={lock}
-            variant='secondary'>
-            <React.Fragment key='.1'>
-              <Icon name='lock' />
-              <Text>Lock Selected</Text>
-            </React.Fragment>
-          </Button>
-        </div>
-      </fieldset>
-    </div>
+    <TabPanel tabId='frames'>
+      <div>
+        <fieldset>
+          <legend>Rename Frames</legend>
+          <InputField label='Prefix'>
+            <input
+              className='input input-small'
+              value={prefix}
+              onChange={(e) => setPrefix(e.target.value)}
+              placeholder='Prefix'
+            />
+          </InputField>
+          <div className='buttons'>
+            <Button
+              onClick={rename}
+              variant='primary'>
+              <React.Fragment key='.0'>
+                <Icon name='edit' />
+                <Text>Rename Frames</Text>
+              </React.Fragment>
+            </Button>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Lock Frames</legend>
+          <div className='buttons'>
+            <Button
+              onClick={lock}
+              variant='secondary'>
+              <React.Fragment key='.1'>
+                <Icon name='lock' />
+                <Text>Lock Selected</Text>
+              </React.Fragment>
+            </Button>
+          </div>
+        </fieldset>
+      </div>
+    </TabPanel>
   );
 };
 

--- a/src/ui/pages/HelpTab.tsx
+++ b/src/ui/pages/HelpTab.tsx
@@ -1,50 +1,53 @@
 import React from 'react';
 import { Heading, Paragraph } from '../components/legacy';
 import changelog from '../../../CHANGELOG.md?raw';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /** Static help page summarising diagram options and tools. */
 export const HelpTab: React.FC = () => (
-  <div data-testid='help-tab'>
-    <Heading level={3}>Getting Started</Heading>
-    <Paragraph>
-      Use the Create tab to import diagrams or cards from a JSON file. Nodes may
-      define templates, labels and ELK options to influence placement.
-    </Paragraph>
-    <Heading level={3}>Diagram Layout Options</Heading>
-    <ul className='list'>
-      <li>
-        <strong>Layered</strong> – Flow diagrams with layers
-      </li>
-      <li>
-        <strong>Tree</strong> – Compact hierarchical tree
-      </li>
-      <li>
-        <strong>Grid</strong> – Organic force-directed grid
-      </li>
-      <li>
-        <strong>Nested</strong> – Containers sized to fit children
-      </li>
-      <li>
-        <strong>Radial</strong> – Circular layout around a hub
-      </li>
-      <li>
-        <strong>Box</strong> – Uniform box grid
-      </li>
-      <li>
-        <strong>Rect Packing</strong> – Fits rectangles within parents
-      </li>
-    </ul>
-    <Heading level={3}>Other Tools</Heading>
-    <ul className='list'>
-      <li>Resize – adjust widget size or copy from selection.</li>
-      <li>Frames – rename selected frames.</li>
-      <li>Colours – modify fill colours.</li>
-      <li>Arrange – grid and spacing tools.</li>
-    </ul>
-    <Heading level={3}>Changelog</Heading>
-    <pre style={{ whiteSpace: 'pre-wrap' }}>{changelog}</pre>
-  </div>
+  <TabPanel tabId='help'>
+    <div data-testid='help-tab'>
+      <Heading level={3}>Getting Started</Heading>
+      <Paragraph>
+        Use the Create tab to import diagrams or cards from a JSON file. Nodes
+        may define templates, labels and ELK options to influence placement.
+      </Paragraph>
+      <Heading level={3}>Diagram Layout Options</Heading>
+      <ul className='list'>
+        <li>
+          <strong>Layered</strong> – Flow diagrams with layers
+        </li>
+        <li>
+          <strong>Tree</strong> – Compact hierarchical tree
+        </li>
+        <li>
+          <strong>Grid</strong> – Organic force-directed grid
+        </li>
+        <li>
+          <strong>Nested</strong> – Containers sized to fit children
+        </li>
+        <li>
+          <strong>Radial</strong> – Circular layout around a hub
+        </li>
+        <li>
+          <strong>Box</strong> – Uniform box grid
+        </li>
+        <li>
+          <strong>Rect Packing</strong> – Fits rectangles within parents
+        </li>
+      </ul>
+      <Heading level={3}>Other Tools</Heading>
+      <ul className='list'>
+        <li>Resize – adjust widget size or copy from selection.</li>
+        <li>Frames – rename selected frames.</li>
+        <li>Colours – modify fill colours.</li>
+        <li>Arrange – grid and spacing tools.</li>
+      </ul>
+      <Heading level={3}>Changelog</Heading>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{changelog}</pre>
+    </div>
+  </TabPanel>
 );
 
 export const tabDef: TabTuple = [

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -27,6 +27,7 @@ import {
   ratioHeight,
   AspectRatioId,
 } from '../../core/utils/aspect-ratio';
+import { TabPanel } from '../components/TabPanel';
 
 /** Predefined button sizes used by the quick presets. */
 const PRESET_SIZES: Record<'S' | 'M' | 'L', Size> = {
@@ -120,100 +121,102 @@ export const ResizeTab: React.FC = () => {
   }, [copy, apply]);
 
   return (
-    <div className='custom-centered'>
-      <fieldset>
-        <legend>Manual Resize</legend>
-        <Paragraph data-testid='size-display'>
-          {copiedSize
-            ? `Copied: ${copiedSize.width}×${copiedSize.height}`
-            : `Selection: ${size.width}×${size.height}`}
-        </Paragraph>
-        {warning && <Paragraph className='error'>{warning}</Paragraph>}
-        <FormGroup>
-          <InputField label='Width:'>
-            <input
-              className='input input-small'
-              type='number'
-              value={String(size.width)}
-              onChange={(e) => update('width')(e.target.value)}
-              placeholder='Width (board units)'
-            />
+    <TabPanel tabId='resize'>
+      <div className='custom-centered'>
+        <fieldset>
+          <legend>Manual Resize</legend>
+          <Paragraph data-testid='size-display'>
+            {copiedSize
+              ? `Copied: ${copiedSize.width}×${copiedSize.height}`
+              : `Selection: ${size.width}×${size.height}`}
+          </Paragraph>
+          {warning && <Paragraph className='error'>{warning}</Paragraph>}
+          <FormGroup>
+            <InputField label='Width:'>
+              <input
+                className='input input-small'
+                type='number'
+                value={String(size.width)}
+                onChange={(e) => update('width')(e.target.value)}
+                placeholder='Width (board units)'
+              />
+            </InputField>
+            <InputField label='Height:'>
+              <input
+                className='input input-small'
+                type='number'
+                value={String(size.height)}
+                onChange={(e) => update('height')(e.target.value)}
+                placeholder='Height (board units)'
+              />
+            </InputField>
+          </FormGroup>
+          <InputField label='Aspect Ratio'>
+            <Select
+              data-testid='ratio-select'
+              className='select-small'
+              value={ratio}
+              onChange={(v) => setRatio(v as AspectRatioId | 'none')}>
+              <SelectOption value='none'>Free</SelectOption>
+              {ASPECT_RATIOS.map((r) => (
+                <SelectOption
+                  key={r.id}
+                  value={r.id}>
+                  {r.label}
+                </SelectOption>
+              ))}
+            </Select>
           </InputField>
-          <InputField label='Height:'>
-            <input
-              className='input input-small'
-              type='number'
-              value={String(size.height)}
-              onChange={(e) => update('height')(e.target.value)}
-              placeholder='Height (board units)'
-            />
-          </InputField>
-        </FormGroup>
-        <InputField label='Aspect Ratio'>
-          <Select
-            data-testid='ratio-select'
-            className='select-small'
-            value={ratio}
-            onChange={(v) => setRatio(v as AspectRatioId | 'none')}>
-            <SelectOption value='none'>Free</SelectOption>
-            {ASPECT_RATIOS.map((r) => (
-              <SelectOption
-                key={r.id}
-                value={r.id}>
-                {r.label}
-              </SelectOption>
+        </fieldset>
+        <fieldset>
+          <legend>Presets</legend>
+          <div>
+            {(['S', 'M', 'L'] as const).map((p) => (
+              <Button
+                key={p}
+                onClick={() => setSize(PRESET_SIZES[p])}
+                variant='secondary'>
+                {p}
+              </Button>
             ))}
-          </Select>
-        </InputField>
-      </fieldset>
-      <fieldset>
-        <legend>Presets</legend>
-        <div>
-          {(['S', 'M', 'L'] as const).map((p) => (
-            <Button
-              key={p}
-              onClick={() => setSize(PRESET_SIZES[p])}
-              variant='secondary'>
-              {p}
-            </Button>
-          ))}
-        </div>
+          </div>
+          <div className='buttons'>
+            {SCALE_OPTIONS.map((s) => (
+              <Button
+                key={s.label}
+                onClick={() => scale(s.factor)}
+                variant='secondary'>
+                {s.label}
+              </Button>
+            ))}
+          </div>
+          <Paragraph>
+            {boardUnitsToMm(size.width).toFixed(1)} mm ×{' '}
+            {boardUnitsToMm(size.height).toFixed(1)} mm (
+            {boardUnitsToInches(size.width).toFixed(2)} ×{' '}
+            {boardUnitsToInches(size.height).toFixed(2)} in)
+          </Paragraph>
+        </fieldset>
         <div className='buttons'>
-          {SCALE_OPTIONS.map((s) => (
-            <Button
-              key={s.label}
-              onClick={() => scale(s.factor)}
-              variant='secondary'>
-              {s.label}
-            </Button>
-          ))}
+          <Button
+            onClick={copiedSize ? resetCopy : copy}
+            variant='secondary'>
+            <React.Fragment key='.0'>
+              <Icon name={copiedSize ? 'undo' : 'duplicate'} />
+              <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
+            </React.Fragment>
+          </Button>
+          <Button
+            onClick={apply}
+            variant='primary'>
+            <React.Fragment key='.0'>
+              <Icon name='arrow-right' />
+              <Text>Apply Size</Text>
+            </React.Fragment>
+          </Button>
         </div>
-        <Paragraph>
-          {boardUnitsToMm(size.width).toFixed(1)} mm ×{' '}
-          {boardUnitsToMm(size.height).toFixed(1)} mm (
-          {boardUnitsToInches(size.width).toFixed(2)} ×{' '}
-          {boardUnitsToInches(size.height).toFixed(2)} in)
-        </Paragraph>
-      </fieldset>
-      <div className='buttons'>
-        <Button
-          onClick={copiedSize ? resetCopy : copy}
-          variant='secondary'>
-          <React.Fragment key='.0'>
-            <Icon name={copiedSize ? 'undo' : 'duplicate'} />
-            <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
-          </React.Fragment>
-        </Button>
-        <Button
-          onClick={apply}
-          variant='primary'>
-          <React.Fragment key='.0'>
-            <Icon name='arrow-right' />
-            <Text>Apply Size</Text>
-          </React.Fragment>
-        </Button>
       </div>
-    </div>
+    </TabPanel>
   );
 };
 export const tabDef: TabTuple = [

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -14,6 +14,7 @@ import {
   useNextMatch,
   useReplaceCurrent,
 } from '../hooks/use-search-handlers';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /**
@@ -114,123 +115,127 @@ export const SearchTab: React.FC = () => {
   );
 
   return (
-    <div>
-      <InputField label='Find'>
-        <input
-          className='input input-small'
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder='Search board text'
-        />
-      </InputField>
-      <InputField label='Replace'>
-        <input
-          className='input input-small'
-          value={replacement}
-          onChange={(e) => setReplacement(e.target.value)}
-          placeholder='Replacement text'
-        />
-      </InputField>
-      <div className='form-group-small'>
-        <Checkbox
-          label='Case sensitive'
-          value={caseSensitive}
-          onChange={setCaseSensitive}
-        />
-        <Checkbox
-          label='Whole word'
-          value={wholeWord}
-          onChange={setWholeWord}
-        />
-        <Checkbox
-          label='Regex'
-          value={regex}
-          onChange={setRegex}
-        />
-      </div>
-      <fieldset className='form-group-small'>
-        <legend className='custom-visually-hidden'>Widget Types</legend>
-        <div>
-          {['shape', 'card', 'sticky_note', 'text'].map((t) => (
-            <Checkbox
-              key={t}
-              label={t}
-              value={widgetTypes.includes(t)}
-              onChange={() => toggleType(t)}
-            />
-          ))}
+    <TabPanel tabId='search'>
+      <div>
+        <InputField label='Find'>
+          <input
+            className='input input-small'
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder='Search board text'
+          />
+        </InputField>
+        <InputField label='Replace'>
+          <input
+            className='input input-small'
+            value={replacement}
+            onChange={(e) => setReplacement(e.target.value)}
+            placeholder='Replacement text'
+          />
+        </InputField>
+        <div className='form-group-small'>
+          <Checkbox
+            label='Case sensitive'
+            value={caseSensitive}
+            onChange={setCaseSensitive}
+          />
+          <Checkbox
+            label='Whole word'
+            value={wholeWord}
+            onChange={setWholeWord}
+          />
+          <Checkbox
+            label='Regex'
+            value={regex}
+            onChange={setRegex}
+          />
         </div>
-      </fieldset>
-      <InputField label='Tag IDs'>
-        <input
-          className='input input-small'
-          value={tagIds}
-          onChange={(e) => setTagIds(e.target.value)}
-          placeholder='Comma separated'
-        />
-      </InputField>
-      <InputField label='Background colour'>
-        <input
-          className='input input-small'
-          value={backgroundColor}
-          onChange={(e) => setBackgroundColor(e.target.value)}
-          placeholder='CSS colour'
-        />
-      </InputField>
-      <InputField label='Assignee ID'>
-        <input
-          className='input input-small'
-          value={assignee}
-          onChange={(e) => setAssignee(e.target.value)}
-          placeholder='User ID'
-        />
-      </InputField>
-      <InputField label='Creator ID'>
-        <input
-          className='input input-small'
-          value={creator}
-          onChange={(e) => setCreator(e.target.value)}
-          placeholder='User ID'
-        />
-      </InputField>
-      <InputField label='Last modified by'>
-        <input
-          className='input input-small'
-          value={lastModifiedBy}
-          onChange={(e) => setLastModifiedBy(e.target.value)}
-          placeholder='User ID'
-        />
-      </InputField>
-      <Paragraph data-testid='match-count'>Matches: {results.length}</Paragraph>
-      <div className='buttons'>
-        <Button
-          onClick={nextMatch}
-          disabled={!results.length}
-          variant='secondary'>
-          <React.Fragment key='.0'>
-            <Icon name='chevron-right' />
-            <Text>Next</Text>
-          </React.Fragment>
-        </Button>
-        <Button
-          onClick={replaceCurrent}
-          disabled={!results.length}
-          variant='secondary'>
-          <React.Fragment key='.1'>
-            <Icon name='edit' />
-            <Text>Replace</Text>
-          </React.Fragment>
-        </Button>
-        <Button
-          onClick={replaceAll}
-          variant='primary'>
-          <React.Fragment key='.2'>
-            <Icon name='arrow-right' />
-            <Text>Replace All</Text>
-          </React.Fragment>
-        </Button>
+        <fieldset className='form-group-small'>
+          <legend className='custom-visually-hidden'>Widget Types</legend>
+          <div>
+            {['shape', 'card', 'sticky_note', 'text'].map((t) => (
+              <Checkbox
+                key={t}
+                label={t}
+                value={widgetTypes.includes(t)}
+                onChange={() => toggleType(t)}
+              />
+            ))}
+          </div>
+        </fieldset>
+        <InputField label='Tag IDs'>
+          <input
+            className='input input-small'
+            value={tagIds}
+            onChange={(e) => setTagIds(e.target.value)}
+            placeholder='Comma separated'
+          />
+        </InputField>
+        <InputField label='Background colour'>
+          <input
+            className='input input-small'
+            value={backgroundColor}
+            onChange={(e) => setBackgroundColor(e.target.value)}
+            placeholder='CSS colour'
+          />
+        </InputField>
+        <InputField label='Assignee ID'>
+          <input
+            className='input input-small'
+            value={assignee}
+            onChange={(e) => setAssignee(e.target.value)}
+            placeholder='User ID'
+          />
+        </InputField>
+        <InputField label='Creator ID'>
+          <input
+            className='input input-small'
+            value={creator}
+            onChange={(e) => setCreator(e.target.value)}
+            placeholder='User ID'
+          />
+        </InputField>
+        <InputField label='Last modified by'>
+          <input
+            className='input input-small'
+            value={lastModifiedBy}
+            onChange={(e) => setLastModifiedBy(e.target.value)}
+            placeholder='User ID'
+          />
+        </InputField>
+        <Paragraph data-testid='match-count'>
+          Matches: {results.length}
+        </Paragraph>
+        <div className='buttons'>
+          <Button
+            onClick={nextMatch}
+            disabled={!results.length}
+            variant='secondary'>
+            <React.Fragment key='.0'>
+              <Icon name='chevron-right' />
+              <Text>Next</Text>
+            </React.Fragment>
+          </Button>
+          <Button
+            onClick={replaceCurrent}
+            disabled={!results.length}
+            variant='secondary'>
+            <React.Fragment key='.1'>
+              <Icon name='edit' />
+              <Text>Replace</Text>
+            </React.Fragment>
+          </Button>
+          <Button
+            onClick={replaceAll}
+            variant='primary'>
+            <React.Fragment key='.2'>
+              <Icon name='arrow-right' />
+              <Text>Replace All</Text>
+            </React.Fragment>
+          </Button>
+        </div>
       </div>
-    </div>
+    </TabPanel>
   );
 };
 

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -6,6 +6,7 @@ import { STYLE_PRESET_NAMES, stylePresets } from '../style-presets';
 import { adjustColor } from '../../core/utils/color-utils';
 import { useSelection } from '../hooks/use-selection';
 import { tokens } from '../tokens';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 /** Adjusts the fill colour of selected widgets. */
@@ -26,95 +27,97 @@ export const StyleTab: React.FC = () => {
     await tweakFillColor(adjust / 100);
   };
   return (
-    <div className='grid form-example'>
-      <form className='cs1 ce12 form-example-main-content'>
-        <InputField label='Adjust fill'>
-          <input
-            data-testid='adjust-slider'
-            type='range'
-            min='-100'
-            max='100'
-            list='adjust-marks'
-            value={adjust}
-            onChange={(e) => setAdjust(Number(e.target.value))}
-          />
-          <datalist id='adjust-marks'>
-            {[-100, -50, 0, 50, 100].map((n) => (
-              <option
-                key={n}
-                value={n}
-              />
-            ))}
-          </datalist>
-          <span
-            data-testid='adjust-preview'
-            style={{
-              display: 'inline-block',
-              width: '24px',
-              height: '24px',
-              marginLeft: tokens.space.small,
-              border: `1px solid ${tokens.color.gray[200]}`,
-              backgroundColor: preview,
-            }}
-          />
-          <code
-            data-testid='color-hex'
-            style={{ marginLeft: tokens.space.xxsmall }}>
-            {preview}
-          </code>
-        </InputField>
-        <InputField label='Adjust value'>
-          <input
-            className='input input-small'
-            data-testid='adjust-input'
-            type='number'
-            min='-100'
-            max='100'
-            value={String(adjust)}
-            onChange={(e) => setAdjust(Number(e.target.value))}
-            placeholder='Adjust (-100–100)'
-          />
-        </InputField>
-        <div className='buttons'>
-          <Button
-            onClick={apply}
-            type='button'
-            variant='primary'
-            className='button-small'>
-            <React.Fragment>
-              <Icon name='parameters' />
-              <Text>Apply</Text>
-            </React.Fragment>
-          </Button>
-        </div>
-        <fieldset className='form-group-small'>
-          <legend className='p-medium'>Style presets</legend>
+    <TabPanel tabId='style'>
+      <div className='grid form-example'>
+        <form className='cs1 ce12 form-example-main-content'>
+          <InputField label='Adjust fill'>
+            <input
+              data-testid='adjust-slider'
+              type='range'
+              min='-100'
+              max='100'
+              list='adjust-marks'
+              value={adjust}
+              onChange={(e) => setAdjust(Number(e.target.value))}
+            />
+            <datalist id='adjust-marks'>
+              {[-100, -50, 0, 50, 100].map((n) => (
+                <option
+                  key={n}
+                  value={n}
+                />
+              ))}
+            </datalist>
+            <span
+              data-testid='adjust-preview'
+              style={{
+                display: 'inline-block',
+                width: '24px',
+                height: '24px',
+                marginLeft: tokens.space.small,
+                border: `1px solid ${tokens.color.gray[200]}`,
+                backgroundColor: preview,
+              }}
+            />
+            <code
+              data-testid='color-hex'
+              style={{ marginLeft: tokens.space.xxsmall }}>
+              {preview}
+            </code>
+          </InputField>
+          <InputField label='Adjust value'>
+            <input
+              className='input input-small'
+              data-testid='adjust-input'
+              type='number'
+              min='-100'
+              max='100'
+              value={String(adjust)}
+              onChange={(e) => setAdjust(Number(e.target.value))}
+              placeholder='Adjust (-100–100)'
+            />
+          </InputField>
           <div className='buttons'>
-            {STYLE_PRESET_NAMES.map((name) => {
-              const preset = stylePresets[name];
-              const style = presetStyle(preset);
-              return (
-                <Button
-                  key={name}
-                  onClick={() => applyStylePreset(preset)}
-                  type='button'
-                  variant='secondary'
-                  className='button-small'
-                  style={{
-                    color: style.color,
-                    backgroundColor: style.fillColor,
-                    borderColor: style.borderColor,
-                    borderWidth: style.borderWidth,
-                    borderStyle: 'solid',
-                  }}>
-                  {preset.label}
-                </Button>
-              );
-            })}
+            <Button
+              onClick={apply}
+              type='button'
+              variant='primary'
+              className='button-small'>
+              <React.Fragment>
+                <Icon name='parameters' />
+                <Text>Apply</Text>
+              </React.Fragment>
+            </Button>
           </div>
-        </fieldset>
-      </form>
-    </div>
+          <fieldset className='form-group-small'>
+            <legend className='p-medium'>Style presets</legend>
+            <div className='buttons'>
+              {STYLE_PRESET_NAMES.map((name) => {
+                const preset = stylePresets[name];
+                const style = presetStyle(preset);
+                return (
+                  <Button
+                    key={name}
+                    onClick={() => applyStylePreset(preset)}
+                    type='button'
+                    variant='secondary'
+                    className='button-small'
+                    style={{
+                      color: style.color,
+                      backgroundColor: style.fillColor,
+                      borderColor: style.borderColor,
+                      borderWidth: style.borderWidth,
+                      borderStyle: 'solid',
+                    }}>
+                    {preset.label}
+                  </Button>
+                );
+              })}
+            </div>
+          </fieldset>
+        </form>
+      </div>
+    </TabPanel>
   );
 };
 

--- a/src/ui/pages/ToolsTab.tsx
+++ b/src/ui/pages/ToolsTab.tsx
@@ -4,6 +4,7 @@ import { ResizeTab } from './ResizeTab';
 import { StyleTab } from './StyleTab';
 import { ArrangeTab } from './ArrangeTab';
 import { FramesTab } from './FramesTab';
+import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 
 const SUB_TABS: SubTab[] = [
@@ -33,14 +34,16 @@ export const ToolsTab: React.FC = () => {
       Current = ResizeTab;
   }
   return (
-    <div>
-      <SubTabBar
-        tabs={SUB_TABS}
-        tab={sub}
-        onChange={setSub}
-      />
-      <Current />
-    </div>
+    <TabPanel tabId='tools'>
+      <div>
+        <SubTabBar
+          tabs={SUB_TABS}
+          tab={sub}
+          onChange={setSub}
+        />
+        <Current />
+      </div>
+    </TabPanel>
   );
 };
 

--- a/tests/diagram-tab-branches.test.tsx
+++ b/tests/diagram-tab-branches.test.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { DiagramTab } from '../src/ui/pages/DiagramTab';
-import { DEFAULT_LAYOUT_OPTIONS } from '../src/core/layout/elk-options';
+import {
+  DEFAULT_LAYOUT_OPTIONS,
+  ElkAlgorithm,
+} from '../src/core/layout/elk-options';
 import type { GraphProcessor } from '../src/core/graph/graph-processor';
 vi.mock('../src/core/graph/graph-processor');
 
@@ -35,7 +38,6 @@ describe('DiagramTab additional branches', () => {
   });
 
   test('all conditional elements render with preset state', () => {
-    const orig = React.useState;
     vi.spyOn(React, 'useState')
       .mockImplementationOnce(() => [[new File([], 'a.json')], vi.fn()])
       .mockImplementationOnce(() => ['Layered', vi.fn()])
@@ -74,7 +76,7 @@ describe('DiagramTab additional branches', () => {
       .mockImplementationOnce(() => [false, vi.fn()])
       .mockImplementationOnce(() => ['', vi.fn()])
       .mockImplementationOnce(() => [
-        { ...DEFAULT_LAYOUT_OPTIONS, algorithm: alg as any },
+        { ...DEFAULT_LAYOUT_OPTIONS, algorithm: alg as ElkAlgorithm },
         vi.fn(),
       ])
       .mockImplementationOnce(() => [0, vi.fn()])

--- a/tests/subtabbar-accessibility.test.tsx
+++ b/tests/subtabbar-accessibility.test.tsx
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SubTabBar, SubTab } from '../src/ui/components/SubTabBar';
+
+describe('SubTabBar accessibility', () => {
+  const tabs: SubTab[] = [
+    { id: 'one', label: 'One' },
+    { id: 'two', label: 'Two' },
+  ];
+
+  test('arrow key navigation and roles', () => {
+    const handler = vi.fn();
+    render(
+      <SubTabBar
+        tabs={tabs}
+        tab='one'
+        onChange={handler}
+      />,
+    );
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    const [first, second] = screen.getAllByRole('tab');
+    fireEvent.keyDown(first, { key: 'ArrowRight' });
+    expect(second).toHaveFocus();
+    fireEvent.keyDown(second, { key: 'Enter' });
+    expect(handler).toHaveBeenCalledWith('two');
+  });
+});

--- a/tests/tabbar-accessibility.test.tsx
+++ b/tests/tabbar-accessibility.test.tsx
@@ -20,10 +20,29 @@ describe('TabBar accessibility', () => {
         onChange={handler}
       />,
     );
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
     const second = screen.getByRole('tab', { name: 'Second' });
     second.focus();
     expect(second).toHaveFocus();
     fireEvent.keyDown(second, { key: 'Enter' });
     expect(handler).toHaveBeenCalledWith('second');
+  });
+
+  test('arrow keys move focus without activation', () => {
+    const handler = vi.fn();
+    render(
+      <TabBar
+        tabs={tabs}
+        tab='first'
+        onChange={handler}
+      />,
+    );
+    const [first, second] = screen.getAllByRole('tab');
+    first.focus();
+    fireEvent.keyDown(first, { key: 'ArrowRight' });
+    expect(second).toHaveFocus();
+    expect(handler).not.toHaveBeenCalled();
+    fireEvent.keyDown(second, { key: 'Home' });
+    expect(first).toHaveFocus();
   });
 });


### PR DESCRIPTION
## Summary
- implement TabPanel wrapper for pages
- add keyboard support for TabBar and SubTabBar
- mark page content as tabpanels
- test arrow key navigation for TabBar and SubTabBar
- fix lint warnings

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863bbf2490c832bbb72a96bbe5412d3