### PR TITLE
Add DummyTab and tab definition tests

### DIFF
--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start */
 import type React from 'react';
 
 export type TabId =
@@ -34,4 +33,3 @@ export interface CommandDef {
 export const COMMANDS: CommandDef[] = [
   { id: 'edit-metadata', label: 'Edit Metadata', shortcut: 'Ctrl+Alt+M' },
 ];
-/* c8 ignore stop */

--- a/tests/dummy-tab.test.tsx
+++ b/tests/dummy-tab.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DummyTab, tabDef } from '../src/ui/pages/DummyTab';
+
+/**
+ * Renders DummyTab and asserts accessible role and text label.
+ */
+describe('DummyTab', () => {
+  test('renders tab panel with label', () => {
+    render(<DummyTab />);
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveAttribute('id', 'panel-dummy');
+    expect(screen.getByTestId('dummy')).toHaveTextContent('Dummy');
+    expect(tabDef[1]).toBe('dummy');
+    expect(tabDef[2]).toBe('Dummy');
+  });
+});

--- a/tests/tab-definitions.test.ts
+++ b/tests/tab-definitions.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'vitest';
+import { COMMANDS } from '../src/ui/pages/tab-definitions';
+import type { TabId } from '../src/ui/pages/tab-definitions';
+
+/** Valid TabId values for runtime validation. */
+const VALID_IDS: TabId[] = [
+  'create',
+  'tools',
+  'resize',
+  'style',
+  'arrange',
+  'frames',
+  'excel',
+  'search',
+  'help',
+  'dummy',
+];
+
+describe('tab-definitions', () => {
+  test('each exported tab definition is valid', async () => {
+    const { TAB_DATA } = await import('../src/ui/pages/tabs.ts?test');
+
+    TAB_DATA.forEach(([order, id, label, instructions, Comp]) => {
+      expect(typeof order).toBe('number');
+      expect(VALID_IDS.includes(id as TabId)).toBe(true);
+      expect(typeof label).toBe('string');
+      expect(typeof instructions).toBe('string');
+      expect(typeof Comp).toBe('function');
+    });
+
+    // ensure constants in tab-definitions are executed for coverage
+    expect(COMMANDS.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- cover TabTuple definitions and DummyTab component
- include COMMANDS to execute `tab-definitions.ts` in tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863d288bcc0832bb77d53f5ff36fb60