### PR TITLE
fix(board): remove redundant type assertion

### DIFF
--- a/src/board/board-cache.ts
+++ b/src/board/board-cache.ts
@@ -51,7 +51,7 @@ export class BoardCache {
     if (missing.length) {
       const fetched = await Promise.all(missing.map((t) => b.get({ type: t })));
       for (let i = 0; i < missing.length; i += 1) {
-        const list = fetched[i] as Array<Record<string, unknown>>;
+        const list = fetched[i];
         this.widgets.set(missing[i], list);
         results.push(...list);
       }


### PR DESCRIPTION
## Summary
- clean up `board-cache` by removing an unnecessary cast

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6868b6fd15a8832ba66dffabfdc2c9a6