### PR TITLE
Update comments to use design system

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -3,7 +3,6 @@
 @import '@mirohq/design-system-themes/base.css';
 @import '@mirohq/design-system-themes/light.css';
 **/
-@import 'mirotone/dist/styles.css';
 
 *,
 *:before,

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from './Button';
 
 export interface ModalProps {
   /** Dialog title displayed in the header. */
@@ -113,12 +114,12 @@ export function Modal({
         ref={ref}>
         <header className='modal-header'>
           <h3>{title}</h3>
-          <button
-            className='button button-secondary'
+          <Button
+            variant='secondary'
             aria-label='Close'
             onClick={onClose}>
             ×
-          </button>
+          </Button>
         </header>
         <div className='modal-content'>{children}</div>
       </dialog>

--- a/src/ui/components/Paragraph.tsx
+++ b/src/ui/components/Paragraph.tsx
@@ -7,7 +7,7 @@ export type ParagraphProps = Readonly<
 >;
 
 /**
- * Paragraph element styled using Mirotone classes.
+ * Paragraph element styled using design-system classes.
  *
  * Custom class names and inline styles are intentionally excluded so
  * typography remains consistent across the app.

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -13,7 +13,7 @@ export type SegmentedControlProps = Readonly<{
 }>;
 
 /**
- * Generic segmented control using Mirotone buttons.
+ * Generic segmented control built with design-system buttons.
  */
 export function SegmentedControl({
   value,

--- a/src/ui/components/Select.tsx
+++ b/src/ui/components/Select.tsx
@@ -19,7 +19,8 @@ export type SelectProps = Readonly<{
 /**
  * Wrapper around the design-system `Select` component.
  *
- * It exposes a simplified API compatible with the old Mirotone-based select.
+ * It exposes a simplified API compatible with the legacy select used in
+ * earlier versions built with Mirotone.
  */
 export function Select({
   value,


### PR DESCRIPTION
## Summary
- update component docs to reference the design system instead of Mirotone
- adjust Modal to use the Button component
- drop old Mirotone stylesheet

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68691e70abcc832bb01e18080452b52c