### PR TITLE
Resolve code smells in UI modules

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -44,8 +44,9 @@ function AppShell(): React.JSX.Element {
   const current = TAB_DATA.find((t) => t[1] === tab)!;
   const CurrentComp = current[4];
 
+  const PrimitiveDiv = Primitive.div;
   return (
-    <Primitive.div className='scrollable'>
+    <PrimitiveDiv className='scrollable'>
       <ExcelDataProvider
         value={{
           rows,
@@ -79,7 +80,7 @@ function AppShell(): React.JSX.Element {
           onClose={() => setShowMeta(false)}
         />
       </ExcelDataProvider>
-    </Primitive.div>
+    </PrimitiveDiv>
   );
 }
 

--- a/src/board/board-cache.ts
+++ b/src/board/board-cache.ts
@@ -1,4 +1,9 @@
-import { BoardLike, BoardQueryLike, getBoardWithQuery } from './board';
+import {
+  BoardLike,
+  BoardQueryLike,
+  getBoardWithQuery,
+  getBoard,
+} from './board';
 
 /**
  * Singleton cache for board data.
@@ -16,7 +21,7 @@ export class BoardCache {
     board?: BoardLike,
   ): Promise<Array<Record<string, unknown>>> {
     if (!this.selection) {
-      const b = getBoardWithQuery(board as BoardQueryLike);
+      const b = getBoard(board);
       this.selection = await b.getSelection();
     }
     return this.selection;

--- a/src/board/templates.ts
+++ b/src/board/templates.ts
@@ -126,7 +126,7 @@ export class TemplateManager {
    */
   private parseNumeric(value: unknown): unknown {
     if (typeof value !== 'string') return value;
-    const m = value.match(/^(-?\d+(?:\.\d+)?)(px)?$/);
+    const m = /^(-?\d+(?:\.\d+)?)(px)?$/.exec(value);
     return m ? parseFloat(m[1]) : value;
   }
 

--- a/src/core/graph/graph-processor.ts
+++ b/src/core/graph/graph-processor.ts
@@ -18,6 +18,9 @@ import {
 } from '../layout/layout-utils';
 import type { BaseItem, Frame, Group } from '@mirohq/websdk-types';
 
+/** Board widget or group item. */
+type BoardItem = BaseItem | Group;
+
 /**
  * High level orchestrator that loads graph data, runs layout and
  * creates all widgets on the board.
@@ -159,7 +162,7 @@ export class GraphProcessor extends UndoableProcessor {
    */
   private buildLayoutInput(
     data: GraphData,
-    existing: Record<string, BaseItem | Group | undefined>,
+    existing: Record<string, BoardItem | undefined>,
     mode: ExistingNodeMode,
   ): GraphData {
     if (mode !== 'layout') return data;
@@ -196,8 +199,8 @@ export class GraphProcessor extends UndoableProcessor {
   /** Collect selected widgets matching graph nodes. */
   private async collectExistingNodes(
     graph: GraphData,
-  ): Promise<Record<string, BaseItem | Group | undefined>> {
-    const map: Record<string, BaseItem | Group | undefined> = {};
+  ): Promise<Record<string, BoardItem | undefined>> {
+    const map: Record<string, BoardItem | undefined> = {};
     for (const node of graph.nodes) {
       map[node.id] = await this.builder.findNodeInSelection(
         node.type,
@@ -216,18 +219,18 @@ export class GraphProcessor extends UndoableProcessor {
     offsetX: number,
     offsetY: number,
     mode: ExistingNodeMode,
-    existing: Record<string, BaseItem | Group | undefined>,
+    existing: Record<string, BoardItem | undefined>,
   ): Promise<{
-    map: Record<string, BaseItem | Group>;
+    map: Record<string, BoardItem>;
     positions: Record<string, PositionedNode>;
   }> {
-    const map: Record<string, BaseItem | Group> = {};
+    const map: Record<string, BoardItem> = {};
     const positions: Record<string, PositionedNode> = {};
     for (const node of graph.nodes) {
       const pos = layout.nodes[node.id];
       const target = { ...pos, x: pos.x + offsetX, y: pos.y + offsetY };
       const found = existing[node.id];
-      let widget: BaseItem | Group;
+      let widget: BoardItem;
       if (found) {
         widget = found;
         if (mode !== 'ignore') {
@@ -267,7 +270,7 @@ export class GraphProcessor extends UndoableProcessor {
   private async createConnectorsAndZoom(
     graph: GraphData,
     layout: LayoutResult,
-    nodeMap: Record<string, BaseItem | Group>,
+    nodeMap: Record<string, BoardItem>,
     frame?: Frame,
   ): Promise<void> {
     const edgeHints = computeEdgeHints(graph, layout);

--- a/src/ui/pages/DiagramsTab.tsx
+++ b/src/ui/pages/DiagramsTab.tsx
@@ -35,7 +35,7 @@ export const DiagramsTab: React.FC = () => {
       <Tabs
         value={sub}
         variant={'tabs'}
-        onChange={(id) => setSub(id as string)}
+        onChange={(id) => setSub(id)}
         size='medium'>
         <Tabs.List>
           {SUB_TABS.map((t) => (

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -67,25 +67,24 @@ export const SearchTab: React.FC = () => {
       .split(',')
       .map((t) => t.trim())
       .filter(Boolean);
-    const pairs: Array<
-      [boolean, keyof SearchOptions, SearchOptions[keyof SearchOptions]]
-    > = [
-      [widgetTypes.length > 0, 'widgetTypes', widgetTypes],
-      [tags.length > 0, 'tagIds', tags],
-      [Boolean(backgroundColor), 'backgroundColor', backgroundColor],
-      [Boolean(assignee), 'assignee', assignee],
-      [Boolean(creator), 'creator', creator],
-      [Boolean(lastModifiedBy), 'lastModifiedBy', lastModifiedBy],
-      [caseSensitive, 'caseSensitive', true],
-      [wholeWord, 'wholeWord', true],
-      [regex, 'regex', true],
-    ];
-    return pairs.reduce<SearchOptions>(
-      (opts, [cond, key, value]) => {
-        return cond ? { ...opts, [key]: value } : opts;
-      },
-      { query },
-    );
+    const opts: SearchOptions = { query };
+    const add = <K extends keyof SearchOptions>(
+      cond: boolean,
+      key: K,
+      value: SearchOptions[K],
+    ): void => {
+      if (cond) opts[key] = value;
+    };
+    add(widgetTypes.length > 0, 'widgetTypes', widgetTypes);
+    add(tags.length > 0, 'tagIds', tags);
+    add(Boolean(backgroundColor), 'backgroundColor', backgroundColor);
+    add(Boolean(assignee), 'assignee', assignee);
+    add(Boolean(creator), 'creator', creator);
+    add(Boolean(lastModifiedBy), 'lastModifiedBy', lastModifiedBy);
+    add(caseSensitive, 'caseSensitive', true);
+    add(wholeWord, 'wholeWord', true);
+    add(regex, 'regex', true);
+    return opts;
   }, [
     query,
     widgetTypes,

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Button, InputField } from '../components';
-import { Form } from '@mirohq/design-system';
 import {
   tweakFillColor,
   tweakOpacity,
@@ -16,7 +15,7 @@ import { tokens } from '../tokens';
 import { TabPanel } from '../components/TabPanel';
 import { TabGrid } from '../components/TabGrid';
 import type { TabTuple } from './tab-definitions';
-import { Heading, IconSlidersX, Text } from '@mirohq/design-system';
+import { Form, Heading, IconSlidersX, Text } from '@mirohq/design-system';
 
 /** Adjusts the fill colour of selected widgets. */
 export const StyleTab: React.FC = () => {
@@ -47,51 +46,47 @@ export const StyleTab: React.FC = () => {
     const colour = await copyFillFromSelection();
     if (colour) setBaseColor(colour);
   }, []);
+  const sliderId = React.useId();
   return (
     <TabPanel tabId='style'>
       <TabGrid columns={2}>
-        {(() => {
-          const sliderId = React.useId();
-          return (
-            <Form.Field>
-              <Form.Label htmlFor={sliderId}>Adjust fill</Form.Label>
-              <input
-                id={sliderId}
-                data-testid='adjust-slider'
-                type='range'
-                min='-100'
-                max='100'
-                list='adjust-marks'
-                value={adjust}
-                onChange={(e) => setAdjust(Number(e.target.value))}
+        <Form.Field>
+          <Form.Label htmlFor={sliderId}>Adjust fill</Form.Label>
+          <input
+            id={sliderId}
+            data-testid='adjust-slider'
+            type='range'
+            min='-100'
+            max='100'
+            list='adjust-marks'
+            value={adjust}
+            onChange={(e) => setAdjust(Number(e.target.value))}
+          />
+          <datalist id='adjust-marks'>
+            {[-100, -50, 0, 50, 100].map((n) => (
+              <option
+                key={n}
+                value={n}
               />
-              <datalist id='adjust-marks'>
-                {[-100, -50, 0, 50, 100].map((n) => (
-                  <option
-                    key={n}
-                    value={n}
-                  />
-                ))}
-              </datalist>
-              <span
-                data-testid='adjust-preview'
-                style={{
-                  display: 'inline-block',
-                  width: '24px',
-                  height: '24px',
-                  marginLeft: tokens.space.small,
-                  border: `1px solid ${tokens.color.gray[200]}`,
-                  backgroundColor: preview,
-                }}
-              />
-              <code
-                data-testid='color-hex'
-                style={{ marginLeft: tokens.space.xxsmall }}>
-                {preview}
-              </code>
-            </Form.Field>
-          );
-        })()}
+            ))}
+          </datalist>
+          <span
+            data-testid='adjust-preview'
+            style={{
+              display: 'inline-block',
+              width: '24px',
+              height: '24px',
+              marginLeft: tokens.space.small,
+              border: `1px solid ${tokens.color.gray[200]}`,
+              backgroundColor: preview,
+            }}
+          />
+          <code
+            data-testid='color-hex'
+            style={{ marginLeft: tokens.space.xxsmall }}>
+            {preview}
+          </code>
+        </Form.Field>
         <InputField
           label='Adjust value'
           type='number'


### PR DESCRIPTION
## Summary
- alias `Primitive.div` with PascalCase name
- drop unnecessary type assertions
- prefer `RegExp.exec` parsing
- use type alias for board items
- streamline search option construction
- collapse duplicate imports and fix hook usage in `StyleTab`

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6868af6290f4832b9bba8f4b81d3601a