### PR TITLE
feat(style): connect new styling tools

### DIFF
--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Button, InputField } from '../components';
 import { Form } from '@mirohq/design-system';
-import { tweakFillColor, extractFillColor } from '../../board/style-tools';
+import {
+  tweakFillColor,
+  tweakOpacity,
+  tweakBorderWidth,
+  copyFillFromSelection,
+  extractFillColor,
+} from '../../board/style-tools';
 import { applyStylePreset, presetStyle } from '../../board/format-tools';
 import { STYLE_PRESET_NAMES, stylePresets } from '../style-presets';
 import { adjustColor } from '../../core/utils/color-utils';
@@ -17,6 +23,8 @@ export const StyleTab: React.FC = () => {
   const [adjust, setAdjust] = React.useState(0);
   const selection = useSelection();
   const [baseColor, setBaseColor] = React.useState('#808080');
+  const [opacityDelta, setOpacityDelta] = React.useState(0);
+  const [borderDelta, setBorderDelta] = React.useState(0);
   // Update base colour when the selection changes
   React.useEffect(() => {
     setBaseColor(extractFillColor(selection[0]) ?? '#808080');
@@ -29,6 +37,16 @@ export const StyleTab: React.FC = () => {
   const apply = async (): Promise<void> => {
     await tweakFillColor(adjust / 100);
   };
+  const applyOpacity = React.useCallback(async (): Promise<void> => {
+    await tweakOpacity(opacityDelta);
+  }, [opacityDelta]);
+  const applyBorder = React.useCallback(async (): Promise<void> => {
+    await tweakBorderWidth(borderDelta);
+  }, [borderDelta]);
+  const copyFill = React.useCallback(async (): Promise<void> => {
+    const colour = await copyFillFromSelection();
+    if (colour) setBaseColor(colour);
+  }, []);
   return (
     <TabPanel tabId='style'>
       <TabGrid columns={2}>
@@ -84,6 +102,25 @@ export const StyleTab: React.FC = () => {
           placeholder='Adjust (-100–100)'
           data-testid='adjust-input'
         />
+        <InputField
+          label='Opacity Δ'
+          type='number'
+          step='0.1'
+          min={-1}
+          max={1}
+          value={String(opacityDelta)}
+          onValueChange={(v) => setOpacityDelta(Number(v))}
+          placeholder='Δ opacity (-1–1)'
+          data-testid='opacity-input'
+        />
+        <InputField
+          label='Border Δ'
+          type='number'
+          value={String(borderDelta)}
+          onValueChange={(v) => setBorderDelta(Number(v))}
+          placeholder='Δ width'
+          data-testid='border-input'
+        />
         <div className='buttons'>
           <Button
             onClick={apply}
@@ -92,6 +129,24 @@ export const StyleTab: React.FC = () => {
             icon={<IconSlidersX />}
             iconPosition='start'>
             <Text>Apply</Text>
+          </Button>
+          <Button
+            onClick={applyOpacity}
+            type='button'
+            variant='secondary'>
+            <Text>Opacity</Text>
+          </Button>
+          <Button
+            onClick={applyBorder}
+            type='button'
+            variant='secondary'>
+            <Text>Border</Text>
+          </Button>
+          <Button
+            onClick={copyFill}
+            type='button'
+            variant='ghost'>
+            <Text>Copy Fill</Text>
           </Button>
         </div>
         <Heading level={2}>Style presets</Heading>

--- a/tests/style-tab-extra.test.tsx
+++ b/tests/style-tab-extra.test.tsx
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StyleTab } from '../src/ui/pages/StyleTab';
+import * as styleTools from '../src/board/style-tools';
+
+vi.mock('../src/board/style-tools');
+
+describe('StyleTab extra features', () => {
+  beforeEach(() => {
+    (styleTools.tweakOpacity as unknown as vi.Mock).mockResolvedValue(
+      undefined,
+    );
+    (styleTools.tweakBorderWidth as unknown as vi.Mock).mockResolvedValue(
+      undefined,
+    );
+    (styleTools.copyFillFromSelection as unknown as vi.Mock).mockResolvedValue(
+      '#123456',
+    );
+  });
+
+  test('opacity and border buttons call helpers', async () => {
+    render(React.createElement(StyleTab));
+    fireEvent.change(screen.getByTestId('opacity-input'), {
+      target: { value: '0.2' },
+    });
+    fireEvent.change(screen.getByTestId('border-input'), {
+      target: { value: '3' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /opacity/i }));
+      fireEvent.click(screen.getByRole('button', { name: /border/i }));
+    });
+    expect(styleTools.tweakOpacity).toHaveBeenCalledWith(0.2);
+    expect(styleTools.tweakBorderWidth).toHaveBeenCalledWith(3);
+  });
+
+  test('copy fill button updates preview', async () => {
+    render(React.createElement(StyleTab));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /copy fill/i }));
+    });
+    expect(screen.getByTestId('color-hex')).toHaveTextContent('#123456');
+  });
+});


### PR DESCRIPTION
## Summary
- expose extra styling controls for opacity and border width
- connect color copy function
- add test coverage for StyleTab

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68674b222a34832bb9ea975c93cc5a62