### PR TITLE
Add more heading level tests

### DIFF
--- a/tests/heading.test.tsx
+++ b/tests/heading.test.tsx
@@ -15,4 +15,16 @@ describe('Heading', () => {
     const el = screen.getByRole('heading', { level: 3 });
     expect(el.tagName).toBe('H3');
   });
+
+  test('renders h2 heading', () => {
+    render(<Heading level={2}>Section</Heading>);
+    const el = screen.getByRole('heading', { level: 2 });
+    expect(el.tagName).toBe('H2');
+  });
+
+  test('renders h4 heading', () => {
+    render(<Heading level={4}>Footer</Heading>);
+    const el = screen.getByRole('heading', { level: 4 });
+    expect(el.tagName).toBe('H4');
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for additional heading levels

## Testing
- `npm test --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863d35e1be0832bb7e87f68304f7479