### PR TITLE
Switch TabGrid to mirotone columns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Audit dependencies
@@ -44,7 +43,6 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Audit dependencies
@@ -66,7 +64,6 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Audit dependencies
@@ -93,7 +90,6 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Audit dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,3 +174,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extract pure spacing functions into `spacing-layout.ts` and refactor board
   tools.
 - Add `calculateGridPositions` helper around grid-layout internals.
+- Replace sidebar form fieldsets with `TabGrid` layout and enforce button sizes.
+- Migrate remaining tabs to grid layout with semantic headings and no forms.
+- Switch TabGrid to apply Mirotone column classes instead of inline styles.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -47,6 +47,7 @@ components or compose manually with Mirotone CSS.
 | **Grid**       | gap, columns               | responsive                | n/a                 |
 | **Stack**      | gap, direction             | vertical, horizontal      | n/a                 |
 | **Cluster**    | gap, align                 | left, right, centre       | n/a                 |
+| **TabGrid**    | columns, className?        | —                         | n/a                 |
 
 The **TabBar** component now covers both sidebar and nested navigation. Pass the
 current tab id via `tab` and handle selection with `onChange`. Use

--- a/src/ui/components/TabGrid.tsx
+++ b/src/ui/components/TabGrid.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface TabGridProps {
+  /** Number of equal-width columns in the grid. Defaults to two. */
+  columns?: number;
+  /** Optional CSS class name */
+  className?: string;
+  /** Grid contents. */
+  children: React.ReactNode;
+}
+
+/**
+ * Layout wrapper rendering children in a 12-column Mirotone grid. Each child
+ * automatically receives column start/end classes to distribute them evenly.
+ */
+export function TabGrid({
+  columns = 2,
+  className = '',
+  children,
+}: TabGridProps): React.JSX.Element {
+  const span = Math.floor(12 / columns);
+  return (
+    <div className={`grid ${className}`.trim()}>
+      {React.Children.map(children, (child, index) => {
+        if (!React.isValidElement(child)) return child;
+        const element = child as React.ReactElement<{ className?: string }>;
+        const start = 1 + (index % columns) * span;
+        const endLine = start + span;
+        const wrappedClass =
+          `${element.props.className ?? ''} cs${start} ce${Math.min(
+            endLine - 1,
+            12,
+          )}`.trim();
+        return React.cloneElement(element, { className: wrappedClass });
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/TabGrid.tsx
+++ b/src/ui/components/TabGrid.tsx
@@ -17,7 +17,7 @@ export function TabGrid({
   columns = 2,
   className = '',
   children,
-}: ReadOnly<TabGridProps>): React.JSX.Element {
+}: Readonly<TabGridProps>): React.JSX.Element {
   const span = Math.floor(12 / columns);
   return (
     <div className={`grid ${className}`.trim()}>

--- a/src/ui/components/TabGrid.tsx
+++ b/src/ui/components/TabGrid.tsx
@@ -17,7 +17,7 @@ export function TabGrid({
   columns = 2,
   className = '',
   children,
-}: TabGridProps): React.JSX.Element {
+}: ReadOnly<TabGridProps>): React.JSX.Element {
   const span = Math.floor(12 / columns);
   return (
     <div className={`grid ${className}`.trim()}>

--- a/src/ui/components/legacy/Button.tsx
+++ b/src/ui/components/legacy/Button.tsx
@@ -3,16 +3,24 @@ import React from 'react';
 export type ButtonProps = Readonly<
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
     variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'danger';
+    /**
+     * Optional size override. When omitted, primary buttons default to
+     * `medium` and all others use `small`.
+     */
+    size?: 'small' | 'medium';
   }
 >;
 
 /** Basic button styled with Mirotone utility classes. */
 export function Button({
   variant = 'primary',
+  size,
   className = '',
   ...props
 }: ButtonProps): React.JSX.Element {
-  const classes = `button button-${variant} ${className}`.trim();
+  const finalSize = size ?? (variant === 'primary' ? 'medium' : 'small');
+  const classes =
+    `button button-${variant} button-${finalSize} ${className}`.trim();
   return (
     <button
       className={classes}

--- a/src/ui/pages/ArrangeTab.tsx
+++ b/src/ui/pages/ArrangeTab.tsx
@@ -8,6 +8,7 @@ import {
   SelectOption,
   Text,
 } from '../components/legacy';
+import { TabGrid } from '../components/TabGrid';
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
 import { TabPanel } from '../components/TabPanel';
@@ -60,69 +61,68 @@ export const ArrangeTab: React.FC = () => {
 
   return (
     <TabPanel tabId='arrange'>
-      <div>
-        <fieldset className='form-group-small'>
-          <InputField label='Columns'>
+      <TabGrid columns={2}>
+        <InputField label='Columns'>
+          <input
+            className='input input-small'
+            type='number'
+            value={String(grid.cols)}
+            onChange={(e) => updateNumber('cols')(e.target.value)}
+            placeholder='Columns'
+          />
+        </InputField>
+        <InputField label='Gap'>
+          <input
+            className='input input-small'
+            type='number'
+            value={String(grid.padding)}
+            onChange={(e) => updateNumber('padding')(e.target.value)}
+            placeholder='Gap'
+          />
+        </InputField>
+        <Checkbox
+          label='Sort by name'
+          value={Boolean(grid.sortByName)}
+          onChange={toggle('sortByName')}
+        />
+        {grid.sortByName && (
+          <InputField label='Order'>
+            <Select
+              value={grid.sortOrientation}
+              onChange={setOrientation}
+              className='select-small'>
+              <SelectOption value='horizontal'>Horizontally</SelectOption>
+              <SelectOption value='vertical'>Vertically</SelectOption>
+            </Select>
+          </InputField>
+        )}
+        <Checkbox
+          label='Group items into Frame'
+          value={Boolean(grid.groupResult)}
+          onChange={toggle('groupResult')}
+        />
+        {grid.groupResult && (
+          <InputField label='Frame Title'>
             <input
               className='input input-small'
-              type='number'
-              value={String(grid.cols)}
-              onChange={(e) => updateNumber('cols')(e.target.value)}
-              placeholder='Columns'
+              value={frameTitle}
+              onChange={(e) => setFrameTitle(e.target.value)}
+              placeholder='Optional'
             />
           </InputField>
-          <InputField label='Gap'>
-            <input
-              className='input input-small'
-              type='number'
-              value={String(grid.padding)}
-              onChange={(e) => updateNumber('padding')(e.target.value)}
-              placeholder='Gap'
-            />
-          </InputField>
-          <Checkbox
-            label='Sort by name'
-            value={Boolean(grid.sortByName)}
-            onChange={toggle('sortByName')}
-          />
-          {grid.sortByName && (
-            <InputField label='Order'>
-              <Select
-                value={grid.sortOrientation}
-                onChange={setOrientation}
-                className='select-small'>
-                <SelectOption value='horizontal'>Horizontally</SelectOption>
-                <SelectOption value='vertical'>Vertically</SelectOption>
-              </Select>
-            </InputField>
-          )}
-          <Checkbox
-            label='Group items into Frame'
-            value={Boolean(grid.groupResult)}
-            onChange={toggle('groupResult')}
-          />
-          {grid.groupResult && (
-            <InputField label='Frame Title'>
-              <input
-                className='input input-small'
-                value={frameTitle}
-                onChange={(e) => setFrameTitle(e.target.value)}
-                placeholder='Optional'
-              />
-            </InputField>
-          )}
-          <div className='buttons'>
-            <Button
-              onClick={applyGrid}
-              variant='primary'>
-              <React.Fragment>
-                <Icon name='grid' />
-                <Text>Arrange Grid</Text>
-              </React.Fragment>
-            </Button>
-          </div>
-        </fieldset>
-        <fieldset className='form-group-small'>
+        )}
+        <div className='buttons'>
+          <Button
+            onClick={applyGrid}
+            variant='primary'>
+            <React.Fragment>
+              <Icon name='grid' />
+              <Text>Arrange Grid</Text>
+            </React.Fragment>
+          </Button>
+        </div>
+
+        <div className='form-group-small'>
           <InputField label='Axis'>
             <Select
               value={spacing.axis}
@@ -160,8 +160,8 @@ export const ArrangeTab: React.FC = () => {
               </React.Fragment>
             </Button>
           </div>
-        </fieldset>
-      </div>
+        </div>
+      </TabGrid>
     </TabPanel>
   );
 };

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -9,6 +9,7 @@ import {
 } from '../components/legacy';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
+import { TabGrid } from '../components/TabGrid';
 import { CardProcessor } from '../../board/card-processor';
 
 import { showError } from '../hooks/notifications';
@@ -75,7 +76,7 @@ export const CardsTab: React.FC = () => {
       <JsonDropZone onFiles={handleFiles} />
 
       {files.length > 0 && (
-        <>
+        <TabGrid columns={2}>
           <ul className='custom-dropped-files'>
             {files.map((file) => (
               <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
@@ -136,7 +137,7 @@ export const CardsTab: React.FC = () => {
               </Button>
             )}
           </div>
-        </>
+        </TabGrid>
       )}
     </div>
   );

--- a/src/ui/pages/CreateTab.tsx
+++ b/src/ui/pages/CreateTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Select, SelectOption, InputField } from '../components/legacy';
+import { TabGrid } from '../components/TabGrid';
 import { DiagramTab } from './DiagramTab';
 import { CardsTab } from './CardsTab';
 import { TabPanel } from '../components/TabPanel';
@@ -12,7 +13,7 @@ export const CreateTab: React.FC = () => {
   const [mode, setMode] = React.useState<'diagram' | 'cards'>('diagram');
   return (
     <TabPanel tabId='create'>
-      <div>
+      <TabGrid columns={2}>
         <InputField label='Create mode'>
           <Select
             value={mode}
@@ -23,7 +24,7 @@ export const CreateTab: React.FC = () => {
           </Select>
         </InputField>
         {mode === 'diagram' ? <DiagramTab /> : <CardsTab />}
-      </div>
+      </TabGrid>
     </TabPanel>
   );
 };

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -11,6 +11,7 @@ import {
 } from '../components/legacy';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
+import { TabGrid } from '../components/TabGrid';
 import { GraphProcessor } from '../../core/graph/graph-processor';
 import {
   ALGORITHMS,
@@ -132,7 +133,7 @@ export const DiagramTab: React.FC = () => {
       <JsonDropZone onFiles={handleFiles} />
 
       {importQueue.length > 0 && (
-        <>
+        <TabGrid columns={2}>
           <ul className='custom-dropped-files'>
             {importQueue.map((file) => (
               <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
@@ -336,7 +337,7 @@ export const DiagramTab: React.FC = () => {
               </Button>
             )}
           </div>
-        </>
+        </TabGrid>
       )}
     </div>
   );

--- a/src/ui/pages/FramesTab.tsx
+++ b/src/ui/pages/FramesTab.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Button, Icon, InputField, Text } from '../components/legacy';
+import { Button, Icon, InputField, Text, Heading } from '../components/legacy';
 import {
   lockSelectedFrames,
   renameSelectedFrames,
 } from '../../board/frame-tools';
 import { TabPanel } from '../components/TabPanel';
+import { TabGrid } from '../components/TabGrid';
 import type { TabTuple } from './tab-definitions';
 
 /** UI for renaming or locking selected frames. */
@@ -19,9 +20,9 @@ export const FramesTab: React.FC = () => {
   };
   return (
     <TabPanel tabId='frames'>
-      <div>
-        <fieldset>
-          <legend>Rename Frames</legend>
+      <TabGrid columns={2}>
+        <section>
+          <Heading level={2}>Rename Frames</Heading>
           <InputField label='Prefix'>
             <input
               className='input input-small'
@@ -40,9 +41,9 @@ export const FramesTab: React.FC = () => {
               </React.Fragment>
             </Button>
           </div>
-        </fieldset>
-        <fieldset>
-          <legend>Lock Frames</legend>
+        </section>
+        <section>
+          <Heading level={2}>Lock Frames</Heading>
           <div className='buttons'>
             <Button
               onClick={lock}
@@ -53,8 +54,8 @@ export const FramesTab: React.FC = () => {
               </React.Fragment>
             </Button>
           </div>
-        </fieldset>
-      </div>
+        </section>
+      </TabGrid>
     </TabPanel>
   );
 };

--- a/src/ui/pages/HelpTab.tsx
+++ b/src/ui/pages/HelpTab.tsx
@@ -8,12 +8,12 @@ import type { TabTuple } from './tab-definitions';
 export const HelpTab: React.FC = () => (
   <TabPanel tabId='help'>
     <div data-testid='help-tab'>
-      <Heading level={3}>Getting Started</Heading>
+      <Heading level={2}>Getting Started</Heading>
       <Paragraph>
         Use the Create tab to import diagrams or cards from a JSON file. Nodes
         may define templates, labels and ELK options to influence placement.
       </Paragraph>
-      <Heading level={3}>Diagram Layout Options</Heading>
+      <Heading level={2}>Diagram Layout Options</Heading>
       <ul className='list'>
         <li>
           <strong>Layered</strong> – Flow diagrams with layers
@@ -37,14 +37,14 @@ export const HelpTab: React.FC = () => (
           <strong>Rect Packing</strong> – Fits rectangles within parents
         </li>
       </ul>
-      <Heading level={3}>Other Tools</Heading>
+      <Heading level={2}>Other Tools</Heading>
       <ul className='list'>
         <li>Resize – adjust widget size or copy from selection.</li>
         <li>Frames – rename selected frames.</li>
         <li>Colours – modify fill colours.</li>
         <li>Arrange – grid and spacing tools.</li>
       </ul>
-      <Heading level={3}>Changelog</Heading>
+      <Heading level={2}>Changelog</Heading>
       <pre style={{ whiteSpace: 'pre-wrap' }}>{changelog}</pre>
     </div>
   </TabPanel>

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -6,6 +6,7 @@ import {
   Select,
   SelectOption,
   Paragraph,
+  Heading,
   Icon,
   Text,
 } from '../components/legacy';
@@ -28,6 +29,7 @@ import {
   AspectRatioId,
 } from '../../core/utils/aspect-ratio';
 import { TabPanel } from '../components/TabPanel';
+import { TabGrid } from '../components/TabGrid';
 
 /** Predefined button sizes used by the quick presets. */
 const PRESET_SIZES: Record<'S' | 'M' | 'L', Size> = {
@@ -123,80 +125,94 @@ export const ResizeTab: React.FC = () => {
   return (
     <TabPanel tabId='resize'>
       <div className='custom-centered'>
-        <fieldset>
-          <legend>Manual Resize</legend>
-          <Paragraph data-testid='size-display'>
-            {copiedSize
-              ? `Copied: ${copiedSize.width}×${copiedSize.height}`
-              : `Selection: ${size.width}×${size.height}`}
-          </Paragraph>
-          {warning && <Paragraph className='error'>{warning}</Paragraph>}
-          <FormGroup>
-            <InputField label='Width:'>
-              <input
-                className='input input-small'
-                type='number'
-                value={String(size.width)}
-                onChange={(e) => update('width')(e.target.value)}
-                placeholder='Width (board units)'
-              />
+        <section>
+          <Heading level={2}>Manual Resize</Heading>
+          <TabGrid columns={2}>
+            <Paragraph data-testid='size-display'>
+              {copiedSize
+                ? `Copied: ${copiedSize.width}×${copiedSize.height}`
+                : `Selection: ${size.width}×${size.height}`}
+            </Paragraph>
+            {warning && <Paragraph className='error'>{warning}</Paragraph>}
+            <FormGroup>
+              <InputField label='Width:'>
+                <input
+                  className='input input-small'
+                  type='number'
+                  value={String(size.width)}
+                  onChange={(e) => update('width')(e.target.value)}
+                  placeholder='Width (board units)'
+                />
+              </InputField>
+              <InputField label='Height:'>
+                <input
+                  className='input input-small'
+                  type='number'
+                  value={String(size.height)}
+                  onChange={(e) => update('height')(e.target.value)}
+                  placeholder='Height (board units)'
+                />
+              </InputField>
+            </FormGroup>
+            <InputField label='Aspect Ratio'>
+              <Select
+                data-testid='ratio-select'
+                className='select-small'
+                value={ratio}
+                onChange={(v) => setRatio(v as AspectRatioId | 'none')}>
+                <SelectOption value='none'>Free</SelectOption>
+                {ASPECT_RATIOS.map((r) => (
+                  <SelectOption
+                    key={r.id}
+                    value={r.id}>
+                    {r.label}
+                  </SelectOption>
+                ))}
+              </Select>
             </InputField>
-            <InputField label='Height:'>
-              <input
-                className='input input-small'
-                type='number'
-                value={String(size.height)}
-                onChange={(e) => update('height')(e.target.value)}
-                placeholder='Height (board units)'
-              />
-            </InputField>
-          </FormGroup>
-          <InputField label='Aspect Ratio'>
-            <Select
-              data-testid='ratio-select'
-              className='select-small'
-              value={ratio}
-              onChange={(v) => setRatio(v as AspectRatioId | 'none')}>
-              <SelectOption value='none'>Free</SelectOption>
-              {ASPECT_RATIOS.map((r) => (
-                <SelectOption
-                  key={r.id}
-                  value={r.id}>
-                  {r.label}
-                </SelectOption>
+            <div className='buttons'>
+              <Button
+                onClick={apply}
+                variant='primary'>
+                <React.Fragment key='.0'>
+                  <Icon name='arrow-right' />
+                  <Text>Apply Size</Text>
+                </React.Fragment>
+              </Button>
+            </div>
+          </TabGrid>
+        </section>
+        <section>
+          <Heading level={2}>Presets</Heading>
+          <TabGrid columns={2}>
+            <div>
+              {(['S', 'M', 'L'] as const).map((p) => (
+                <Button
+                  key={p}
+                  onClick={() => setSize(PRESET_SIZES[p])}
+                  variant='secondary'>
+                  {p}
+                </Button>
               ))}
-            </Select>
-          </InputField>
-        </fieldset>
-        <fieldset>
-          <legend>Presets</legend>
-          <div>
-            {(['S', 'M', 'L'] as const).map((p) => (
-              <Button
-                key={p}
-                onClick={() => setSize(PRESET_SIZES[p])}
-                variant='secondary'>
-                {p}
-              </Button>
-            ))}
-          </div>
-          <div className='buttons'>
-            {SCALE_OPTIONS.map((s) => (
-              <Button
-                key={s.label}
-                onClick={() => scale(s.factor)}
-                variant='secondary'>
-                {s.label}
-              </Button>
-            ))}
-          </div>
-          <Paragraph>
-            {boardUnitsToMm(size.width).toFixed(1)} mm ×{' '}
-            {boardUnitsToMm(size.height).toFixed(1)} mm (
-            {boardUnitsToInches(size.width).toFixed(2)} ×{' '}
-            {boardUnitsToInches(size.height).toFixed(2)} in)
-          </Paragraph>
-        </fieldset>
+            </div>
+            <div className='buttons'>
+              {SCALE_OPTIONS.map((s) => (
+                <Button
+                  key={s.label}
+                  onClick={() => scale(s.factor)}
+                  variant='secondary'>
+                  {s.label}
+                </Button>
+              ))}
+            </div>
+            <Paragraph>
+              {boardUnitsToMm(size.width).toFixed(1)} mm ×{' '}
+              {boardUnitsToMm(size.height).toFixed(1)} mm (
+              {boardUnitsToInches(size.width).toFixed(2)} ×{' '}
+              {boardUnitsToInches(size.height).toFixed(2)} in)
+            </Paragraph>
+          </TabGrid>
+        </section>
         <div className='buttons'>
           <Button
             onClick={copiedSize ? resetCopy : copy}
@@ -204,14 +220,6 @@ export const ResizeTab: React.FC = () => {
             <React.Fragment key='.0'>
               <Icon name={copiedSize ? 'undo' : 'duplicate'} />
               <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
-            </React.Fragment>
-          </Button>
-          <Button
-            onClick={apply}
-            variant='primary'>
-            <React.Fragment key='.0'>
-              <Icon name='arrow-right' />
-              <Text>Apply Size</Text>
             </React.Fragment>
           </Button>
         </div>

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   Text,
 } from '../components/legacy';
+import { TabGrid } from '../components/TabGrid';
 import type { SearchOptions } from '../../board/search-tools';
 import {
   useDebouncedSearch,
@@ -116,7 +117,7 @@ export const SearchTab: React.FC = () => {
 
   return (
     <TabPanel tabId='search'>
-      <div>
+      <TabGrid columns={2}>
         <InputField label='Find'>
           <input
             className='input input-small'
@@ -150,7 +151,7 @@ export const SearchTab: React.FC = () => {
             onChange={setRegex}
           />
         </div>
-        <fieldset className='form-group-small'>
+        <div className='form-group-small'>
           <legend className='custom-visually-hidden'>Widget Types</legend>
           <div>
             {['shape', 'card', 'sticky_note', 'text'].map((t) => (
@@ -162,7 +163,7 @@ export const SearchTab: React.FC = () => {
               />
             ))}
           </div>
-        </fieldset>
+        </div>
         <InputField label='Tag IDs'>
           <input
             className='input input-small'
@@ -234,7 +235,7 @@ export const SearchTab: React.FC = () => {
             </React.Fragment>
           </Button>
         </div>
-      </div>
+      </TabGrid>
     </TabPanel>
   );
 };

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Icon, InputField, Text } from '../components/legacy';
+import { Button, Icon, InputField, Text, Heading } from '../components/legacy';
 import { tweakFillColor, extractFillColor } from '../../board/style-tools';
 import { applyStylePreset, presetStyle } from '../../board/format-tools';
 import { STYLE_PRESET_NAMES, stylePresets } from '../style-presets';
@@ -7,6 +7,7 @@ import { adjustColor } from '../../core/utils/color-utils';
 import { useSelection } from '../hooks/use-selection';
 import { tokens } from '../tokens';
 import { TabPanel } from '../components/TabPanel';
+import { TabGrid } from '../components/TabGrid';
 import type { TabTuple } from './tab-definitions';
 
 /** Adjusts the fill colour of selected widgets. */
@@ -29,7 +30,9 @@ export const StyleTab: React.FC = () => {
   return (
     <TabPanel tabId='style'>
       <div className='grid form-example'>
-        <form className='cs1 ce12 form-example-main-content'>
+        <TabGrid
+          className='cs1 ce12 form-example-main-content'
+          columns={2}>
           <InputField label='Adjust fill'>
             <input
               data-testid='adjust-slider'
@@ -89,33 +92,31 @@ export const StyleTab: React.FC = () => {
               </React.Fragment>
             </Button>
           </div>
-          <fieldset className='form-group-small'>
-            <legend className='p-medium'>Style presets</legend>
-            <div className='buttons'>
-              {STYLE_PRESET_NAMES.map((name) => {
-                const preset = stylePresets[name];
-                const style = presetStyle(preset);
-                return (
-                  <Button
-                    key={name}
-                    onClick={() => applyStylePreset(preset)}
-                    type='button'
-                    variant='secondary'
-                    className='button-small'
-                    style={{
-                      color: style.color,
-                      backgroundColor: style.fillColor,
-                      borderColor: style.borderColor,
-                      borderWidth: style.borderWidth,
-                      borderStyle: 'solid',
-                    }}>
-                    {preset.label}
-                  </Button>
-                );
-              })}
-            </div>
-          </fieldset>
-        </form>
+          <Heading level={2}>Style presets</Heading>
+          <div className='buttons'>
+            {STYLE_PRESET_NAMES.map((name) => {
+              const preset = stylePresets[name];
+              const style = presetStyle(preset);
+              return (
+                <Button
+                  key={name}
+                  onClick={() => applyStylePreset(preset)}
+                  type='button'
+                  variant='secondary'
+                  className='button-small'
+                  style={{
+                    color: style.color,
+                    backgroundColor: style.fillColor,
+                    borderColor: style.borderColor,
+                    borderWidth: style.borderWidth,
+                    borderStyle: 'solid',
+                  }}>
+                  {preset.label}
+                </Button>
+              );
+            })}
+          </div>
+        </TabGrid>
       </div>
     </TabPanel>
   );

--- a/tests/button-size.test.tsx
+++ b/tests/button-size.test.tsx
@@ -1,0 +1,26 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Button } from '../src/ui/components/legacy/Button';
+
+it('defaults to medium size for primary', () => {
+  const { getByRole } = render(<Button variant='primary'>Ok</Button>);
+  expect(getByRole('button')).toHaveClass('button-medium');
+});
+
+it('defaults to small size for secondary', () => {
+  const { getByRole } = render(<Button variant='secondary'>Ok</Button>);
+  expect(getByRole('button')).toHaveClass('button-small');
+});
+
+it('accepts explicit size override', () => {
+  const { getByRole } = render(
+    <Button
+      variant='secondary'
+      size='medium'>
+      Ok
+    </Button>,
+  );
+  expect(getByRole('button')).toHaveClass('button-medium');
+});

--- a/tests/tabgrid.test.tsx
+++ b/tests/tabgrid.test.tsx
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TabGrid } from '../src/ui/components/TabGrid';
+
+it('applies grid class and item column classes', () => {
+  const { container } = render(
+    <TabGrid columns={1}>
+      <span>A</span>
+      <span>B</span>
+    </TabGrid>,
+  );
+  const el = container.firstChild as HTMLElement;
+  expect(el).toHaveClass('grid');
+  const items = el.children;
+  expect(items[0]).toHaveClass('cs1', 'ce12');
+  expect(items[1]).toHaveClass('cs1', 'ce12');
+});
+
+it('uses two columns by default', () => {
+  const { container } = render(
+    <TabGrid>
+      <span>A</span>
+      <span>B</span>
+    </TabGrid>,
+  );
+  const el = container.firstChild as HTMLElement;
+  const items = el.children;
+  expect(items[0]).toHaveClass('cs1', 'ce6');
+  expect(items[1]).toHaveClass('cs7', 'ce12');
+});


### PR DESCRIPTION
## Summary
- apply `cs`/`ce` column classes in `TabGrid`
- update TabGrid tests for new layout logic
- document change in the changelog

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863e3bf55a8832b956e91b01d161e37