### PR TITLE
feat(ui): support button icons

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -38,19 +38,19 @@ import '@mirohq/design-system-themes/light.css';
 Only props that junior devs **must** supply are shown. Use the wrapper
 components or compose using the design system tokens.
 
-| Name                          | Core props                 | Variants                  | Default height (px) |
-| ----------------------------- | -------------------------- | ------------------------- | ------------------- |
-| **Button**                    | label, onClick, disabled   | primary, secondary, ghost | 32                  |
-| **Input**                     | value, onChange            | text, number              | 32                  |
-| **Select**                    | options, value, onChange   | single, multi             | 32                  |
-| **Switch** (Checkbox wrapper) | checked, onChange          | medium, large             | 24                  |
-| **Modal**                     | title, isOpen, onClose     | small, medium             | auto                |
-| _SidebarTab_                  | id, icon, title            | persistent, modal         | fill                |
-| _TabBar_                      | tabs, tab, onChange, size? | regular, small            | 48                  |
-| **Grid**                      | gap, columns               | responsive                | n/a                 |
-| **Stack**                     | gap, direction             | vertical, horizontal      | n/a                 |
-| **Cluster**                   | gap, align                 | left, right, centre       | n/a                 |
-| **TabGrid**                   | columns, className?        | —                         | n/a                 |
+| Name                          | Core props                      | Variants                  | Default height (px) |
+| ----------------------------- | ------------------------------- | ------------------------- | ------------------- |
+| **Button**                    | label, onClick, disabled, icon? | primary, secondary, ghost | 32                  |
+| **Input**                     | value, onChange                 | text, number              | 32                  |
+| **Select**                    | options, value, onChange        | single, multi             | 32                  |
+| **Switch** (Checkbox wrapper) | checked, onChange               | medium, large             | 24                  |
+| **Modal**                     | title, isOpen, onClose          | small, medium             | auto                |
+| _SidebarTab_                  | id, icon, title                 | persistent, modal         | fill                |
+| _TabBar_                      | tabs, tab, onChange, size?      | regular, small            | 48                  |
+| **Grid**                      | gap, columns                    | responsive                | n/a                 |
+| **Stack**                     | gap, direction                  | vertical, horizontal      | n/a                 |
+| **Cluster**                   | gap, align                      | left, right, centre       | n/a                 |
+| **TabGrid**                   | columns, className?             | —                         | n/a                 |
 
 The main navigation now relies on `@mirohq/design-system-tabs`. The custom
 **TabBar** component remains for nested navigation. Pass the current tab id via
@@ -153,6 +153,14 @@ via the `as` prop and provide its props through `options`:
     Save
   </Button>
 </Cluster>
+```
+
+To add an icon use the `icon` prop and optionally `iconPosition='end'`:
+
+```tsx
+import { IconActivity } from '@mirohq/design-system-icons/react';
+
+<Button icon={<IconActivity />}>Activity</Button>;
 ```
 
 ---

--- a/src/ui/components/Button.tsx
+++ b/src/ui/components/Button.tsx
@@ -12,20 +12,49 @@ export type ButtonProps = Readonly<
      * `medium` and all others use `small`.
      */
     size?: 'small' | 'medium';
+    /** Optional icon shown inside the button. */
+    icon?: React.ReactNode;
+    /**
+     * Placement of the icon relative to the label.
+     * @default 'start'
+     */
+    iconPosition?: 'start' | 'end';
   }
 >;
 
 /** Basic button bridging to the design-system implementation. */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button({ variant = 'primary', size, ...props }, ref) {
+  function Button(
+    {
+      variant = 'primary',
+      size,
+      icon,
+      iconPosition = 'start',
+      children,
+      ...props
+    },
+    ref,
+  ) {
     const finalSize = size ?? (variant === 'primary' ? 'medium' : 'small');
+    let start: React.ReactNode = null;
+    let end: React.ReactNode = null;
+    if (icon) {
+      if (iconPosition === 'start') {
+        start = <DSButton.IconSlot key='icon-start'>{icon}</DSButton.IconSlot>;
+      } else if (iconPosition === 'end') {
+        end = <DSButton.IconSlot key='icon-end'>{icon}</DSButton.IconSlot>;
+      }
+    }
     return (
       <DSButton
         ref={ref}
         variant={variant}
         size={finalSize}
-        {...props}
-      />
+        {...props}>
+        {start}
+        <DSButton.Label>{children}</DSButton.Label>
+        {end}
+      </DSButton>
     );
   },
 );

--- a/tests/button-icon.test.tsx
+++ b/tests/button-icon.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Button } from '../src/ui/components/Button';
+import { IconActivity } from '@mirohq/design-system-icons/react';
+
+describe('Button icon support', () => {
+  test('renders start icon by default', () => {
+    render(<Button icon={<IconActivity />}>Hello</Button>);
+    const button = screen.getByRole('button');
+    const icon = button.querySelector('[data-icon-component]');
+    expect(icon).toBeInTheDocument();
+    expect(button.firstChild).toBe(icon?.parentElement);
+  });
+
+  test('renders end icon', () => {
+    render(
+      <Button
+        icon={<IconActivity />}
+        iconPosition='end'>
+        Next
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    const icon = button.querySelector('[data-icon-component]');
+    expect(icon).toBeInTheDocument();
+    expect(button.lastChild).toBe(icon?.parentElement);
+  });
+});


### PR DESCRIPTION
## Summary
- add optional icon props to Button component
- document icon usage in COMPONENTS guide
- test icons inside Button

## Testing
- `npm run typecheck --silent`
- `npm test --silent` *(fails: The `className` and `style` attributes are not available in styled components)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6865b7f04b54832b806279faf1686134