### PR TITLE
Add husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm install
+npm run typecheck --silent
+npm test --silent
+npm run lint --silent
+npm run stylelint --silent
+npm run prettier --silent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ npm run stylelint --silent
 npm run prettier --silent
 ```
 
+A Husky pre-commit hook now runs these commands automatically when creating a
+commit. Activate the hooks with `npm run prepare` after cloning.
+
 These commands run **ESLint**, **Stylelint** and **Prettier** to ensure a
 consistent codebase.
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ npm run stylelint --silent
 npm run prettier --silent
 ```
 
+A Husky pre-commit hook runs these commands automatically. After cloning the
+repository run `npm run prepare` once to activate the hooks so every commit is
+validated.
+
 These commands perform TypeScript type checking, execute the **Vitest** suite
 with coverage enabled, run ESLint and format files with Prettier. Aim for at
 least 90 % line and branch coverage and keep cyclomatic complexity under eight

--- a/src/ui/components/legacy/Paragraph.tsx
+++ b/src/ui/components/legacy/Paragraph.tsx
@@ -13,10 +13,10 @@ export function Paragraph({
   return (
     <p
       className={`p-medium ${className}`.trim()}
-              style={{
-                fontSize: 'var(--font-sizes-175)',
-                ...(style as React.CSSProperties),
-              }}
+      style={{
+        fontSize: 'var(--font-sizes-175)',
+        ...(style as React.CSSProperties),
+      }}
       {...props}
     />
   );

--- a/tests/tab-definitions.test.ts
+++ b/tests/tab-definitions.test.ts
@@ -6,7 +6,7 @@ import type { TabId } from '../src/ui/pages/tab-definitions';
 const VALID_IDS: TabId[] = [
   'create',
   'tools',
-  'resize',
+  'size',
   'style',
   'arrange',
   'frames',


### PR DESCRIPTION
## Summary
- add a husky pre-commit hook that runs type checking, tests and linters
- mention the pre-commit hook in AGENTS.md and README
- fix tab-definitions test id value
- format Paragraph component

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent && npm run stylelint --silent && npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_68649f37a188832babc8889e70b48aff