### PR TITLE
Add selection-based diagram placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,3 +223,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrate remaining tabs to grid layout with semantic headings and no forms.
 - Add `ci:local` script to replicate CI pipeline locally.
 - Switch TabGrid to apply Mirotone column classes instead of inline styles.
+- Allow reusing selected widgets when creating diagrams with options to move, layout or keep their position.

--- a/src/ui/hooks/use-diagram-create.ts
+++ b/src/ui/hooks/use-diagram-create.ts
@@ -24,6 +24,7 @@ interface CreateOptions {
   layoutOpts: UserLayoutOptions;
   nestedPadding: number;
   nestedTopSpacing: number;
+  existingMode: import('../../core/graph/graph-processor').ExistingNodeMode;
 }
 
 /**
@@ -79,6 +80,7 @@ export function useDiagramCreate(
             createFrame: opts.withFrame,
             frameTitle: opts.frameTitle || undefined,
             layout: { ...opts.layoutOpts, algorithm: selectedAlg },
+            existingMode: opts.existingMode,
           });
         }
         setProgress(100);

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -74,19 +74,22 @@ export const CardsTab: React.FC = () => {
               <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
             ))}
           </ul>
-          <Checkbox
-            label='Wrap items in frame'
-            value={withFrame}
-            onChange={setWithFrame}
-          />
-          {withFrame && (
-            <InputField
-              label='Frame title'
-              value={frameTitle}
-              onChange={(v) => setFrameTitle(v)}
-              placeholder='Frame title'
+          <fieldset>
+            <legend className='custom-visually-hidden'>Card options</legend>
+            <Checkbox
+              label='Wrap items in frame'
+              value={withFrame}
+              onChange={setWithFrame}
             />
-          )}
+            {withFrame && (
+              <InputField
+                label='Frame title'
+                value={frameTitle}
+                onChange={(v) => setFrameTitle(v)}
+                placeholder='Frame title'
+              />
+            )}
+          </fieldset>
           <div className='buttons'>
             <Button
               onClick={handleCreate}

--- a/src/ui/pages/StructuredTab.tsx
+++ b/src/ui/pages/StructuredTab.tsx
@@ -10,7 +10,10 @@ import {
 import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
 import { TabGrid } from '../components/TabGrid';
-import { GraphProcessor } from '../../core/graph/graph-processor';
+import {
+  GraphProcessor,
+  ExistingNodeMode,
+} from '../../core/graph/graph-processor';
 import {
   ALGORITHMS,
   DEFAULT_LAYOUT_OPTIONS,
@@ -104,6 +107,8 @@ export const StructuredTab: React.FC = () => {
   );
   const [nestedPadding, setNestedPadding] = React.useState(20);
   const [nestedTopSpacing, setNestedTopSpacing] = React.useState(50);
+  const [existingMode, setExistingMode] =
+    React.useState<ExistingNodeMode>('move');
   const [progress, setProgress] = React.useState<number>(0);
   const [error, setError] = React.useState<string | null>(null);
   const [lastProc, setLastProc] = React.useState<
@@ -126,6 +131,7 @@ export const StructuredTab: React.FC = () => {
       layoutOpts,
       nestedPadding,
       nestedTopSpacing,
+      existingMode,
     },
     setImportQueue,
     setProgress,
@@ -148,167 +154,178 @@ export const StructuredTab: React.FC = () => {
               <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
             ))}
           </ul>
-          <SelectField
-            label='Layout type'
-            value={layoutChoice}
-            onChange={(v) => setLayoutChoice(v as LayoutChoice)}>
-            {LAYOUTS.map((l) => (
-              <SelectOption
-                key={l}
-                value={l}>
-                {l}
-              </SelectOption>
-            ))}
-          </SelectField>
-          <Paragraph className='field-help'>Layout options:</Paragraph>
-          <ul className='field-help'>
-            {LAYOUTS.map((l) => (
-              <li key={`desc-${l}`}>{LAYOUT_DESCRIPTIONS[l]}</li>
-            ))}
-          </ul>
-          <div style={{ marginTop: tokens.space.small }}>
-            <Checkbox
-              label='Wrap items in frame'
-              value={withFrame}
-              onChange={setWithFrame}
-            />
-          </div>
-          {withFrame && (
-            <InputField
-              label='Frame title'
-              value={frameTitle}
-              onChange={(v) => setFrameTitle(v)}
-              placeholder='Frame title'
-            />
-          )}
-          <details
-            open={showAdvanced}
-            aria-label='Advanced options'
-            onToggle={(e) =>
-              setShowAdvanced((e.target as HTMLDetailsElement).open)
-            }>
-            <summary>Advanced options</summary>
+          <fieldset>
+            <legend className='custom-visually-hidden'>Diagram options</legend>
             <SelectField
-              label='Algorithm'
-              value={layoutOpts.algorithm}
-              onChange={(v) =>
-                setLayoutOpts({ ...layoutOpts, algorithm: v as ElkAlgorithm })
-              }>
-              {ALGORITHMS.map((a) => (
+              label='Layout type'
+              value={layoutChoice}
+              onChange={(v) => setLayoutChoice(v as LayoutChoice)}>
+              {LAYOUTS.map((l) => (
                 <SelectOption
-                  key={a}
-                  value={a}>
-                  {a}
+                  key={l}
+                  value={l}>
+                  {l}
                 </SelectOption>
               ))}
             </SelectField>
-            <SelectField
-              label='Direction'
-              value={layoutOpts.direction}
-              onChange={(v) =>
-                setLayoutOpts({ ...layoutOpts, direction: v as ElkDirection })
-              }>
-              {DIRECTIONS.map((d) => (
-                <SelectOption
-                  key={d}
-                  value={d}>
-                  {d}
-                </SelectOption>
+            <Paragraph className='field-help'>Layout options:</Paragraph>
+            <ul className='field-help'>
+              {LAYOUTS.map((l) => (
+                <li key={`desc-${l}`}>{LAYOUT_DESCRIPTIONS[l]}</li>
               ))}
-            </SelectField>
-            <InputField
-              label='Spacing'
-              type='number'
-              value={String(layoutOpts.spacing)}
-              onChange={(v) =>
-                setLayoutOpts({ ...layoutOpts, spacing: Number(v) })
-              }
-            />
-            {OPTION_VISIBILITY[layoutOpts.algorithm].aspectRatio && (
+            </ul>
+            <div style={{ marginTop: tokens.space.small }}>
+              <Checkbox
+                label='Wrap items in frame'
+                value={withFrame}
+                onChange={setWithFrame}
+              />
+            </div>
+            {withFrame && (
               <InputField
-                label='Aspect ratio'
-                type='number'
-                step={0.1}
-                value={String(layoutOpts.aspectRatio)}
+                label='Frame title'
+                value={frameTitle}
+                onChange={(v) => setFrameTitle(v)}
+                placeholder='Frame title'
+              />
+            )}
+            <SelectField
+              label='Existing nodes'
+              value={existingMode}
+              onChange={(v) => setExistingMode(v as ExistingNodeMode)}>
+              <SelectOption value='move'>Move into place</SelectOption>
+              <SelectOption value='layout'>Use for layout</SelectOption>
+              <SelectOption value='ignore'>Keep position</SelectOption>
+            </SelectField>
+            <details
+              open={showAdvanced}
+              aria-label='Advanced options'
+              onToggle={(e) =>
+                setShowAdvanced((e.target as HTMLDetailsElement).open)
+              }>
+              <summary>Advanced options</summary>
+              <SelectField
+                label='Algorithm'
+                value={layoutOpts.algorithm}
                 onChange={(v) =>
-                  setLayoutOpts({ ...layoutOpts, aspectRatio: Number(v) })
+                  setLayoutOpts({ ...layoutOpts, algorithm: v as ElkAlgorithm })
+                }>
+                {ALGORITHMS.map((a) => (
+                  <SelectOption
+                    key={a}
+                    value={a}>
+                    {a}
+                  </SelectOption>
+                ))}
+              </SelectField>
+              <SelectField
+                label='Direction'
+                value={layoutOpts.direction}
+                onChange={(v) =>
+                  setLayoutOpts({ ...layoutOpts, direction: v as ElkDirection })
+                }>
+                {DIRECTIONS.map((d) => (
+                  <SelectOption
+                    key={d}
+                    value={d}>
+                    {d}
+                  </SelectOption>
+                ))}
+              </SelectField>
+              <InputField
+                label='Spacing'
+                type='number'
+                value={String(layoutOpts.spacing)}
+                onChange={(v) =>
+                  setLayoutOpts({ ...layoutOpts, spacing: Number(v) })
                 }
               />
-            )}
-            {OPTION_VISIBILITY[layoutOpts.algorithm].edgeRouting && (
-              <SelectField
-                label='Edge routing'
-                value={layoutOpts.edgeRouting as ElkEdgeRouting}
-                onChange={(v) =>
-                  setLayoutOpts({
-                    ...layoutOpts,
-                    edgeRouting: v as ElkEdgeRouting,
-                  })
-                }>
-                {EDGE_ROUTINGS.map((e) => (
-                  <SelectOption
-                    key={e}
-                    value={e}>
-                    {e}
-                  </SelectOption>
-                ))}
-              </SelectField>
-            )}
-            {OPTION_VISIBILITY[layoutOpts.algorithm].edgeRoutingMode && (
-              <SelectField
-                label='Routing mode'
-                value={layoutOpts.edgeRoutingMode as ElkEdgeRoutingMode}
-                onChange={(v) =>
-                  setLayoutOpts({
-                    ...layoutOpts,
-                    edgeRoutingMode: v as ElkEdgeRoutingMode,
-                  })
-                }>
-                {EDGE_ROUTING_MODES.map((m) => (
-                  <SelectOption
-                    key={m}
-                    value={m}>
-                    {m}
-                  </SelectOption>
-                ))}
-              </SelectField>
-            )}
-            {OPTION_VISIBILITY[layoutOpts.algorithm].optimizationGoal && (
-              <SelectField
-                label='Optimisation goal'
-                value={layoutOpts.optimizationGoal as ElkOptimizationGoal}
-                onChange={(v) =>
-                  setLayoutOpts({
-                    ...layoutOpts,
-                    optimizationGoal: v as ElkOptimizationGoal,
-                  })
-                }>
-                {OPTIMIZATION_GOALS.map((o) => (
-                  <SelectOption
-                    key={o}
-                    value={o}>
-                    {o}
-                  </SelectOption>
-                ))}
-              </SelectField>
-            )}
-            {layoutChoice === 'Nested' && (
-              <InputField
-                label='Padding'
-                type='number'
-                value={String(nestedPadding)}
-                onChange={(v) => setNestedPadding(Number(v))}
-              />
-            )}
-            {layoutChoice === 'Nested' && (
-              <InputField
-                label='Top spacing'
-                type='number'
-                value={String(nestedTopSpacing)}
-                onChange={(v) => setNestedTopSpacing(Number(v))}
-              />
-            )}
-          </details>
+              {OPTION_VISIBILITY[layoutOpts.algorithm].aspectRatio && (
+                <InputField
+                  label='Aspect ratio'
+                  type='number'
+                  step={0.1}
+                  value={String(layoutOpts.aspectRatio)}
+                  onChange={(v) =>
+                    setLayoutOpts({ ...layoutOpts, aspectRatio: Number(v) })
+                  }
+                />
+              )}
+              {OPTION_VISIBILITY[layoutOpts.algorithm].edgeRouting && (
+                <SelectField
+                  label='Edge routing'
+                  value={layoutOpts.edgeRouting as ElkEdgeRouting}
+                  onChange={(v) =>
+                    setLayoutOpts({
+                      ...layoutOpts,
+                      edgeRouting: v as ElkEdgeRouting,
+                    })
+                  }>
+                  {EDGE_ROUTINGS.map((e) => (
+                    <SelectOption
+                      key={e}
+                      value={e}>
+                      {e}
+                    </SelectOption>
+                  ))}
+                </SelectField>
+              )}
+              {OPTION_VISIBILITY[layoutOpts.algorithm].edgeRoutingMode && (
+                <SelectField
+                  label='Routing mode'
+                  value={layoutOpts.edgeRoutingMode as ElkEdgeRoutingMode}
+                  onChange={(v) =>
+                    setLayoutOpts({
+                      ...layoutOpts,
+                      edgeRoutingMode: v as ElkEdgeRoutingMode,
+                    })
+                  }>
+                  {EDGE_ROUTING_MODES.map((m) => (
+                    <SelectOption
+                      key={m}
+                      value={m}>
+                      {m}
+                    </SelectOption>
+                  ))}
+                </SelectField>
+              )}
+              {OPTION_VISIBILITY[layoutOpts.algorithm].optimizationGoal && (
+                <SelectField
+                  label='Optimisation goal'
+                  value={layoutOpts.optimizationGoal as ElkOptimizationGoal}
+                  onChange={(v) =>
+                    setLayoutOpts({
+                      ...layoutOpts,
+                      optimizationGoal: v as ElkOptimizationGoal,
+                    })
+                  }>
+                  {OPTIMIZATION_GOALS.map((o) => (
+                    <SelectOption
+                      key={o}
+                      value={o}>
+                      {o}
+                    </SelectOption>
+                  ))}
+                </SelectField>
+              )}
+              {layoutChoice === 'Nested' && (
+                <InputField
+                  label='Padding'
+                  type='number'
+                  value={String(nestedPadding)}
+                  onChange={(v) => setNestedPadding(Number(v))}
+                />
+              )}
+              {layoutChoice === 'Nested' && (
+                <InputField
+                  label='Top spacing'
+                  type='number'
+                  value={String(nestedTopSpacing)}
+                  onChange={(v) => setNestedTopSpacing(Number(v))}
+                />
+              )}
+            </details>
+          </fieldset>
           <div className='buttons'>
             <Button
               onClick={handleCreate}

--- a/tests/boardbuilder-selection.test.ts
+++ b/tests/boardbuilder-selection.test.ts
@@ -1,0 +1,40 @@
+import { BoardBuilder } from '../src/board/board-builder';
+
+interface GlobalWithMiro {
+  miro?: { board?: Record<string, unknown> };
+}
+
+declare const global: GlobalWithMiro;
+
+describe('BoardBuilder.findNodeInSelection', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  test('locates shape within the current selection', async () => {
+    const shape = { type: 'shape', content: 'X' } as Record<string, unknown>;
+    global.miro = {
+      board: { getSelection: jest.fn().mockResolvedValue([shape]) },
+    };
+    const builder = new BoardBuilder();
+    const result = await builder.findNodeInSelection('any', 'X');
+    expect(result).toBe(shape);
+  });
+
+  test('locates group by metadata in the selection', async () => {
+    const item = {
+      getMetadata: jest.fn().mockResolvedValue({ type: 'T', label: 'L' }),
+    } as Record<string, unknown>;
+    const group = {
+      type: 'group',
+      getItems: jest.fn().mockResolvedValue([item]),
+    } as Record<string, unknown>;
+    global.miro = {
+      board: { getSelection: jest.fn().mockResolvedValue([group]) },
+    };
+    const builder = new BoardBuilder();
+    const result = await builder.findNodeInSelection('T', 'L');
+    expect(result).toBe(group);
+  });
+});

--- a/tests/diagram-tab-existing.test.tsx
+++ b/tests/diagram-tab-existing.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DiagramsTab } from '../src/ui/pages/DiagramsTab';
+import { GraphProcessor } from '../src/core/graph/graph-processor';
+
+vi.mock('../src/core/graph/graph-processor');
+
+describe('DiagramsTab existing node option', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { miro: unknown }).miro = {
+      board: { ui: { on: vi.fn() } },
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { miro: unknown }).miro;
+    vi.clearAllMocks();
+  });
+
+  test('passes existingMode option', async () => {
+    const spy = vi
+      .spyOn(GraphProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<DiagramsTab />);
+    const file = new File(['{}'], 'graph.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create diagram/i }));
+    });
+    expect(spy).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({ existingMode: 'move' }),
+    );
+  });
+});

--- a/tests/processor-existing.test.ts
+++ b/tests/processor-existing.test.ts
@@ -1,0 +1,145 @@
+import { GraphProcessor } from '../src/core/graph/graph-processor';
+import { layoutEngine } from '../src/core/layout/elk-layout';
+import { BoardBuilder } from '../src/board/board-builder';
+
+interface GlobalWithMiro {
+  miro?: { board?: Record<string, unknown> };
+}
+
+declare const global: GlobalWithMiro;
+
+describe('GraphProcessor with existing nodes', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  test('ignore mode keeps existing position', async () => {
+    const processor = new GraphProcessor();
+    const shape = {
+      id: 's',
+      type: 'shape',
+      x: 5,
+      y: 6,
+      sync: jest.fn(),
+      setMetadata: jest.fn(),
+      getMetadata: jest.fn(),
+    } as Record<string, unknown>;
+    global.miro = {
+      board: {
+        getSelection: jest.fn().mockResolvedValue([shape]),
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+        viewport: {
+          get: jest
+            .fn()
+            .mockResolvedValue({ x: 0, y: 0, width: 1000, height: 1000 }),
+          zoomTo: jest.fn(),
+          set: jest.fn(),
+        },
+        createConnector: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 'c',
+          }),
+        createShape: jest.fn(),
+        createText: jest.fn(),
+        createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
+        group: jest
+          .fn()
+          .mockResolvedValue({
+            type: 'group',
+            getItems: jest.fn().mockResolvedValue([]),
+          }),
+      },
+    };
+    jest
+      .spyOn(BoardBuilder.prototype, 'findNodeInSelection')
+      .mockResolvedValue(shape as unknown);
+    jest
+      .spyOn(BoardBuilder.prototype, 'createNode')
+      .mockResolvedValue(shape as unknown);
+    jest
+      .spyOn(layoutEngine, 'layoutGraph')
+      .mockResolvedValue({
+        nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+        edges: [],
+      });
+    const graph = { nodes: [{ id: 'n1', label: 'L', type: 'T' }], edges: [] };
+    await processor.processGraph(graph as unknown, {
+      existingMode: 'ignore',
+      createFrame: false,
+    });
+    expect((shape as { x: number }).x).toBe(5);
+    expect(BoardBuilder.prototype.createNode).not.toHaveBeenCalled();
+  });
+
+  test('layout mode forwards coordinates to layout engine', async () => {
+    const processor = new GraphProcessor();
+    const shape = {
+      id: 's',
+      type: 'shape',
+      x: 10,
+      y: 20,
+      sync: jest.fn(),
+      setMetadata: jest.fn(),
+      getMetadata: jest.fn(),
+    } as Record<string, unknown>;
+    global.miro = {
+      board: {
+        getSelection: jest.fn().mockResolvedValue([shape]),
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+        viewport: {
+          get: jest
+            .fn()
+            .mockResolvedValue({ x: 0, y: 0, width: 1000, height: 1000 }),
+          zoomTo: jest.fn(),
+          set: jest.fn(),
+        },
+        createConnector: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 'c',
+          }),
+        createShape: jest.fn(),
+        createText: jest.fn(),
+        createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
+        group: jest
+          .fn()
+          .mockResolvedValue({
+            type: 'group',
+            getItems: jest.fn().mockResolvedValue([]),
+          }),
+      },
+    };
+    jest
+      .spyOn(BoardBuilder.prototype, 'findNodeInSelection')
+      .mockResolvedValue(shape as unknown);
+    const spy = jest
+      .spyOn(layoutEngine, 'layoutGraph')
+      .mockImplementation(async (g) => {
+        expect((g as { nodes: unknown[] }).nodes[0]).toHaveProperty('metadata');
+        return {
+          nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+          edges: [],
+        };
+      });
+    const graph = { nodes: [{ id: 'n1', label: 'L', type: 'T' }], edges: [] };
+    await processor.processGraph(graph as unknown, {
+      existingMode: 'layout',
+      createFrame: false,
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- enable finding nodes within the current selection only
- handle existing nodes during diagram creation
- test BoardBuilder selection lookup
- test GraphProcessor existing node modes
- provide UI option for existing node placement
- apply fieldset markup for card/diagram tabs
- clarify behaviour in GraphProcessor docs
- update changelog

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686682c66dd4832b8d74b76d172990d2