### PR TITLE
Fix modal dialog role

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -15,6 +15,9 @@ export interface ModalProps {
 
 /**
  * Accessible modal dialog with focus trap and Escape key handling.
+ *
+ * Uses the native `<dialog>` element which has an implicit
+ * `dialog` role, so no explicit ARIA role is set.
  */
 export function Modal({
   title,
@@ -106,7 +109,6 @@ export function Modal({
         open
         aria-label={title}
         aria-modal='true'
-        role='dialog'
         className={`modal modal-${size}`}
         ref={ref}>
         <header className='modal-header'>

--- a/tests/modal.test.tsx
+++ b/tests/modal.test.tsx
@@ -14,7 +14,9 @@ describe('Modal', () => {
         <button>Ok</button>
       </Modal>,
     );
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).not.toHaveAttribute('role');
     expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
   });
 


### PR DESCRIPTION
## Summary
- remove redundant role attribute from `<dialog>`
- document implicit role in Modal component
- verify absence of role attribute in Modal tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863c9f37a94832bba7b43bb07b22306