### PR TITLE
feat(ui): expose tab panels with ARIA role

### DIFF
--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -67,7 +67,11 @@ export const CardsTab: React.FC = () => {
   };
 
   return (
-    <div style={{ marginTop: tokens.space.small }}>
+    <div
+      id='panel-cards'
+      role='tabpanel'
+      aria-labelledby='tab-cards'
+      style={{ marginTop: tokens.space.small }}>
       <JsonDropZone onFiles={handleFiles} />
 
       {files.length > 0 && (

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -124,7 +124,11 @@ export const DiagramTab: React.FC = () => {
   );
 
   return (
-    <div style={{ marginTop: tokens.space.small }}>
+    <div
+      id='panel-diagram'
+      role='tabpanel'
+      aria-labelledby='tab-diagram'
+      style={{ marginTop: tokens.space.small }}>
       <JsonDropZone onFiles={handleFiles} />
 
       {importQueue.length > 0 && (

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -52,6 +52,20 @@ describe('tab components', () => {
     delete (globalThis as any).miro;
     jest.clearAllMocks();
   });
+
+  const COMPONENTS: Array<[string, React.FC]> = [
+    ['ResizeTab', ResizeTab],
+    ['StyleTab', StyleTab],
+    ['ArrangeTab', ArrangeTab],
+    ['DiagramTab', DiagramTab],
+    ['CardsTab', CardsTab],
+    ['FramesTab', FramesTab],
+  ];
+
+  test.each(COMPONENTS)('%s exposes tabpanel role', (_, Comp) => {
+    render(React.createElement(Comp));
+    expect(screen.getAllByRole('tabpanel').length).toBeGreaterThan(0);
+  });
   test('ResizeTab applies size', async () => {
     const spy = jest
       .spyOn(resizeTools, 'applySizeToSelection')


### PR DESCRIPTION
## Summary
- add ARIA tabpanel wrapper to CardsTab
- add ARIA tabpanel wrapper to DiagramTab
- verify tabs expose a tabpanel role

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863ce65e554832b966662f02ec69809