### PR TITLE
feat(ui): render intro and changelog from markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# Miro JSON Graph Diagram App
+# Quick Tools
 
-This project imports graphs or cards from JSON or Excel files and builds
-diagrams on a Miro board. The application uses the **Eclipse Layout Kernel
-(ELK)** to arrange nodes and edges automatically. Shapes are generated from
-templates and each element can carry metadata that controls its appearance and
-placement.
+Quick Tools imports graphs or cards from JSON or Excel files and builds diagrams
+on a Miro board. The application uses the **Eclipse Layout Kernel (ELK)** to
+arrange nodes and edges automatically. Shapes are generated from templates and
+each element can carry metadata that controls its appearance and placement.
 
 ## Uploading JSON Content
 

--- a/app-manifest.yml
+++ b/app-manifest.yml
@@ -1,4 +1,4 @@
-appName: 'Structured Graph Generator'
+appName: 'Quick Tools'
 sdkVersion: SDK_V2
 sdkUri: 'http://localhost:3000'
 boardPicker:

--- a/app.html
+++ b/app.html
@@ -9,7 +9,7 @@
       href="/src/assets/style.css"
       rel="stylesheet" />
     <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
-    <title>Structured Graph Generator</title>
+    <title>Quick Tools</title>
   </head>
 
   <body>

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -2,11 +2,10 @@
 
 _Explicit UI + interaction walkthrough for every tab (June 2025)_
 
-This document narrows focus to the **ten sidebar tabs** in the
-Structured Diagramming add‑on. Each tab section specifies panel layout, visible
-controls, states, interaction flows, tool‑tips, keyboard shortcuts, and
-validation rules—so any developer can translate designs into code with zero
-ambiguity.
+This document narrows focus to the **ten sidebar tabs** in the Quick Tools
+add‑on. Each tab section specifies panel layout, visible controls, states,
+interaction flows, tool‑tips, keyboard shortcuts and validation rules—so any
+developer can translate designs into code with zero ambiguity.
 
 ---
 

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -66,6 +66,6 @@ see [LAYOUT_OPTIONS.md](LAYOUT_OPTIONS.md).
 
 ---
 
-The UI for template selection is part of the Structured Diagramming add-on
-running on a Miro board. All widgets are created through the Miro Web SDK and
-can be customised by editing the template files.
+The UI for template selection is part of the Quick Tools add-on running on a
+Miro board. All widgets are created through the Miro Web SDK and can be
+customised by editing the template files.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       href="/src/assets/style.css"
       rel="stylesheet" />
     <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
-    <title>Miro Structured Graph Generator</title>
+    <title>Miro Quick Tools</title>
   </head>
 
   <body>
@@ -20,7 +20,7 @@
           src="/src/assets/welcome.png" />
       </div>
       <div class="cs1 ce12">
-        <h1>Structured Graph Generator is running locally</h1>
+        <h1>Quick Tools is running locally</h1>
         <p>
           You can now create your Developer team to get your app running in
           Miro.

--- a/src/ui/components/InputField.tsx
+++ b/src/ui/components/InputField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, Input, Primitive } from '@mirohq/design-system';
+import { Form, Input } from '@mirohq/design-system';
 
 export type InputFieldProps = Readonly<{
   /** Visible label text. */
@@ -15,7 +15,9 @@ export type InputFieldProps = Readonly<{
   /** Optional id forwarded to the control and label. */
   id?: string;
   type?: string;
-  value: string;
+  value?: string;
+  /** Placeholder text for input elements. */
+  placeholder?: string;
 }>;
 
 // Custom class names and inline styles are intentionally excluded so spacing
@@ -33,6 +35,7 @@ export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
       id,
       type,
       value,
+      placeholder,
     },
     ref,
   ) {
@@ -54,23 +57,21 @@ export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
       }
     };
 
