### PR TITLE
Fix border style parsing

### DIFF
--- a/src/board/templates.ts
+++ b/src/board/templates.ts
@@ -119,11 +119,23 @@ export class TemplateManager {
     return token ?? value;
   }
 
-  /** Apply token resolution to all string properties in the provided object. */
+  /**
+   * Convert numeric strings into numbers while leaving other values intact.
+   *
+   * Supports optional `px` units which are stripped off.
+   */
+  private parseNumeric(value: unknown): unknown {
+    if (typeof value !== 'string') return value;
+    const m = value.match(/^(-?\d+(?:\.\d+)?)(px)?$/);
+    return m ? parseFloat(m[1]) : value;
+  }
+
+  /** Apply token and numeric resolution to style values. */
   public resolveStyle(style: Record<string, unknown>): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     Object.entries(style).forEach(([k, v]) => {
-      result[k] = this.resolveToken(v);
+      const token = this.resolveToken(v);
+      result[k] = this.parseNumeric(token);
     });
     return result;
   }

--- a/tests/style-presets.test.ts
+++ b/tests/style-presets.test.ts
@@ -13,9 +13,10 @@ describe('style-presets', () => {
   test('presets derived from templates', () => {
     const tpl = (templatesJson as Record<string, TemplateDefinition>)
       .Technology;
-    const fill = templateManager.resolveStyle(tpl.elements[0].style)
-      .fillColor as string;
-    expect(stylePresets.Technology.fillColor).toBe(fill);
+    const style = templateManager.resolveStyle(tpl.elements[0].style);
+    expect(stylePresets.Technology.fillColor).toBe(style.fillColor);
+    expect(stylePresets.Technology.borderColor).toBe(style.borderColor);
+    expect(stylePresets.Technology.borderWidth).toBe(style.borderWidth);
     expect(STYLE_PRESET_NAMES).toContain('Technology');
   });
 

--- a/tests/templates-functions.test.ts
+++ b/tests/templates-functions.test.ts
@@ -48,4 +48,13 @@ describe('token resolution', () => {
     const style = templateManager.resolveStyle({ gap: 'tokens.space.small' });
     expect(style.gap).toBe('var(--space-small)');
   });
+
+  test('parses numeric values', () => {
+    const style = templateManager.resolveStyle({
+      borderWidth: '2px',
+      borderColor: '#123456',
+    });
+    expect(style.borderWidth).toBe(2);
+    expect(style.borderColor).toBe('#123456');
+  });
 });


### PR DESCRIPTION
## Summary
- handle numeric values in style templates
- test numeric style parsing
- check presets use template border styles

## Testing
- `npm run typecheck --silent` *(fails: Property 'value' is missing in type)*
- `npm test --silent` *(fails: 13 test files failed)*
- `npm run lint --silent` *(fails: 3 errors)*
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866428c37b0832ba80d56dc80611c0b