### PR TITLE
feat(layout): add recursive ELK preprocessor

### DIFF
--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -22,6 +22,10 @@ export interface HierarchyProcessOptions {
   createFrame?: boolean;
   frameTitle?: string;
   sortKey?: string;
+  /** Spacing between sibling nodes. */
+  padding?: number;
+  /** Height of the invisible spacer inserted above children. */
+  topSpacing?: number;
 }
 
 /**
@@ -67,7 +71,11 @@ export class HierarchyProcessor extends UndoableProcessor<
     const data = Array.isArray(roots) ? roots : edgesToHierarchy(roots);
     if (!Array.isArray(data)) throw new Error('Invalid hierarchy');
     this.lastCreated = [];
-    const result = await layoutHierarchy(data, { sortKey: opts.sortKey });
+    const result = await layoutHierarchy(data, {
+      sortKey: opts.sortKey,
+      padding: opts.padding,
+      topSpacing: opts.topSpacing,
+    });
     const bounds = this.computeBounds(result);
     const margin = 40;
     const width = bounds.maxX - bounds.minX + margin * 2;

--- a/src/core/layout/elk-preprocessor.ts
+++ b/src/core/layout/elk-preprocessor.ts
@@ -43,7 +43,7 @@ function insertSpacer(node: LayoutNode, opts: Required<SpacerOptions>): void {
 function applyAlgorithm(node: LayoutNode): void {
   if (!node.children?.length) return;
   node.layoutOptions = node.layoutOptions || {};
-  node.layoutOptions['algorithm'] = 'org.eclipse.elk.rectanglePacking';
+  node.layoutOptions['elk.algorithm'] = 'org.eclipse.elk.rectpacking';
 }
 
 /**

--- a/src/core/layout/elk-preprocessor.ts
+++ b/src/core/layout/elk-preprocessor.ts
@@ -1,0 +1,69 @@
+import type { ElkNode } from 'elkjs/lib/elk-api';
+
+/** ELK node extended with optional custom properties. */
+export interface LayoutNode extends ElkNode {
+  /** Additional properties used by the renderer. */
+  properties?: Record<string, unknown>;
+}
+
+/** Options controlling spacer creation. */
+export interface SpacerOptions {
+  /** Spacer height inserted above children. */
+  topMargin?: number;
+  /** Fallback width when parent width is undefined. */
+  defaultWidth?: number;
+}
+
+const DEFAULT_MARGIN = 50;
+const DEFAULT_WIDTH = 200;
+
+/**
+ * Insert an invisible spacer node as the first child when missing.
+ */
+function insertSpacer(node: LayoutNode, opts: Required<SpacerOptions>): void {
+  const children = node.children ?? [];
+  if (children.length === 0) return;
+
+  const first = children[0];
+  const hasSpacer = Boolean(first?.id?.startsWith('spacer_'));
+  if (hasSpacer) return;
+
+  const spacer: LayoutNode = {
+    id: `spacer_${node.id}`,
+    width: node.width ?? opts.defaultWidth,
+    height: opts.topMargin,
+    labels: [],
+    ports: [],
+    properties: { invisible: true },
+  };
+  node.children = [spacer, ...children];
+}
+
+/** Apply rectangle packing algorithm to a parent node. */
+function applyAlgorithm(node: LayoutNode): void {
+  if (!node.children?.length) return;
+  node.layoutOptions = node.layoutOptions || {};
+  node.layoutOptions['algorithm'] = 'org.eclipse.elk.rectanglePacking';
+}
+
+/**
+ * Recursively prepare a node for ELK layout by applying rectangle packing
+ * and inserting spacer nodes.
+ *
+ * @param node - The root node to modify in-place.
+ * @param topMargin - Height of the spacer node, defaults to 50.
+ * @param defaultWidth - Width used when the parent node lacks a width.
+ */
+export function prepareForElk(
+  node: LayoutNode,
+  topMargin: number = DEFAULT_MARGIN,
+  defaultWidth: number = DEFAULT_WIDTH,
+): void {
+  if (!Array.isArray(node.children) || node.children.length === 0) return;
+
+  applyAlgorithm(node);
+  insertSpacer(node, { topMargin, defaultWidth });
+  node.children.forEach((child) =>
+    prepareForElk(child, topMargin, defaultWidth),
+  );
+}

--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -96,6 +96,19 @@ export class NestedLayouter {
     return null;
   }
 