+    const Control = Component;
     return (
       <Form.Field>
         <Form.Label htmlFor={inputId}>{label}</Form.Label>
-        <Input
+        <Control
           id={inputId}
+          ref={ref}
+          {...options}
+          placeholder={placeholder}
           onChange={handleChange}
           type={type}
           value={value}>
           {children}
-        </Input>
+        </Control>
       </Form.Field>
     );
-    /**
-        {React.createElement(
-          Component,
-          { id: inputId, ref, ...options, onChange: handleChange },
-          children,
-        )} */
   },
 );

--- a/src/ui/components/IntroScreen.tsx
+++ b/src/ui/components/IntroScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from './Button';
-import { Paragraph } from './Paragraph';
+import { Markdown } from './Markdown';
+import introText from '../intro.md?raw';
 
 export interface IntroScreenProps {
   /** Called when the user chooses to start the app. */
@@ -18,7 +19,7 @@ export function IntroScreen({ onStart }: IntroScreenProps): React.JSX.Element {
     <div
       className='intro-screen'
       data-testid='intro-screen'>
-      <Paragraph>Welcome to Structured Diagram Tools</Paragraph>
+      <Markdown source={introText} />
       <Button
         variant='primary'
         onClick={onStart}

--- a/src/ui/components/Markdown.tsx
+++ b/src/ui/components/Markdown.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { marked } from 'marked';
+
+export interface MarkdownProps {
+  /** Markdown source to convert to HTML. */
+  readonly source: string;
+  /** Optional CSS class for the container. */
+  readonly className?: string;
+}
+
+/**
+ * Renders Markdown content using the `marked` parser.
+ * The generated HTML is injected using `dangerouslySetInnerHTML`.
+ */
+export function Markdown({
+  source,
+  className,
+}: MarkdownProps): React.JSX.Element {
+  const html = React.useMemo(() => marked.parse(source), [source]);
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -11,3 +11,4 @@ export { TabPanel } from './TabPanel';
 export { Select, SelectOption } from './Select';
 export { Paragraph } from './Paragraph';
 export { IntroScreen } from './IntroScreen';
+export { Markdown } from './Markdown';

--- a/src/ui/intro.md
+++ b/src/ui/intro.md
@@ -1,0 +1,5 @@
+Welcome to **Quick Tools**.
+
+This add-on helps you import, lay out and manage diagrams directly on your Miro
+board. Choose a tab to upload files, tweak layouts or edit metadata once you
+start.

--- a/src/ui/pages/HelpTab.tsx
+++ b/src/ui/pages/HelpTab.tsx
@@ -1,53 +1,63 @@
-import React from 'react';
-import { Paragraph } from '../components';
+import React, { useState } from 'react';
+import { Paragraph, Button, Markdown } from '../components';
 import changelog from '../../../CHANGELOG.md?raw';
 import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
 import { Heading } from '@mirohq/design-system';
 
 /** Static help page summarising diagram options and tools. */
-export const HelpTab: React.FC = () => (
-  <TabPanel tabId='help'>
-    <Heading level={2}>Getting Started</Heading>
-    <Paragraph>
-      Use the Create tab to import diagrams or cards from a JSON file. Nodes may
-      define templates, labels and ELK options to influence placement.
-    </Paragraph>
-    <Heading level={2}>Diagram Layout Options</Heading>
-    <ul className='list'>
-      <li>
-        <strong>Layered</strong> – Flow diagrams with layers
-      </li>
-      <li>
-        <strong>Tree</strong> – Compact hierarchical tree
-      </li>
-      <li>
-        <strong>Grid</strong> – Organic force-directed grid
-      </li>
-      <li>
-        <strong>Nested</strong> – Containers sized to fit children
-      </li>
-      <li>
-        <strong>Radial</strong> – Circular layout around a hub
-      </li>
-      <li>
-        <strong>Box</strong> – Uniform box grid
-      </li>
-      <li>
-        <strong>Rect Packing</strong> – Fits rectangles within parents
-      </li>
-    </ul>
-    <Heading level={2}>Other Tools</Heading>
-    <ul className='list'>
-      <li>Resize – adjust widget size or copy from selection.</li>
-      <li>Frames – rename selected frames.</li>
-      <li>Colours – modify fill colours.</li>
-      <li>Arrange – grid and spacing tools.</li>
-    </ul>
-    <Heading level={2}>Changelog</Heading>
-    <pre style={{ whiteSpace: 'pre-wrap' }}>{changelog}</pre>
-  </TabPanel>
-);
+export const HelpTab: React.FC = () => {
+  const [showLog, setShowLog] = useState(false);
+
+  return (
+    <TabPanel tabId='help'>
+      <Heading level={2}>Getting Started</Heading>
+      <Paragraph>
+        Use the Create tab to import diagrams or cards from a JSON file. Nodes
+        may define templates, labels and ELK options to influence placement.
+      </Paragraph>
+      <Heading level={2}>Diagram Layout Options</Heading>
+      <ul className='list'>
+        <li>
+          <strong>Layered</strong> – Flow diagrams with layers
+        </li>
+        <li>
+          <strong>Tree</strong> – Compact hierarchical tree
+        </li>
+        <li>
+          <strong>Grid</strong> – Organic force-directed grid
+        </li>
+        <li>
+          <strong>Nested</strong> – Containers sized to fit children
+        </li>
+        <li>
+          <strong>Radial</strong> – Circular layout around a hub
+        </li>
+        <li>
+          <strong>Box</strong> – Uniform box grid
+        </li>
+        <li>
+          <strong>Rect Packing</strong> – Fits rectangles within parents
+        </li>
+      </ul>
+      <Heading level={2}>Other Tools</Heading>
+      <ul className='list'>
+        <li>Resize – adjust widget size or copy from selection.</li>
+        <li>Frames – rename selected frames.</li>
+        <li>Colours – modify fill colours.</li>
+        <li>Arrange – grid and spacing tools.</li>
+      </ul>
+      <Heading level={2}>Changelog</Heading>
+      <Button
+        variant='secondary'
+        onClick={() => setShowLog((v) => !v)}
+        data-testid='toggle-changelog'>
+        {showLog ? 'Hide' : 'Show'} Changelog
+      </Button>
+      {showLog && <Markdown source={changelog} />}
+    </TabPanel>
+  );
+};
 
 export const tabDef: TabTuple = [
   99,

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -149,7 +149,7 @@ export const ResizeTab: React.FC = () => {
             label='Width:'
             type='number'
             value={String(size.width)}
-            onChange={(e) => update('width')(e.target.value)}
+            onChange={(v) => update('width')(v)}
             placeholder='Width (board units)'></InputField>
         </Grid.Item>
         <Grid.Item

--- a/tests/help-tab.test.tsx
+++ b/tests/help-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { HelpTab } from '../src/ui/pages/HelpTab';
 
@@ -12,7 +12,10 @@ describe('HelpTab', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/compact hierarchical tree/i)).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: /changelog/i }),
+      screen.getByRole('button', { name: /show changelog/i }),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/unreleased/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /show changelog/i }));
+    expect(screen.getByText(/unreleased/i)).toBeInTheDocument();
   });
 });

--- a/tests/intro-screen.test.tsx
+++ b/tests/intro-screen.test.tsx
@@ -8,6 +8,7 @@ describe('IntroScreen', () => {
   test('calls onStart when button clicked', () => {
     const spy = vi.fn();
     render(<IntroScreen onStart={spy} />);
+    expect(screen.getByText(/Welcome to Quick Tools/i)).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('start-button'));
     expect(spy).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- introduce Markdown component for converting markdown to HTML
- display intro screen text from `src/ui/intro.md`
- toggle and render changelog markdown in Help tab
- update Quick Tools branding across docs and manifest
- fix InputField types and resize tab handler

## Testing
- `npm run typecheck --silent`
- `npm test --silent` *(fails: 24 failed, 395 passed)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68664226a560832bba423456b207a739