### PR TITLE
Expand JsonDropZone drag event tests

### DIFF
--- a/tests/json-dropzone.test.tsx
+++ b/tests/json-dropzone.test.tsx
@@ -15,3 +15,51 @@ test('invokes callback when file selected', async () => {
   expect(handle).toHaveBeenCalled();
   expect(handle.mock.calls[0][0]).toEqual([file]);
 });
+
+test('drag accept toggles text and triggers drop', async () => {
+  const handle = vi.fn();
+  render(<JsonDropZone onFiles={handle} />);
+  const zone = screen.getByLabelText('File drop area');
+  const file = new File(['{}'], 'data.json', { type: 'application/json' });
+  const data = {
+    files: [file],
+    items: [{ kind: 'file', type: 'application/json', getAsFile: () => file }],
+    types: ['Files'],
+  } as DataTransfer;
+  await act(async () => {
+    fireEvent.dragEnter(zone, { dataTransfer: data });
+    await Promise.resolve();
+  });
+  expect(
+    screen.getByText('Drop your JSON file here'),
+  ).toBeInTheDocument();
+  await act(async () => {
+    fireEvent.drop(zone, { dataTransfer: data });
+    await Promise.resolve();
+  });
+  expect(handle.mock.calls[0][0]).toEqual([file]);
+  expect(
+    screen.getByText('Or drop your JSON file here'),
+  ).toBeInTheDocument();
+});
+
+test('drag reject toggles reject style', async () => {
+  render(<JsonDropZone onFiles={vi.fn()} />);
+  const zone = screen.getByLabelText('File drop area');
+  const file = new File(['hi'], 'text.txt', { type: 'text/plain' });
+  const data = {
+    files: [file],
+    items: [{ kind: 'file', type: 'text/plain', getAsFile: () => file }],
+    types: ['Files'],
+  } as DataTransfer;
+  await act(async () => {
+    fireEvent.dragEnter(zone, { dataTransfer: data });
+    await Promise.resolve();
+  });
+  expect(zone.style.borderColor).toBe('var(--red700)');
+  await act(async () => {
+    fireEvent.dragLeave(zone, { dataTransfer: data });
+    await Promise.resolve();
+  });
+  expect(zone.style.borderColor).toBe('var(--indigoAlpha40)');
+});


### PR DESCRIPTION
## Summary
- exercise drag-and-drop states in JsonDropZone tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863b5f581b4832bb6e425693e143caf