### PR TITLE
Add icon support to Button component

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -8,7 +8,8 @@ Practical, step-by-step reference for junior engineers who build the add-on UI.
 Explains how to:
 
 - Consume the **Mirotone CSS** design language. ([mirotone.xyz][1])
-- Use the lightweight wrapper components in `src/ui/components/legacy`.
+- Use the lightweight wrapper components under `src/ui/components`. Legacy shims
+  live in `src/ui/components/legacy`.
 - Meet the accessibility, performance and quality gates defined in
   **ARCHITECTURE.md** and **FOUNDATION.md**.
 
@@ -58,9 +59,9 @@ prop. Set `iconPosition="end"` to place the icon after the children.
 >
 > 1. Write semantic HTML (for example `<div class="grid grid-gap-8">`).
 > 2. Apply the documented Mirotone CSS classes.
-> 3. Encapsulate in a small local React component under
->    `src/ui/components/legacy/` so that future upgrades swap the implementation
->    behind a stable API.
+> 3. Encapsulate in a small local React component under `src/ui/components/` so
+>    that future upgrades swap the implementation behind a stable API. Previous
+>    wrappers remain available in `src/ui/components/legacy/`.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -35,23 +35,24 @@ import 'mirotone/dist/styles.css';
 Only props that junior devs **must** supply are shown. Use the wrapper
 components or compose manually with Mirotone CSS.
 
-| Name           | Core props                 | Variants                  | Default height (px) |
-| -------------- | -------------------------- | ------------------------- | ------------------- |
-| **Button**     | label, onClick, disabled   | primary, secondary, ghost | 32                  |
-| **InputField** | value, onChange            | text, number              | 32                  |
-| **Select**     | options, value, onChange   | single, multi             | 32                  |
-| **Checkbox**   | checked, onChange          | —                         | 20                  |
-| **Modal**      | title, isOpen, onClose     | small, medium             | auto                |
-| _SidebarTab_   | id, icon, title            | persistent, modal         | fill                |
-| _TabBar_       | tabs, tab, onChange, size? | regular, small            | 48                  |
-| **Grid**       | gap, columns               | responsive                | n/a                 |
-| **Stack**      | gap, direction             | vertical, horizontal      | n/a                 |
-| **Cluster**    | gap, align                 | left, right, centre       | n/a                 |
-| **TabGrid**    | columns, className?        | —                         | n/a                 |
+| Name           | Core props                      | Variants                  | Default height (px) |
+| -------------- | ------------------------------- | ------------------------- | ------------------- |
+| **Button**     | label, onClick, disabled, icon? | primary, secondary, ghost | 32                  |
+| **InputField** | value, onChange                 | text, number              | 32                  |
+| **Select**     | options, value, onChange        | single, multi             | 32                  |
+| **Checkbox**   | checked, onChange               | —                         | 20                  |
+| **Modal**      | title, isOpen, onClose          | small, medium             | auto                |
+| _SidebarTab_   | id, icon, title                 | persistent, modal         | fill                |
+| _TabBar_       | tabs, tab, onChange, size?      | regular, small            | 48                  |
+| **Grid**       | gap, columns                    | responsive                | n/a                 |
+| **Stack**      | gap, direction                  | vertical, horizontal      | n/a                 |
+| **Cluster**    | gap, align                      | left, right, centre       | n/a                 |
+| **TabGrid**    | columns, className?             | —                         | n/a                 |
 
 The **TabBar** component now covers both sidebar and nested navigation. Pass the
 current tab id via `tab` and handle selection with `onChange`. Use
-`size='small'` for compact nested tab sets.
+`size='small'` for compact nested tab sets. Buttons accept an optional `icon`
+prop. Set `iconPosition="end"` to place the icon after the children.
 
 > **When a wrapper is missing**
 >

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -53,7 +53,9 @@ components or compose manually with Mirotone CSS.
 The **TabBar** component now covers both sidebar and nested navigation. Pass the
 current tab id via `tab` and handle selection with `onChange`. Use
 `size='small'` for compact nested tab sets. Buttons accept an optional `icon`
-prop. Set `iconPosition="end"` to place the icon after the children.
+prop. Set `iconPosition="end"` to place the icon after the children. Buttons use
+`--space-small` as default padding and you can override colours or borders via
+the `style` prop.
 
 > **When a wrapper is missing**
 >

