### PR TITLE
Switch from Mirotone to design-system styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "d3-dsv": "^3.0.1",
         "elkjs": "^0.10.0",
         "exceljs": "^4.4.0",
-        "mirotone": "^5.3.2",
         "react-dropzone": "^14.3.8"
       },
       "devDependencies": {
@@ -8890,77 +8889,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
-      "license": "MIT"
-    },
-    "node_modules/cloneable-readable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
-      }
-    },
-    "node_modules/cloneable-readable/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/cloneable-readable/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/cloneable-readable/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/cloneable-readable/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -11582,16 +11510,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/gulp-file": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/gulp-file/-/gulp-file-0.4.0.tgz",
-      "integrity": "sha512-3NPCJpAPpbNoV2aml8T96OK3Aof4pm4PMOIa1jSQbMNSNUUXdZ5QjVgLXLStjv0gg9URcETc7kvYnzXdYXUWug==",
-      "license": "BSD",
-      "dependencies": {
-        "through2": "^0.4.1",
-        "vinyl": "^2.1.0"
-      }
-    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -13824,21 +13742,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mirotone": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/mirotone/-/mirotone-5.3.2.tgz",
-      "integrity": "sha512-LSzXFV4YLdk6VaPj37oIAYMwLaMyLqYi6EgcvAJAzvj8k1vYGtvfjYVZqWd/Hgb7XCb5x1hV49+oT9vTF7a9wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mirohq/design-tokens": "5.1.1",
-        "gulp-file": "^0.4.0"
-      }
-    },
-    "node_modules/mirotone/node_modules/@mirohq/design-tokens": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@mirohq/design-tokens/-/design-tokens-5.1.1.tgz",
-      "integrity": "sha512-PcCA7HlumSSaRkAIlrB4+CKhFyF+w93q1SnbIL6zPM69hzN9kJD7zNUk2ngGJpDcQseRyoE+uJkN8f+WRvp0Lg=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -17876,21 +17779,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-      "license": "ISC"
-    },
-    "node_modules/replace-ext": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -19621,40 +19509,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/through2": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
     "node_modules/time-span": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
@@ -20252,23 +20106,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/vinyl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
-      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vite": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.2.tgz",
@@ -20789,23 +20626,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "license": "MIT"
-    },
-    "node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/xtend/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
       "license": "MIT"
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "d3-dsv": "^3.0.1",
     "elkjs": "^0.10.0",
     "exceljs": "^4.4.0",
-    "mirotone": "^5.3.2",
     "react-dropzone": "^14.3.8"
   },
   "devDependencies": {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,9 +1,26 @@
-/**
 @import '@mirohq/design-tokens/tokens.css';
 @import '@mirohq/design-system-themes/base.css';
 @import '@mirohq/design-system-themes/light.css';
-**/
-@import 'mirotone/dist/styles.css';
+
+:root {
+  /* Mirotone alias variables mapped to design-system tokens */
+  --space-xxsmall: var(--space-50);
+  --space-xsmall: var(--space-100);
+  --space-small: var(--space-200);
+  --space-medium: var(--space-300);
+  --space-large: var(--space-400);
+  --space-xlarge: var(--space-500);
+  --indigoAlpha40: var(--colors-alpha-gray-400);
+  --indigo700: var(--colors-blue-700);
+  --green700: var(--colors-green-700);
+  --red700: var(--colors-red-700);
+  --red600: var(--colors-red-600);
+  --white: var(--white);
+  --black: var(--black);
+  --primary-text-color: var(--colors-gray-900);
+  --font-size-large: var(--fontSize-250);
+  --font-weight-bold: var(--font-weights-semibold);
+}
 
 *,
 *:before,
@@ -71,4 +88,54 @@ body {
 
 .search-input input {
   flex: 1;
+}
+
+.custom-form-group-small {
+  margin-bottom: var(--space-small);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xsmall);
+}
+
+.custom-modal-container {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+
+.custom-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--colors-background-alpha-neutrals-overlay-subtle);
+  border: none;
+}
+
+.custom-modal {
+  position: relative;
+  margin: auto;
+  border: none;
+  border-radius: var(--radii-100);
+  background: var(--colors-background-neutrals);
+  color: var(--primary-text-color);
+  padding: var(--space-medium);
+  max-width: 400px;
+}
+
+.custom-modal-small {
+  width: 300px;
+}
+
+.custom-modal-medium {
+  width: 400px;
+}
+
+.custom-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-small);
+}
+
+.custom-modal-content {
+  overflow-y: auto;
 }

