### PR TITLE
Fix test formatting

### DIFF
--- a/tests/json-dropzone.test.tsx
+++ b/tests/json-dropzone.test.tsx
@@ -30,17 +30,13 @@ test('drag accept toggles text and triggers drop', async () => {
     fireEvent.dragEnter(zone, { dataTransfer: data });
     await Promise.resolve();
   });
-  expect(
-    screen.getByText('Drop your JSON file here'),
-  ).toBeInTheDocument();
+  expect(screen.getByText('Drop your JSON file here')).toBeInTheDocument();
   await act(async () => {
     fireEvent.drop(zone, { dataTransfer: data });
     await Promise.resolve();
   });
   expect(handle.mock.calls[0][0]).toEqual([file]);
-  expect(
-    screen.getByText('Or drop your JSON file here'),
-  ).toBeInTheDocument();
+  expect(screen.getByText('Or drop your JSON file here')).toBeInTheDocument();
 });
 
 test('drag reject toggles reject style', async () => {


### PR DESCRIPTION
## Summary
- fix formatting on the `JsonDropZone` test

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863e0d7500c832bacfd20be311c23e4