--- a/src/ui/components/Button.tsx
+++ b/src/ui/components/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Icon } from './legacy/Icon';
+import { tokens } from '../tokens';
 
 export type ButtonProps = Readonly<
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -17,19 +18,25 @@ export type ButtonProps = Readonly<
      * Defaults to `start`.
      */
     iconPosition?: 'start' | 'end';
+    /** Optional padding override, defaults to tokens.space.small. */
+    padding?: string;
   }
 >;
 
 /**
  * Basic design-system button composed from Mirotone utility classes.
  * Supports optional start or end icons.
+ * Padding defaults to `tokens.space.small`. Supply `style` overrides to
+ * customise colour, font or border.
  */
 export function Button({
   variant = 'primary',
   size,
   icon,
   iconPosition = 'start',
+  padding = tokens.space.small,
   className = '',
+  style,
   children,
   ...props
 }: ButtonProps): React.JSX.Element {
@@ -48,6 +55,7 @@ export function Button({
   return (
     <button
       className={classes}
+      style={{ padding, ...style }}
       {...props}>
       {icons.start}
       {children}

--- a/src/ui/components/Button.tsx
+++ b/src/ui/components/Button.tsx
@@ -1,30 +1,57 @@
 import React from 'react';
+import { Icon } from './legacy/Icon';
 
 export type ButtonProps = Readonly<
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    /** Visual style variant. */
     variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'danger';
     /**
      * Optional size override. When omitted, primary buttons default to
      * `medium` and all others use `small`.
      */
     size?: 'small' | 'medium';
+    /** Optional icon displayed inside the button. */
+    icon?: string;
+    /**
+     * Position of the icon relative to children.
+     * Defaults to `start`.
+     */
+    iconPosition?: 'start' | 'end';
   }
 >;
 
-/** Basic button styled with Mirotone utility classes. */
+/**
+ * Basic design-system button composed from Mirotone utility classes.
+ * Supports optional start or end icons.
+ */
 export function Button({
   variant = 'primary',
   size,
+  icon,
+  iconPosition = 'start',
   className = '',
+  children,
   ...props
 }: ButtonProps): React.JSX.Element {
   const finalSize = size ?? (variant === 'primary' ? 'medium' : 'small');
   const classes =
     `button button-${variant} button-${finalSize} ${className}`.trim();
+
+  const icons: Record<'start' | 'end', React.ReactNode> = {
+    start: null,
+    end: null,
+  };
+  if (icon) {
+    icons[iconPosition] = <Icon name={icon} />;
+  }
+
   return (
     <button
       className={classes}
-      {...props}
-    />
+      {...props}>
+      {icons.start}
+      {children}
+      {icons.end}
+    </button>
   );
 }

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Button, Icon, InputField, Paragraph, Text } from './legacy';
+import { InputField, Paragraph, Text } from './legacy';
+import { Button } from './Button';
 import { getDropzoneStyle } from '../hooks/ui-utils';
 import { tokens } from '../tokens';
 
@@ -45,8 +46,9 @@ export function JsonDropZone({
           <Paragraph className='dnd-text'>Drop your JSON file here</Paragraph>
         ) : (
           <div style={{ padding: tokens.space.small }}>
-            <Button variant='primary'>
-              <Icon name='upload' />
+            <Button
+              icon='upload'
+              variant='primary'>
               <Text>Select JSON file</Text>
             </Button>
             <Paragraph className='dnd-text'>

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from './legacy';
+import { Button } from './Button';
 
 export interface SegmentedOption {
   readonly label: string;

--- a/src/ui/components/legacy/Button.tsx
+++ b/src/ui/components/legacy/Button.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon } from './Icon';
 
 export type ButtonProps = Readonly<
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -8,23 +9,50 @@ export type ButtonProps = Readonly<
      * `medium` and all others use `small`.
      */
     size?: 'small' | 'medium';
+    /** Optional icon displayed inside the button. */
+    icon?: string;
+    /**
+     * Position of the icon relative to children.
+     * Defaults to `start`.
+     */
+    iconPosition?: 'start' | 'end';
   }
 >;
 
-/** Basic button styled with Mirotone utility classes. */
+/**
+ * Basic button styled with Mirotone utility classes.
+ * Supports optional start or end icons.
+ */
 export function Button({
   variant = 'primary',
   size,
+  icon,
+  iconPosition = 'start',
   className = '',
+  children,
   ...props
 }: ButtonProps): React.JSX.Element {
   const finalSize = size ?? (variant === 'primary' ? 'medium' : 'small');
   const classes =
     `button button-${variant} button-${finalSize} ${className}`.trim();
+
+  let startIcon: React.JSX.Element | null = null;
+  let endIcon: React.JSX.Element | null = null;
+  if (icon) {
+    if (iconPosition === 'start') {
+      startIcon = <Icon name={icon} />;
+    } else {
+      endIcon = <Icon name={icon} />;
+    }
+  }
+
   return (
     <button
       className={classes}
-      {...props}
-    />
+      {...props}>
+      {startIcon}
+      {children}
+      {endIcon}
+    </button>
   );
 }

--- a/src/ui/pages/ArrangeTab.tsx
+++ b/src/ui/pages/ArrangeTab.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import {
-  Button,
   Checkbox,
   InputField,
-  Icon,
   Select,
   SelectOption,
   Text,
 } from '../components/legacy';
+import { Button } from '../components/Button';
 import { TabGrid } from '../components/TabGrid';
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
@@ -113,12 +112,10 @@ export const ArrangeTab: React.FC = () => {
         )}
         <div className='buttons'>
           <Button
+            icon='grid'
             onClick={applyGrid}
             variant='primary'>
-            <React.Fragment>
-              <Icon name='grid' />
-              <Text>Arrange Grid</Text>
-            </React.Fragment>
+            <Text>Arrange Grid</Text>
           </Button>
         </div>
 
@@ -152,12 +149,10 @@ export const ArrangeTab: React.FC = () => {
           </InputField>
           <div className='buttons'>
             <Button
+              icon='arrow-right'
               onClick={applySpacing}
               variant='primary'>
-              <React.Fragment>
-                <Icon name='arrow-right' />
-                <Text>Distribute</Text>
-              </React.Fragment>
+              <Text>Distribute</Text>
             </Button>
           </div>
         </div>

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
-import {
-  Button,
-  Checkbox,
-  InputField,
-  Paragraph,
-  Text,
-  Icon,
-} from '../components/legacy';
+import { Checkbox, InputField, Paragraph, Text } from '../components/legacy';
+import { Button } from '../components/Button';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
 import { TabGrid } from '../components/TabGrid';
@@ -101,12 +95,10 @@ export const CardsTab: React.FC = () => {
           )}
           <div className='buttons'>
             <Button
+              icon='plus'
               onClick={handleCreate}
               variant='primary'>
-              <React.Fragment key='.0'>
-                <Icon name='plus' />
-                <Text>Create Cards</Text>
-              </React.Fragment>
+              <Text>Create Cards</Text>
             </Button>
             {progress > 0 && progress < 100 && (
               <progress
@@ -126,14 +118,12 @@ export const CardsTab: React.FC = () => {
             )}
             {lastProc && (
               <Button
+                icon='undo'
                 onClick={() => {
                   undoLastImport(lastProc, () => setLastProc(undefined));
                 }}
                 variant='secondary'>
-                <React.Fragment key='.0'>
-                  <Icon name='undo' />
-                  <Text>Undo Last Import</Text>
-                </React.Fragment>
+                <Text>Undo Last Import</Text>
               </Button>
             )}
           </div>

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import {
-  Button,
   Checkbox,
   InputField,
   Paragraph,
   Select,
   SelectOption,
   Text,
-  Icon,
 } from '../components/legacy';
+import { Button } from '../components/Button';
 import { tokens } from '../tokens';
 import {
   excelLoader,
@@ -264,12 +263,10 @@ export const ExcelTab: React.FC = () => {
             </ul>
             <div className='buttons'>
               <Button
+                icon='plus'
                 onClick={handleCreate}
                 variant='primary'>
-                <React.Fragment key='.0'>
-                  <Icon name='plus' />
-                  <Text>Create Nodes</Text>
-                </React.Fragment>
+                <Text>Create Nodes</Text>
               </Button>
             </div>
           </>

--- a/src/ui/pages/FramesTab.tsx
+++ b/src/ui/pages/FramesTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Icon, InputField, Text, Heading } from '../components/legacy';
+import { InputField, Text, Heading } from '../components/legacy';
+import { Button } from '../components/Button';
 import {
   lockSelectedFrames,
   renameSelectedFrames,
@@ -33,12 +34,10 @@ export const FramesTab: React.FC = () => {
           </InputField>
           <div className='buttons'>
             <Button
+              icon='edit'
               onClick={rename}
               variant='primary'>
-              <React.Fragment key='.0'>
-                <Icon name='edit' />
-                <Text>Rename Frames</Text>
-              </React.Fragment>
+              <Text>Rename Frames</Text>
             </Button>
           </div>
         </section>
@@ -46,12 +45,10 @@ export const FramesTab: React.FC = () => {
           <Heading level={2}>Lock Frames</Heading>
           <div className='buttons'>
             <Button
+              icon='lock'
               onClick={lock}
               variant='secondary'>
-              <React.Fragment key='.1'>
-                <Icon name='lock' />
-                <Text>Lock Selected</Text>
-              </React.Fragment>
+              <Text>Lock Selected</Text>
             </Button>
           </div>
         </section>

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import {
-  Button,
   FormGroup,
   InputField,
   Select,
   SelectOption,
   Paragraph,
   Heading,
-  Icon,
   Text,
 } from '../components/legacy';
+import { Button } from '../components/Button';
 import {
   applySizeToSelection,
   copySizeFromSelection,
@@ -210,20 +209,16 @@ export const ResizeTab: React.FC = () => {
       </section>
       <div className='buttons'>
         <Button
+          icon='arrow-right'
           onClick={apply}
           variant='primary'>
-          <React.Fragment key='.0'>
-            <Icon name='arrow-right' />
-            <Text>Apply Size</Text>
-          </React.Fragment>
+          <Text>Apply Size</Text>
         </Button>
         <Button
+          icon={copiedSize ? 'undo' : 'duplicate'}
           onClick={copiedSize ? resetCopy : copy}
           variant='secondary'>
-          <React.Fragment key='.0'>
-            <Icon name={copiedSize ? 'undo' : 'duplicate'} />
-            <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
-          </React.Fragment>
+          <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
         </Button>
       </div>
     </TabPanel>

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
-import {
-  Button,
-  Checkbox,
-  InputField,
-  Paragraph,
-  Icon,
-  Text,
-} from '../components/legacy';
+import { Checkbox, InputField, Paragraph, Text } from '../components/legacy';
+import { Button } from '../components/Button';
 import { TabGrid } from '../components/TabGrid';
 import type { SearchOptions } from '../../board/search-tools';
 import {
@@ -209,30 +203,24 @@ export const SearchTab: React.FC = () => {
         </Paragraph>
         <div className='buttons'>
           <Button
+            icon='chevron-right'
             onClick={nextMatch}
             disabled={!results.length}
             variant='secondary'>
-            <React.Fragment key='.0'>
-              <Icon name='chevron-right' />
-              <Text>Next</Text>
-            </React.Fragment>
+            <Text>Next</Text>
           </Button>
           <Button
+            icon='edit'
             onClick={replaceCurrent}
             disabled={!results.length}
             variant='secondary'>
-            <React.Fragment key='.1'>
-              <Icon name='edit' />
-              <Text>Replace</Text>
-            </React.Fragment>
+            <Text>Replace</Text>
           </Button>
           <Button
+            icon='arrow-right'
             onClick={replaceAll}
             variant='primary'>
-            <React.Fragment key='.2'>
-              <Icon name='arrow-right' />
-              <Text>Replace All</Text>
-            </React.Fragment>
+            <Text>Replace All</Text>
           </Button>
         </div>
       </TabGrid>

--- a/src/ui/pages/StructuredTab.tsx
+++ b/src/ui/pages/StructuredTab.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import {
-  Button,
   Checkbox,
-  Icon,
   InputField,
   Paragraph,
   Select,
   SelectOption,
   Text,
 } from '../components/legacy';
+import { Button } from '../components/Button';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
 import { TabGrid } from '../components/TabGrid';
@@ -340,12 +339,10 @@ export const StructuredTab: React.FC = () => {
           </details>
           <div className='buttons'>
             <Button
+              icon='plus'
               onClick={handleCreate}
               variant='primary'>
-              <React.Fragment key='.0'>
-                <Icon name='plus' />
-                <Text>Create Diagram</Text>
-              </React.Fragment>
+              <Text>Create Diagram</Text>
             </Button>
             {progress > 0 && progress < 100 && (
               <progress
@@ -356,14 +353,12 @@ export const StructuredTab: React.FC = () => {
             {error && <Paragraph className='error'>{error}</Paragraph>}
             {lastProc && (
               <Button
+                icon='undo'
                 onClick={() => {
                   undoLastImport(lastProc, () => setLastProc(undefined));
                 }}
                 variant='secondary'>
-                <React.Fragment key='.0'>
-                  <Icon name='undo' />
-                  <Text>Undo Last Import</Text>
-                </React.Fragment>
+                <Text>Undo Last Import</Text>
               </Button>
             )}
           </div>

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Icon, InputField, Text, Heading } from '../components/legacy';
+import { InputField, Text, Heading } from '../components/legacy';
+import { Button } from '../components/Button';
 import { tweakFillColor, extractFillColor } from '../../board/style-tools';
 import { applyStylePreset, presetStyle } from '../../board/format-tools';
 import { STYLE_PRESET_NAMES, stylePresets } from '../style-presets';
@@ -82,14 +83,12 @@ export const StyleTab: React.FC = () => {
           </InputField>
           <div className='buttons'>
             <Button
+              icon='parameters'
               onClick={apply}
               type='button'
               variant='primary'
               className='button-small'>
-              <React.Fragment>
-                <Icon name='parameters' />
-                <Text>Apply</Text>
-              </React.Fragment>
+              <Text>Apply</Text>
             </Button>
           </div>
           <Heading level={2}>Style presets</Heading>

--- a/tests/button-icon.test.tsx
+++ b/tests/button-icon.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Button } from '../src/ui/components/legacy/Button';
+import { Button } from '../src/ui/components/Button';
 
 test('renders start icon before children', () => {
   const { getByRole } = render(<Button icon='edit'>Edit</Button>);

--- a/tests/button-icon.test.tsx
+++ b/tests/button-icon.test.tsx
@@ -1,0 +1,23 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Button } from '../src/ui/components/legacy/Button';
+
+test('renders start icon before children', () => {
+  const { getByRole } = render(<Button icon='edit'>Edit</Button>);
+  const btn = getByRole('button');
+  expect(btn.firstElementChild).toHaveClass('icon-edit');
+});
+
+test('renders end icon after children', () => {
+  const { getByRole } = render(
+    <Button
+      icon='edit'
+      iconPosition='end'>
+      Edit
+    </Button>,
+  );
+  const btn = getByRole('button');
+  expect(btn.lastElementChild).toHaveClass('icon-edit');
+});

--- a/tests/button-size.test.tsx
+++ b/tests/button-size.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Button } from '../src/ui/components/legacy/Button';
+import { Button } from '../src/ui/components/Button';
 
 it('defaults to medium size for primary', () => {
   const { getByRole } = render(<Button variant='primary'>Ok</Button>);

--- a/tests/button-style.test.tsx
+++ b/tests/button-style.test.tsx
@@ -1,0 +1,18 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Button } from '../src/ui/components/Button';
+import { tokens } from '../src/ui/tokens';
+
+test('defaults to space-small padding', () => {
+  const { getByRole } = render(<Button>Ok</Button>);
+  expect(getByRole('button')).toHaveStyle(`padding: ${tokens.space.small}`);
+});
+
+test('applies style overrides', () => {
+  const { getByRole } = render(
+    <Button style={{ color: 'red', borderColor: 'blue' }}>Ok</Button>,
+  );
+  expect(getByRole('button')).toHaveStyle('border-color: blue');
+});


### PR DESCRIPTION
## Summary
- support optional icons in legacy `Button`
- document the new props in `COMPONENTS.md`
- test icon rendering positions

## Testing
- `npm install --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686526435500832ba968ca170d178f6f