--- a/src/ui/components/FilterDropdown.tsx
+++ b/src/ui/components/FilterDropdown.tsx
@@ -63,7 +63,7 @@ export function FilterDropdown({
           Whole word
         </DropdownMenu.SwitchItem>
         <DropdownMenu.Separator />
-        <div className='form-group-small'>
+        <div className='custom-form-group-small'>
           <legend className='custom-visually-hidden'>Widget Types</legend>
           <div>
             {['shape', 'card', 'sticky_note', 'text'].map((t) => (

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -52,7 +52,7 @@ export function JsonDropZone({
           {...fileInputProps}
         />
         {dropzone.isDragAccept ? (
-          <p className='dnd-text'>Drop your JSON file here</p>
+          <p style={{ margin: tokens.space.small }}>Drop your JSON file here</p>
         ) : (
           <div style={{ padding: tokens.space.small }}>
             <Button
@@ -61,7 +61,9 @@ export function JsonDropZone({
               icon={<IconSquareArrowIn />}>
               <Text>Select JSON file</Text>
             </Button>
-            <p className='dnd-text'>Or drop your JSON file here</p>
+            <p style={{ marginTop: tokens.space.small }}>
+              Or drop your JSON file here
+            </p>
           </div>
         )}
       </div>

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from './Button';
 
 export interface ModalProps {
   /** Dialog title displayed in the header. */
@@ -86,12 +87,12 @@ export function Modal({
 
   // Close the modal when the backdrop is activated via mouse or keyboard
   return (
-    <div className='modal-container'>
+    <div className='custom-modal-container'>
       <button
         type='button'
         aria-label='Close modal'
         data-testid='modal-backdrop'
-        className='modal-backdrop'
+        className='custom-modal-backdrop'
         onClick={(e) => {
           if (e.target === e.currentTarget) onClose();
         }}
@@ -109,18 +110,18 @@ export function Modal({
         open
         aria-label={title}
         aria-modal='true'
-        className={`modal modal-${size}`}
+        className={`custom-modal custom-modal-${size}`}
         ref={ref}>
-        <header className='modal-header'>
+        <header className='custom-modal-header'>
           <h3>{title}</h3>
-          <button
-            className='button button-secondary'
+          <Button
+            variant='secondary'
             aria-label='Close'
             onClick={onClose}>
             ×
-          </button>
+          </Button>
         </header>
-        <div className='modal-content'>{children}</div>
+        <div className='custom-modal-content'>{children}</div>
       </dialog>
     </div>
   );

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -21,7 +21,7 @@ export function SegmentedControl({
   options,
 }: SegmentedControlProps): React.JSX.Element {
   return (
-    <fieldset className='segmented-control'>
+    <fieldset className='custom-segment'>
       <legend className='custom-visually-hidden'>Layout type</legend>
       {options.map((opt) => (
         <Button

--- a/src/ui/pages/ArrangeTab.tsx
+++ b/src/ui/pages/ArrangeTab.tsx
@@ -131,7 +131,7 @@ export const ArrangeTab: React.FC = () => {
         </Grid.Item>
 
         <Grid.Item>
-          <div className='form-group-small'>
+          <div className='custom-form-group-small'>
             <SelectField
               label='Axis'
               value={spacing.axis}


### PR DESCRIPTION
## Summary
- drop Mirotone and import the design-system styles
- update custom CSS variables and create modal/form styles
- replace deprecated class names
- use design-system `Button` in `Modal`
- regenerate lock file without mirotone dependency

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686920de4b20832bad5053b36d7b0934