### PR TITLE
Fix sidebar scroll area layout

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -14,12 +14,14 @@
 html,
 body {
   height: 100%;
+  min-height: 100%;
   background: none;
   padding: var(--space-xxsmall);
 }
 
 #root {
   height: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -28,8 +30,14 @@ body {
 
 .scrollable {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   padding-top: var(--space-small);
+}
+
+.scrollable > .buttons {
+  margin-top: auto;
 }
 
 #root .buttons {


### PR DESCRIPTION
## Summary
- ensure body takes full height
- add min-height and flex layout for scrollable sections
- keep bottom buttons pinned to scroll area

## Testing
- `npm run typecheck --silent`
- `npm test --silent` *(fails: Missing "./react" specifier in "@mirohq/design-system-icons" package)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6865ced42250832bbb0a5fcb2346074f