+  private collectChildPositions(
+    node: ElkNode,
+    map: Record<string, PositionedNode>,
+    offsetX: number,
+    offsetY: number,
+  ): void {
+    const childX = (typeof node.x === 'number' ? node.x : 0) + offsetX;
+    const childY = (typeof node.y === 'number' ? node.y : 0) + offsetY;
+    for (const child of node.children ?? []) {
+      this.collectPositions(child, map, childX, childY);
+    }
+  }
+
   private collectPositions(
     node: ElkNode,
     map: Record<string, PositionedNode>,
@@ -103,14 +116,14 @@ export class NestedLayouter {
     offsetY = 0,
   ): void {
     const pos = this.computePosition(node, offsetX, offsetY);
-    if (pos) {
+    // Skip spacer nodes that only influence layout sizing
+    const isInvisible =
+      (node as LayoutNode).properties?.invisible === true ||
+      String(node.id).startsWith('spacer_');
+    if (pos && !isInvisible) {
       map[node.id] = pos;
     }
-    for (const child of node.children ?? []) {
-      const childX = typeof node.x === 'number' ? offsetX + node.x : offsetX;
-      const childY = typeof node.y === 'number' ? offsetY + node.y : offsetY;
-      this.collectPositions(child, map, childX, childY);
-    }
+    this.collectChildPositions(node, map, offsetX, offsetY);
   }
 
   /**

--- a/src/core/utils/aspect-ratio.ts
+++ b/src/core/utils/aspect-ratio.ts
@@ -16,7 +16,7 @@ export interface AspectRatioPreset {
 }
 
 /** Supported preset identifiers. */
-export type AspectRatioId = 'golden' | '16:9' | '16:10' | '4:3';
+export type AspectRatioId = 'golden' | 'square' | '16:9' | '16:10' | '4:3';
 
 /** Golden ratio constant used by presets. */
 export const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;

--- a/src/ui/hooks/use-diagram-create.ts
+++ b/src/ui/hooks/use-diagram-create.ts
@@ -22,6 +22,8 @@ interface CreateOptions {
   withFrame: boolean;
   frameTitle: string;
   layoutOpts: UserLayoutOptions;
+  nestedPadding: number;
+  nestedTopSpacing: number;
 }
 
 /**
@@ -56,6 +58,8 @@ export function useDiagramCreate(
           await hierarchyProcessor.processFile(file, {
             createFrame: opts.withFrame,
             frameTitle: opts.frameTitle || undefined,
+            padding: opts.nestedPadding,
+            topSpacing: opts.nestedTopSpacing,
           });
         } else {
           setLastProc(graphProcessor);

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -103,6 +103,8 @@ export const DiagramTab: React.FC = () => {
   const [layoutOpts, setLayoutOpts] = React.useState<UserLayoutOptions>(
     DEFAULT_LAYOUT_OPTIONS,
   );
+  const [nestedPadding, setNestedPadding] = React.useState(20);
+  const [nestedTopSpacing, setNestedTopSpacing] = React.useState(50);
   const [progress, setProgress] = React.useState<number>(0);
   const [error, setError] = React.useState<string | null>(null);
   const [lastProc, setLastProc] = React.useState<
@@ -117,7 +119,15 @@ export const DiagramTab: React.FC = () => {
 
   const handleCreate = useDiagramCreate(
     importQueue,
-    { layoutChoice, showAdvanced, withFrame, frameTitle, layoutOpts },
+    {
+      layoutChoice,
+      showAdvanced,
+      withFrame,
+      frameTitle,
+      layoutOpts,
+      nestedPadding,
+      nestedTopSpacing,
+    },
     setImportQueue,
     setProgress,
     setError,
@@ -305,6 +315,26 @@ export const DiagramTab: React.FC = () => {
                     </SelectOption>
                   ))}
                 </Select>
+              </InputField>
+            )}
+            {layoutChoice === 'Nested' && (
+              <InputField label='Padding'>
+                <input
+                  className='input'
+                  type='number'
+                  value={String(nestedPadding)}
+                  onChange={(e) => setNestedPadding(Number(e.target.value))}
+                />
+              </InputField>
+            )}
+            {layoutChoice === 'Nested' && (
+              <InputField label='Top spacing'>
+                <input
+                  className='input'
+                  type='number'
+                  value={String(nestedTopSpacing)}
+                  onChange={(e) => setNestedTopSpacing(Number(e.target.value))}
+                />
               </InputField>
             )}
           </details>

--- a/tests/elk-preprocessor.test.ts
+++ b/tests/elk-preprocessor.test.ts
@@ -5,8 +5,8 @@ describe('prepareForElk', () => {
   test('assigns algorithm and inserts spacer', () => {
     const root: LayoutNode = { id: 'r', children: [{ id: 'c' }] };
     prepareForElk(root, 10, 50);
-    expect(root.layoutOptions?.algorithm).toBe(
-      'org.eclipse.elk.rectanglePacking',
+    expect(root.layoutOptions?.['elk.algorithm']).toBe(
+      'org.eclipse.elk.rectpacking',
     );
     expect(root.children?.[0].id).toBe('spacer_r');
     expect(root.children).toHaveLength(2);
@@ -39,8 +39,8 @@ describe('prepareForElk', () => {
     };
     prepareForElk(root);
     const parent = root.children?.find((n) => n.id === 'p') as LayoutNode;
-    expect(parent.layoutOptions?.algorithm).toBe(
-      'org.eclipse.elk.rectanglePacking',
+    expect(parent.layoutOptions?.['elk.algorithm']).toBe(
+      'org.eclipse.elk.rectpacking',
     );
     expect(parent.children?.[0].id).toBe('spacer_p');
   });

--- a/tests/elk-preprocessor.test.ts
+++ b/tests/elk-preprocessor.test.ts
@@ -1,0 +1,54 @@
+import type { LayoutNode } from '../src/core/layout/elk-preprocessor';
+import { prepareForElk } from '../src/core/layout/elk-preprocessor';
+
+describe('prepareForElk', () => {
+  test('assigns algorithm and inserts spacer', () => {
+    const root: LayoutNode = { id: 'r', children: [{ id: 'c' }] };
+    prepareForElk(root, 10, 50);
+    expect(root.layoutOptions?.algorithm).toBe(
+      'org.eclipse.elk.rectanglePacking',
+    );
+    expect(root.children?.[0].id).toBe('spacer_r');
+    expect(root.children).toHaveLength(2);
+  });
+
+  test('avoids duplicate spacers', () => {
+    const root: LayoutNode = {
+      id: 'r',
+      children: [
+        {
+          id: 'spacer_r',
+          width: 50,
+          height: 10,
+          properties: { invisible: true },
+        },
+        { id: 'c' },
+      ],
+    };
+    prepareForElk(root, 10, 50);
+    const spacerCount = root.children?.filter(
+      (n) => n.id === 'spacer_r',
+    ).length;
+    expect(spacerCount).toBe(1);
+  });
+
+  test('recurses into nested children', () => {
+    const root: LayoutNode = {
+      id: 'r',
+      children: [{ id: 'p', children: [{ id: 'c' }] }],
+    };
+    prepareForElk(root);
+    const parent = root.children?.find((n) => n.id === 'p') as LayoutNode;
+    expect(parent.layoutOptions?.algorithm).toBe(
+      'org.eclipse.elk.rectanglePacking',
+    );
+    expect(parent.children?.[0].id).toBe('spacer_p');
+  });
+
+  test('uses parent width when available', () => {
+    const root: LayoutNode = { id: 'r', width: 80, children: [{ id: 'c' }] };
+    prepareForElk(root, 10, 50);
+    const spacer = root.children?.[0] as LayoutNode;
+    expect(spacer.width).toBe(80);
+  });
+});

--- a/tests/nested-layout.test.ts
+++ b/tests/nested-layout.test.ts
@@ -38,7 +38,7 @@ describe('layoutHierarchy', () => {
     const childB = result.nodes.b;
     expect(childA.y).not.toBe(childB.y);
     expect(parent.width).toBeGreaterThan(childA.width);
-    expect(Object.keys(result.nodes)).toContain('spacer_p');
+    expect(Object.keys(result.nodes)).not.toContain('spacer_p');
   });
 
   test('sorts children by custom key', async () => {
@@ -67,7 +67,7 @@ describe('layoutHierarchy', () => {
 
   test('positions example dataset', async () => {
     const result = await layoutHierarchy(sampleHier as TestNode[]);
-    expect(Object.keys(result.nodes)).toHaveLength(105);
+    expect(Object.keys(result.nodes)).toHaveLength(84);
     expect(result.nodes['r1c1g1'].width).toBe(120);
     expect(result.nodes['r1c1g1'].height).toBe(30);
   });


### PR DESCRIPTION
## Summary
- implement `prepareForElk` to recursively set rectangle packing algorithm and insert spacer nodes
- add test coverage for new preprocessor

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686470625c18832b9c2b033ea5941f58