### PR TITLE
Fix file upload handler

### DIFF
--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -11,7 +11,12 @@ export type JsonDropZoneProps = Readonly<{
   onFiles: (files: File[]) => void;
 }>;
 
-/** Dropzone for importing JSON files. */
+/**
+ * Dropzone for importing a single JSON file.
+ *
+ * The hidden input forwards its change event to react-dropzone so both
+ * drag-and-drop and file picker interactions invoke `onFiles` uniformly.
+ */
 export function JsonDropZone({
   onFiles,
 }: JsonDropZoneProps): React.JSX.Element {

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -21,7 +21,7 @@ export function JsonDropZone({
     onDrop: onFiles,
   });
 
-  const style = React.useMemo(() => {
+  const dropzoneStyle = React.useMemo(() => {
     let state: Parameters<typeof getDropzoneStyle>[0] = 'base';
     if (dropzone.isDragReject) {
       state = 'reject';
@@ -34,12 +34,13 @@ export function JsonDropZone({
   return (
     <>
       <div
-        {...dropzone.getRootProps({ style })}
+        {...dropzone.getRootProps({ style: dropzoneStyle })}
         aria-label='File drop area'
         aria-describedby='dropzone-instructions'>
         {(() => {
           const { onChange, ...rest } = dropzone.getInputProps();
           return (
+            // Hidden file input so selecting a file triggers drop event
             <input
               className='custom-visually-hidden'
               data-testid='file-input'

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -36,25 +36,22 @@ export function JsonDropZone({
     return getDropzoneStyle(state);
   }, [dropzone.isDragAccept, dropzone.isDragReject]);
 
+  const { onChange, ...fileInputProps } = dropzone.getInputProps();
+
   return (
     <>
       <div
         {...dropzone.getRootProps({ style: dropzoneStyle })}
         aria-label='File drop area'
         aria-describedby='dropzone-instructions'>
-        {(() => {
-          const { onChange, ...rest } = dropzone.getInputProps();
-          return (
-            // Hidden file input so selecting a file triggers drop event
-            <input
-              className='custom-visually-hidden'
-              data-testid='file-input'
-              onChange={onChange}
-              aria-label='JSON file input'
-              {...rest}
-            />
-          );
-        })()}
+        {/* hidden input ensures keyboard selection triggers the drop handler */}
+        <input
+          className='custom-visually-hidden'
+          data-testid='file-input'
+          onChange={onChange}
+          aria-label='JSON file input'
+          {...fileInputProps}
+        />
         {dropzone.isDragAccept ? (
           <Paragraph className='dnd-text'>Drop your JSON file here</Paragraph>
         ) : (

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Button } from './Button';
-import { InputField } from './InputField';
 import { getDropzoneStyle } from '../hooks/ui-utils';
 import { tokens } from '../tokens';
 import { Paragraph } from './Paragraph';
@@ -39,23 +38,14 @@ export function JsonDropZone({
         aria-label='File drop area'
         aria-describedby='dropzone-instructions'>
         {(() => {
-          const {
-            style: _style,
-            className: _class,
-            onChange: _on,
-            ...inputProps
-          } = dropzone.getInputProps({
-            'aria-label': 'JSON file input',
-          }) as Record<string, unknown>;
-          void _style;
-          void _class;
-          void _on;
+          const { onChange, ...rest } = dropzone.getInputProps();
           return (
-            <InputField
-              label='JSON file'
-              type='file'
+            <input
+              className='custom-visually-hidden'
               data-testid='file-input'
-              {...inputProps}
+              onChange={onChange}
+              aria-label='JSON file input'
+              {...rest}
             />
           );
         })()}

--- a/tests/intro-screen.test.tsx
+++ b/tests/intro-screen.test.tsx
@@ -8,7 +8,8 @@ describe('IntroScreen', () => {
   test('calls onStart when button clicked', () => {
     const spy = vi.fn();
     render(<IntroScreen onStart={spy} />);
-    expect(screen.getByText(/Welcome to Quick Tools/i)).toBeInTheDocument();
+    const intro = screen.getByTestId('intro-screen');
+    expect(intro.textContent).toMatch(/Welcome to Quick Tools/i);
     fireEvent.click(screen.getByTestId('start-button'));
     expect(spy).toHaveBeenCalled();
   });

--- a/tests/json-dropzone.test.tsx
+++ b/tests/json-dropzone.test.tsx
@@ -8,6 +8,7 @@ test('invokes callback when file selected', async () => {
   const handle = vi.fn();
   render(<JsonDropZone onFiles={handle} />);
   const input = screen.getByTestId('file-input');
+  expect(input).toHaveClass('custom-visually-hidden');
   const file = new File(['{}'], 'test.json', { type: 'application/json' });
   await act(async () => {
     fireEvent.change(input, { target: { files: [file] } });


### PR DESCRIPTION
## Summary
- hide JsonDropZone input and ensure onChange triggers onDrop
- make IntroScreen text assertion robust
- verify JsonDropZone input hidden via test

## Testing
- `npm test --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68666b71c9d0832b99396bc5aaf178fa