### PR TITLE
feat(ui): update InputField API

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ older Mirotone wrappers remain under `src/ui/components/legacy`.
 When creating forms use the wrapper components so your inputs and buttons match
 the rest of the UI. These guidelines help keep layouts consistent:
 
-- Use `InputField` to pair labels with their controls.
+- Use `InputField` to pair labels with their controls. Provide the input
+  component via the `as` prop and pass component props through `options`.
 - `Button` and `InputField` wrap the design-system components so events and
   sizing tokens behave consistently.
 - Group related fields using `FormGroup` to maintain spacing and a clear

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -79,6 +79,19 @@ Common form controls such as `Button` and `InputField` are also provided in the
 `legacy` folder. They pass sizing tokens and `onChange` events through to the
 design-system components so existing code keeps working while the UI migrates.
 
+`InputField` composes a label with a form control. Pass the control component
+via the `as` prop and provide its props through `options`:
+
+```tsx
+<InputField
+  label='Template'
+  as={Select}
+  options={{ value: tpl, onChange: setTpl }}>
+  <SelectOption value='a'>A</SelectOption>
+  <SelectOption value='b'>B</SelectOption>
+</InputField>
+```
+
 > **When a wrapper is missing**
 >
 > 1. Write semantic HTML (for example `<div class="grid grid-gap-8">`).

--- a/src/ui/components/InputField.tsx
+++ b/src/ui/components/InputField.tsx
@@ -1,65 +1,56 @@
 import React from 'react';
 import { Form, Input } from '@mirohq/design-system';
 
-export type InputFieldProps = Readonly<
-  Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    'onChange' | 'className' | 'style'
-  > & {
-    /** Visible label text. */
-    label: React.ReactNode;
-    /** Optional custom form control. If omitted, a text input is rendered. */
-    children?: React.ReactNode;
-    /** Change handler returning the input value. */
-    onChange?: (value: string) => void;
-  }
->;
+export type InputFieldProps = Readonly<{
+  /** Visible label text. */
+  label: React.ReactNode;
+  /** Component used for the control. Defaults to `Input`. */
+  as?: React.ElementType;
+  /** Props forwarded to the rendered control component. */
+  options?: Record<string, unknown>;
+  /** Change handler returning the input value. */
+  onChange?: (value: string) => void;
+  /** Optional control children, e.g. `<SelectOption>` elements. */
+  children?: React.ReactNode;
+  /** Optional id forwarded to the control and label. */
+  id?: string;
+}>;
 
 // Custom class names and inline styles are intentionally excluded so spacing
 // and typography remain consistent across the app.
 
 /** Single component combining label and input control. */
 export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
