### PR TITLE
Add client-side commitlint hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/h"
+
+npx --no-install commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ complexity below eight as described in
 
 ## Commit messages
 
-Verify that your commit message follows the Conventional Commits format by
-running:
+Verify that your commit message follows the Conventional Commits format. A
+`commit-msg` hook runs commitlint automatically, but you can also check the
+latest commit manually by running:
 
 ```bash
 npm run commitlint -- --edit $(git rev-parse --verify HEAD)

--- a/README.md
+++ b/README.md
@@ -277,8 +277,9 @@ everyone uses the exact dependency versions when installing.
 
 ## Commit message checks
 
-Commit messages must follow the Conventional Commits specification. Verify the
-latest commit locally by running:
+Commit messages must follow the Conventional Commits specification. A
+`commit-msg` hook now runs commitlint automatically. Verify the latest commit
+manually by running:
 
 ```bash
 npm run commitlint -- --edit $(git rev-parse --verify HEAD)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.30.0",
         "eslint-plugin-react": "^7.37.5",
+        "husky": "^9.0.11",
         "jsdom": "^26.1.0",
         "prettier": "^3.6.2",
         "semantic-release": "^24.2.6",
@@ -7736,6 +7737,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "stylelint": "stylelint 'src/**/*.css'",
     "build-storybook": "echo 'Storybook build placeholder'",
     "semantic-release": "semantic-release",
-    "commitlint": "commitlint --color"
+    "commitlint": "commitlint --color",
+    "prepare": "husky install"
   },
   "dependencies": {
     "d3-dsv": "^3.0.1",
@@ -59,6 +60,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.30.0",
     "eslint-plugin-react": "^7.37.5",
+    "husky": "^9.0.11",
     "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
     "semantic-release": "^24.2.6",


### PR DESCRIPTION
## Summary
- add Husky dependency and prepare script
- enforce commitlint via new `commit-msg` hook
- document commitlint automation in README and contributing guide

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686470029330832bb0747912559ad0cd