-  function InputField({ label, children, onChange, id, ...props }, ref) {
+  function InputField(
+    { label, as: Component = Input, options = {}, onChange, children, id },
+    ref,
+  ) {
     const generatedId = React.useId();
     const inputId = id ?? generatedId;
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-      onChange?.(e.target.value);
+    const handleChange = (valueOrEvent: unknown): void => {
+      const opts = options as { onChange?: (arg: unknown) => void };
+      opts.onChange?.(valueOrEvent);
+      if (typeof valueOrEvent === 'string') {
+        onChange?.(valueOrEvent);
+      } else if (
+        valueOrEvent &&
+        typeof (valueOrEvent as { target?: { value?: string } }).target
+          ?.value === 'string'
+      ) {
+        onChange?.(
+          (valueOrEvent as { target: { value: string } }).target.value,
+        );
+      }
     };
-    let control: React.ReactNode;
-    if (
-      children &&
-      React.isValidElement(children) &&
-      children.type !== React.Fragment
-    ) {
-      control = React.cloneElement(children as React.ReactElement, {
-        id: inputId,
-        onChange: (e: React.ChangeEvent<HTMLInputElement>): void => {
-          (
-            children.props as {
-              onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-            }
-          ).onChange?.(e);
-          handleChange(e);
-        },
-      });
-    } else if (children) {
-      control = children;
-    } else {
-      control = (
-        <Input
-          id={inputId}
-          onChange={handleChange}
-          ref={ref}
-          {...(props as React.ComponentProps<typeof Input>)}
-        />
-      );
-    }
 
     return (
       <Form.Field>
         <Form.Label htmlFor={inputId}>{label}</Form.Label>
-        {control}
+        {React.createElement(
+          Component,
+          { id: inputId, ref, ...options, onChange: handleChange },
+          children,
+        )}
       </Form.Field>
     );
   },

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -37,12 +37,14 @@ export function JsonDropZone({
         {...dropzone.getRootProps({ style })}
         aria-label='File drop area'
         aria-describedby='dropzone-instructions'>
-        <InputField label='JSON file'>
-          <input
-            data-testid='file-input'
-            {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
-          />
-        </InputField>
+        <InputField
+          label='JSON file'
+          as='input'
+          options={{
+            'data-testid': 'file-input',
+            ...dropzone.getInputProps({ 'aria-label': 'JSON file input' }),
+          }}
+        />
         {dropzone.isDragAccept ? (
           <Paragraph className='dnd-text'>Drop your JSON file here</Paragraph>
         ) : (

--- a/src/ui/components/Panel.tsx
+++ b/src/ui/components/Panel.tsx
@@ -21,7 +21,7 @@ export interface PanelProps
 export const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
   function Panel({ padding = 'medium', ...props }, ref) {
     // Remove style and className so callers cannot override layout
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
       style: _style,
       className: _className,
@@ -31,6 +31,7 @@ export const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
       className?: string;
       [key: string]: unknown;
     };
+    /* eslint-enable @typescript-eslint/no-unused-vars */
     return (
       <Primitive.section
         ref={ref}

--- a/src/ui/components/RowInspector.tsx
+++ b/src/ui/components/RowInspector.tsx
@@ -52,7 +52,7 @@ export function RowInspector({
           <li key={k}>
             <InputField
               label={<code>{k}</code>}
-              value={String(v)}
+              options={{ value: String(v) }}
               onChange={handleChange(k)}
             />
           </li>

--- a/src/ui/components/Section.tsx
+++ b/src/ui/components/Section.tsx
@@ -20,7 +20,7 @@ export interface SectionProps
 export const Section = React.forwardRef<HTMLDivElement, SectionProps>(
   function Section({ padding = 'small', ...props }, ref) {
     // Remove style and className so callers cannot override layout
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
       style: _style,
       className: _className,
@@ -30,6 +30,7 @@ export const Section = React.forwardRef<HTMLDivElement, SectionProps>(
       className?: string;
       [key: string]: unknown;
     };
+    /* eslint-enable @typescript-eslint/no-unused-vars */
     return (
       <Primitive.div
         ref={ref}

--- a/src/ui/pages/ArrangeTab.tsx
+++ b/src/ui/pages/ArrangeTab.tsx
@@ -56,38 +56,46 @@ export const ArrangeTab: React.FC = () => {
     <TabPanel tabId='arrange'>
       <Panel padding='small'>
         <TabGrid columns={2}>
-          <InputField label='Columns'>
-            <input
-              className='input input-small'
-              type='number'
-              value={String(grid.cols)}
-              onChange={(e) => updateNumber('cols')(e.target.value)}
-              placeholder='Columns'
-            />
-          </InputField>
-          <InputField label='Gap'>
-            <input
-              className='input input-small'
-              type='number'
-              value={String(grid.padding)}
-              onChange={(e) => updateNumber('padding')(e.target.value)}
-              placeholder='Gap'
-            />
-          </InputField>
+          <InputField
+            label='Columns'
+            as='input'
+            options={{
+              className: 'input input-small',
+              type: 'number',
+              value: String(grid.cols),
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                updateNumber('cols')(e.target.value),
+              placeholder: 'Columns',
+            }}
+          />
+          <InputField
+            label='Gap'
+            as='input'
+            options={{
+              className: 'input input-small',
+              type: 'number',
+              value: String(grid.padding),
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                updateNumber('padding')(e.target.value),
+              placeholder: 'Gap',
+            }}
+          />
           <Checkbox
             label='Sort by name'
             value={Boolean(grid.sortByName)}
             onChange={toggle('sortByName')}
           />
           {grid.sortByName && (
-            <InputField label='Order'>
-              <Select
-                value={grid.sortOrientation}
-                onChange={setOrientation}
-                className='select-small'>
-                <SelectOption value='horizontal'>Horizontally</SelectOption>
-                <SelectOption value='vertical'>Vertically</SelectOption>
-              </Select>
+            <InputField
+              label='Order'
+              as={Select}
+              options={{
+                value: grid.sortOrientation,
+                onChange: setOrientation,
+                className: 'select-small',
+              }}>
+              <SelectOption value='horizontal'>Horizontally</SelectOption>
+              <SelectOption value='vertical'>Vertically</SelectOption>
             </InputField>
           )}
           <Checkbox
@@ -96,14 +104,17 @@ export const ArrangeTab: React.FC = () => {
             onChange={toggle('groupResult')}
           />
           {grid.groupResult && (
-            <InputField label='Frame Title'>
-              <input
-                className='input input-small'
-                value={frameTitle}
-                onChange={(e) => setFrameTitle(e.target.value)}
-                placeholder='Optional'
-              />
-            </InputField>
+            <InputField
+              label='Frame Title'
+              as='input'
+              options={{
+                className: 'input input-small',
+                value: frameTitle,
+                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                  setFrameTitle(e.target.value),
+                placeholder: 'Optional',
+              }}
+            />
           )}
           <div className='buttons'>
             <Button
@@ -117,33 +128,40 @@ export const ArrangeTab: React.FC = () => {
           </div>
 
           <div className='form-group-small'>
-            <InputField label='Axis'>
-              <Select
-                value={spacing.axis}
-                onChange={updateAxis}
-                className='select-small'>
-                <SelectOption value='x'>Horizontal</SelectOption>
-                <SelectOption value='y'>Vertical</SelectOption>
-              </Select>
+            <InputField
+              label='Axis'
+              as={Select}
+              options={{
+                value: spacing.axis,
+                onChange: updateAxis,
+                className: 'select-small',
+              }}>
+              <SelectOption value='x'>Horizontal</SelectOption>
+              <SelectOption value='y'>Vertical</SelectOption>
             </InputField>
-            <InputField label='Mode'>
-              <Select
-                value={spacing.mode ?? 'move'}
-                onChange={updateMode}
-                className='select-small'>
-                <SelectOption value='move'>Move</SelectOption>
-                <SelectOption value='grow'>Expand</SelectOption>
-              </Select>
+            <InputField
+              label='Mode'
+              as={Select}
+              options={{
+                value: spacing.mode ?? 'move',
+                onChange: updateMode,
+                className: 'select-small',
+              }}>
+              <SelectOption value='move'>Move</SelectOption>
+              <SelectOption value='grow'>Expand</SelectOption>
             </InputField>
-            <InputField label='Spacing'>
-              <input
-                className='input input-small'
-                type='number'
-                value={String(spacing.spacing)}
-                onChange={(e) => updateSpacing(e.target.value)}
-                placeholder='Distance'
-              />
-            </InputField>
+            <InputField
+              label='Spacing'
+              as='input'
+              options={{
+                className: 'input input-small',
+                type: 'number',
+                value: String(spacing.spacing),
+                onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateSpacing(e.target.value),
+                placeholder: 'Distance',
+              }}
+            />
             <div className='buttons'>
               <Button
                 onClick={applySpacing}

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -136,20 +136,25 @@ export const ExcelTab: React.FC = () => {
         <div
           {...dropzone.getRootProps({ style })}
           aria-label='Excel drop area'>
-          <InputField label='Excel file'>
-            <input
-              data-testid='file-input'
-              {...dropzone.getInputProps()}
-            />
-          </InputField>
-        </div>
-        <InputField label='OneDrive/SharePoint file'>
-          <input
-            value={remote}
-            onChange={(e) => setRemote(e.target.value)}
-            aria-label='graph file'
+          <InputField
+            label='Excel file'
+            as='input'
+            options={{
+              'data-testid': 'file-input',
+              ...dropzone.getInputProps(),
+            }}
           />
-        </InputField>
+        </div>
+        <InputField
+          label='OneDrive/SharePoint file'
+          as='input'
+          options={{
+            'value': remote,
+            'onChange': (e: React.ChangeEvent<HTMLInputElement>) =>
+              setRemote(e.target.value),
+            'aria-label': 'graph file',
+          }}
+        />
         <Button
           onClick={fetchRemote}
           variant='secondary'>
@@ -157,27 +162,29 @@ export const ExcelTab: React.FC = () => {
         </Button>
         {loader.listSheets().length > 0 && (
           <>
-            <InputField label='Data source'>
-              <Select
-                value={source}
-                onChange={setSource}
-                aria-label='Data source'>
-                <SelectOption value=''>Select…</SelectOption>
-                {loader.listSheets().map((s) => (
-                  <SelectOption
-                    key={`s-${s}`}
-                    value={`sheet:${s}`}>
-                    Sheet: {s}
-                  </SelectOption>
-                ))}
-                {loader.listNamedTables().map((t) => (
-                  <SelectOption
-                    key={`t-${t}`}
-                    value={`table:${t}`}>
-                    Table: {t}
-                  </SelectOption>
-                ))}
-              </Select>
+            <InputField
+              label='Data source'
+              as={Select}
+              options={{
+                'value': source,
+                'onChange': setSource,
+                'aria-label': 'Data source',
+              }}>
+              <SelectOption value=''>Select…</SelectOption>
+              {loader.listSheets().map((s) => (
+                <SelectOption
+                  key={`s-${s}`}
+                  value={`sheet:${s}`}>
+                  Sheet: {s}
+                </SelectOption>
+              ))}
+              {loader.listNamedTables().map((t) => (
+                <SelectOption
+                  key={`t-${t}`}
+                  value={`table:${t}`}>
+                  Table: {t}
+                </SelectOption>
+              ))}
             </InputField>
             <Button
               onClick={loadRows}
@@ -188,64 +195,72 @@ export const ExcelTab: React.FC = () => {
         )}
         {rows.length > 0 && (
           <>
-            <InputField label='Template'>
-              <Select
-                value={template}
-                onChange={setTemplate}
-                aria-label='Template'>
-                {Object.keys(templateManager.templates).map((tpl) => (
-                  <SelectOption
-                    key={tpl}
-                    value={tpl}>
-                    {tpl}
-                  </SelectOption>
-                ))}
-              </Select>
+            <InputField
+              label='Template'
+              as={Select}
+              options={{
+                'value': template,
+                'onChange': setTemplate,
+                'aria-label': 'Template',
+              }}>
+              {Object.keys(templateManager.templates).map((tpl) => (
+                <SelectOption
+                  key={tpl}
+                  value={tpl}>
+                  {tpl}
+                </SelectOption>
+              ))}
             </InputField>
-            <InputField label='Label column'>
-              <Select
-                value={labelColumn}
-                onChange={setLabelColumn}
-                aria-label='Label column'>
-                <SelectOption value=''>None</SelectOption>
-                {columns.map((c) => (
-                  <SelectOption
-                    key={`l-${c}`}
-                    value={c}>
-                    {c}
-                  </SelectOption>
-                ))}
-              </Select>
+            <InputField
+              label='Label column'
+              as={Select}
+              options={{
+                'value': labelColumn,
+                'onChange': setLabelColumn,
+                'aria-label': 'Label column',
+              }}>
+              <SelectOption value=''>None</SelectOption>
+              {columns.map((c) => (
+                <SelectOption
+                  key={`l-${c}`}
+                  value={c}>
+                  {c}
+                </SelectOption>
+              ))}
             </InputField>
-            <InputField label='Template column'>
-              <Select
-                value={templateColumn}
-                onChange={setTemplateColumn}
-                aria-label='Template column'>
-                <SelectOption value=''>None</SelectOption>
-                {columns.map((c) => (
-                  <SelectOption
-                    key={`tcol-${c}`}
-                    value={c}>
-                    {c}
-                  </SelectOption>
-                ))}
-              </Select>
+            <InputField
+              label='Template column'
+              as={Select}
+              options={{
+                'value': templateColumn,
+                'onChange': setTemplateColumn,
+                'aria-label': 'Template column',
+              }}>
+              <SelectOption value=''>None</SelectOption>
+              {columns.map((c) => (
+                <SelectOption
+                  key={`tcol-${c}`}
+                  value={c}>
+                  {c}
+                </SelectOption>
+              ))}
             </InputField>
-            <InputField label='ID column'>
-              <Select
-                value={idColumn}
-                onChange={setIdColumn}
-                aria-label='ID column'>
-                <SelectOption value=''>None</SelectOption>
-                {columns.map((c) => (
-                  <SelectOption
-                    key={`i-${c}`}
-                    value={c}>
-                    {c}
-                  </SelectOption>
-                ))}
-              </Select>
+            <InputField
+              label='ID column'
+              as={Select}
+              options={{
+                'value': idColumn,
+                'onChange': setIdColumn,
+                'aria-label': 'ID column',
+              }}>
+              <SelectOption value=''>None</SelectOption>
+              {columns.map((c) => (
+                <SelectOption
+                  key={`i-${c}`}
+                  value={c}>
+                  {c}
+                </SelectOption>
+              ))}
             </InputField>
             <ul style={{ maxHeight: 160, overflowY: 'auto' }}>
               {rows.map((r, i) => (

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -113,22 +113,28 @@ export const SearchTab: React.FC = () => {
     <TabPanel tabId='search'>
       <Panel padding='small'>
         <TabGrid columns={2}>
-          <InputField label='Find'>
-            <input
-              className='input input-small'
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder='Search board text'
-            />
-          </InputField>
-          <InputField label='Replace'>
-            <input
-              className='input input-small'
-              value={replacement}
-              onChange={(e) => setReplacement(e.target.value)}
-              placeholder='Replacement text'
-            />
-          </InputField>
+          <InputField
+            label='Find'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: query,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setQuery(e.target.value),
+              placeholder: 'Search board text',
+            }}
+          />
+          <InputField
+            label='Replace'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: replacement,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setReplacement(e.target.value),
+              placeholder: 'Replacement text',
+            }}
+          />
           <div className='form-group-small'>
             <Checkbox
               label='Case sensitive'
@@ -159,46 +165,61 @@ export const SearchTab: React.FC = () => {
               ))}
             </div>
           </div>
-          <InputField label='Tag IDs'>
-            <input
-              className='input input-small'
-              value={tagIds}
-              onChange={(e) => setTagIds(e.target.value)}
-              placeholder='Comma separated'
-            />
-          </InputField>
-          <InputField label='Background colour'>
-            <input
-              className='input input-small'
-              value={backgroundColor}
-              onChange={(e) => setBackgroundColor(e.target.value)}
-              placeholder='CSS colour'
-            />
-          </InputField>
-          <InputField label='Assignee ID'>
-            <input
-              className='input input-small'
-              value={assignee}
-              onChange={(e) => setAssignee(e.target.value)}
-              placeholder='User ID'
-            />
-          </InputField>
-          <InputField label='Creator ID'>
-            <input
-              className='input input-small'
-              value={creator}
-              onChange={(e) => setCreator(e.target.value)}
-              placeholder='User ID'
-            />
-          </InputField>
-          <InputField label='Last modified by'>
-            <input
-              className='input input-small'
-              value={lastModifiedBy}
-              onChange={(e) => setLastModifiedBy(e.target.value)}
-              placeholder='User ID'
-            />
-          </InputField>
+          <InputField
+            label='Tag IDs'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: tagIds,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setTagIds(e.target.value),
+              placeholder: 'Comma separated',
+            }}
+          />
+          <InputField
+            label='Background colour'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: backgroundColor,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setBackgroundColor(e.target.value),
+              placeholder: 'CSS colour',
+            }}
+          />
+          <InputField
+            label='Assignee ID'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: assignee,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setAssignee(e.target.value),
+              placeholder: 'User ID',
+            }}
+          />
+          <InputField
+            label='Creator ID'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: creator,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setCreator(e.target.value),
+              placeholder: 'User ID',
+            }}
+          />
+          <InputField
+            label='Last modified by'
+            as='input'
+            options={{
+              className: 'input input-small',
+              value: lastModifiedBy,
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setLastModifiedBy(e.target.value),
+              placeholder: 'User ID',
+            }}
+          />
           <Paragraph data-testid='match-count'>
             Matches: {results.length}
           </Paragraph>

--- a/tests/inputfield.test.tsx
+++ b/tests/inputfield.test.tsx
@@ -8,7 +8,7 @@ test('renders label and input', () => {
   render(
     <InputField
       label='Name'
-      value='x'
+      options={{ value: 'x' }}
       onChange={() => {}}
     />,
   );
@@ -31,14 +31,13 @@ test('calls onChange with value', () => {
   expect(handler).toHaveBeenCalledWith('42');
 });
 
-test('supports custom child element', () => {
+test('supports custom component', () => {
   render(
-    <InputField label='File'>
-      <input
-        data-testid='custom'
-        type='file'
-      />
-    </InputField>,
+    <InputField
+      label='File'
+      as='input'
+      options={{ 'data-testid': 'custom', 'type': 'file' }}
+    />,
   );
   const input = screen.getByTestId('custom');
   const label = screen.getByText('File');


### PR DESCRIPTION
## Summary
- update InputField to accept `as` and `options` props
- refactor components and pages to use new InputField API
- document new usage in README and COMPONENTS guide
- adjust InputField tests

## Testing
- `npm run prettier --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run typecheck --silent`
- `npm test --silent` *(fails: The `className` and `style` attributes are not available in styled components)*

------
https://chatgpt.com/codex/tasks/task_e_6865171fc724832badf894a30e180c50