### PR TITLE
Update token imports, clean up docs

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,46 @@
-import type { Preview } from '@storybook/react';
+import type { Decorator, Preview } from '@storybook/react';
+import '@mirohq/design-system-themes/base.css';
+import '@mirohq/design-system-themes/light.css';
+
+const darkHref = new URL(
+  '@mirohq/design-system-themes/dark.css',
+  import.meta.url,
+).toString();
+const darkLink = document.createElement('link');
+darkLink.rel = 'stylesheet';
+darkLink.href = darkHref;
+
+const withTheme: Decorator = (Story, context) => {
+  const { theme } = context.globals;
+  if (theme === 'dark') {
+    if (!document.head.querySelector(`link[href="${darkHref}"]`)) {
+      document.head.appendChild(darkLink);
+    }
+  } else {
+    document.head.querySelector(`link[href="${darkHref}"]`)?.remove();
+  }
+  return Story(context);
+};
 
 const preview: Preview = {
+  decorators: [withTheme],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: { expanded: true },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'mirror',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+        ],
+      },
+    },
   },
 };
 

--- a/README.md
+++ b/README.md
@@ -333,8 +333,9 @@ The CI pipeline also enforces commitlint via
 ## Storybook
 
 Run the component explorer to preview the UI library. Storybook exposes
-interactive examples for each component and supports the design-system light and
-dark themes.
+interactive examples for each component and includes a toolbar toggle for the
+design-system light and dark themes. Add stories for any new UI element so
+reviewers can verify visuals.
 
 ```bash
 npm run storybook

--- a/README.md
+++ b/README.md
@@ -330,6 +330,22 @@ The CI pipeline also enforces commitlint via
 - [UI Patterns](docs/PATTERNS.md) shows common layouts and best practices.
 - [Excel Import](docs/EXCEL_IMPORT.md) details workbook loading and sync.
 
+## Storybook
+
+Run the component explorer to preview the UI library. Storybook exposes
+interactive examples for each component and supports the design-system light and
+dark themes.
+
+```bash
+npm run storybook
+```
+
+Generate a static Storybook site for publishing with:
+
+```bash
+npm run build-storybook
+```
+
 ## Docker Image
 
 The project can be packaged as a container image. Build and run using:

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -10,8 +10,8 @@ Explains how to:
 - Adopt the **@mirohq/design-system** components to ensure 100% alignment with
   Miro visuals.
 - Use **@mirohq/design-system** components directly for new features.
-- Use the lightweight wrapper components in `src/ui/components` while older
-  versions remain in `src/ui/components/legacy` until migration completes.
+- Use the lightweight wrapper components in `src/ui/components` for simplified
+  markup.
 - Meet the accessibility, performance and quality gates defined in
   **ARCHITECTURE.md** and **FOUNDATION.md**.
 
@@ -60,9 +60,8 @@ nested tab sets.
 
 The design system expects container elements to declare their own padding. To
 preserve the existing API and layering, small wrappers live under
-`src/ui/components` (e.g. `Panel`, `Section`, `ActionBar`). Legacy variants live
-under `src/ui/components/legacy`. Each wrapper accepts a `padding` prop that
-maps to numeric values from `@mirohq/design-tokens`:
+`src/ui/components` (e.g. `Panel`, `Section`, `ActionBar`). Each wrapper accepts
+a `padding` prop that maps to numeric values from `@mirohq/design-tokens`:
 
 ```tsx
 <Panel padding='medium'>
@@ -75,8 +74,7 @@ underlying design-system primitives. This keeps styling decisions inside the
 component. Keep nesting shallow to avoid unnecessary DOM layers.
 
 Common form controls such as `Button`, `InputField` and `Select` are provided
-under `src/ui/components`. Older variants remain in `src/ui/components/legacy`
-while the UI migrates to the design system.
+under `src/ui/components`.
 
 `InputField` composes a label with a form control. Pass the control component
 via the `as` prop and provide its props through `options`:
@@ -95,9 +93,8 @@ via the `as` prop and provide its props through `options`:
 >
 > 1. Write semantic HTML (for example `<div class="grid grid-gap-8">`).
 > 2. Apply the documented design-system tokens or component styles.
-> 3. Encapsulate the markup in a small local React component under
->    `src/ui/components/legacy/` so future upgrades can swap the implementation
->    behind a stable API.
+> 3. Encapsulate the markup in a small local React component so future upgrades
+>    can swap the implementation behind a stable API.
 
 ---
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -47,6 +47,7 @@ components or compose using the design system tokens.
 | **Modal**                     | title, isOpen, onClose          | small, medium             | auto                |
 | _SidebarTab_                  | id, icon, title                 | persistent, modal         | fill                |
 | _TabBar_                      | tabs, tab, onChange, size?      | regular, small            | 48                  |
+| **TabPanel**                  | tabId                           | –                         | fill                |
 | **Grid**                      | gap, columns                    | responsive                | n/a                 |
 | **Stack**                     | gap, direction                  | vertical, horizontal      | n/a                 |
 | **Cluster**                   | gap, align                      | left, right, centre       | n/a                 |

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -20,6 +20,10 @@ developer can translate designs into code with zero ambiguity.
 
 ---
 
+Each page component wraps its content in a `TabPanel` wrapper which sets
+`role="tabpanel"` and links the panel to its controlling tab. Preview the tab
+layouts under **Pages/Tabs** in Storybook.
+
 ## 1  Diagrams Tab
 
 | Step | UI Element         | Copy (EN‑AU)                           | Interaction Flow                               | State Store   |

--- a/docs/UI_MODULES.md
+++ b/docs/UI_MODULES.md
@@ -18,17 +18,6 @@ src/ui/
     RowInspector.tsx
     SegmentedControl.tsx
     TabBar.tsx
-    legacy/
-      Button.tsx
-      Checkbox.tsx
-      FormGroup.tsx
-      Heading.tsx
-      Icon.tsx
-      InputField.tsx
-      Paragraph.tsx
-      Select.tsx
-      Text.tsx
-      index.ts
   hooks/
     excel-data-context.tsx
     notifications.ts
@@ -69,7 +58,6 @@ src/ui/
 | components/RowInspector.tsx      | Displays row details in side panel.                    |
 | components/SegmentedControl.tsx  | Simple segmented switch for small options.             |
 | components/TabBar.tsx            | Horizontal list of available tabs.                     |
-| components/legacy/               | Legacy folder; all wrappers have been migrated.        |
 | hooks/                           | React hooks for state management and board operations. |
 | pages/                           | Individual tabs rendered inside the panel.             |
 | style-presets.ts                 | Named style collections for widgets.                   |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "description": "Miro diagramming plugin template",
   "keywords": [
-    "Mirotone",
     "React",
     "TypeScript",
     "Miro Web SDK",

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -3,7 +3,7 @@
 @import '@mirohq/design-system-themes/light.css';
 
 :root {
-  /* Mirotone alias variables mapped to design-system tokens */
+  /* Design-system token variables */
   --space-xxsmall: var(--space-50);
   --space-xsmall: var(--space-100);
   --space-small: var(--space-200);

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ArrangeTab } from '../ui/pages/ArrangeTab';
+import { CardsTab } from '../ui/pages/CardsTab';
+import { SearchTab } from '../ui/pages/SearchTab';
+
+const meta: Meta = {
+  title: 'Pages/Tabs',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Arrange: Story = { render: () => <ArrangeTab /> };
+export const Cards: Story = { render: () => <CardsTab /> };
+export const Search: Story = { render: () => <SearchTab /> };

--- a/src/ui/components/FormGroup.tsx
+++ b/src/ui/components/FormGroup.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { Form, styled } from '@mirohq/design-system';
-import { tokens } from '../tokens';
+import { space as dsSpace } from '@mirohq/design-tokens';
+
+// Add semantic alias for spacing tokens until the design-tokens package
+// exposes named slots. Small corresponds to 16 px.
+const space = { ...dsSpace, small: dsSpace[200] } as const;
 
 export type FormGroupProps = Readonly<React.ComponentProps<typeof Form.Field>>;
 
 /**
  * Wrapper for grouping related form fields with consistent vertical spacing.
  */
-const StyledFormField = styled(Form.Field, {
-  marginBottom: tokens.space.small,
-});
+const StyledFormField = styled(Form.Field, { marginBottom: space.small });
 
 export function FormGroup({
   children,

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Button } from './Button';
 import { getDropzoneStyle } from '../hooks/ui-utils';
-import { space } from '@mirohq/design-tokens';
+import { space as dsSpace } from '@mirohq/design-tokens';
+
+// Provide semantic spacing aliases until the design tokens include them.
+const space = { ...dsSpace, small: dsSpace[200] } as const;
 import { IconSquareArrowIn, Text } from '@mirohq/design-system';
 
 export type JsonDropZoneProps = Readonly<{
@@ -52,7 +55,7 @@ export function JsonDropZone({
           {...fileInputProps}
         />
         {dropzone.isDragAccept ? (
-          <p style={{ margin: tokens.space.small }}>Drop your JSON file here</p>
+          <p style={{ margin: space.small }}>Drop your JSON file here</p>
         ) : (
           <div style={{ padding: space[200] }}>
             <Button
@@ -61,7 +64,7 @@ export function JsonDropZone({
               icon={<IconSquareArrowIn />}>
               <Text>Select JSON file</Text>
             </Button>
-            <p style={{ marginTop: tokens.space.small }}>
+            <p style={{ marginTop: space.small }}>
               Or drop your JSON file here
             </p>
           </div>

--- a/src/ui/components/Select.tsx
+++ b/src/ui/components/Select.tsx
@@ -19,8 +19,8 @@ export type SelectProps = Readonly<{
 /**
  * Wrapper around the design-system `Select` component.
  *
- * It exposes a simplified API compatible with the legacy select used in
- * earlier versions built with Mirotone.
+ * It exposes a simplified API compatible with earlier implementations
+ * so existing callers require no changes.
  */
 export function Select({
   value,

--- a/src/ui/components/TabPanel.tsx
+++ b/src/ui/components/TabPanel.tsx
@@ -1,19 +1,29 @@
 import React from 'react';
-import type { TabId } from '../pages/tab-definitions';
 
 /**
  * Wraps tab content with appropriate ARIA attributes.
  */
-export const TabPanel: React.FC<{
+export interface TabPanelProps extends React.ComponentPropsWithoutRef<'div'> {
   /** Identifier of the tab controlling this panel. */
-  tabId: TabId;
+  readonly tabId: string;
   /** Panel content. */
-  children: React.ReactNode;
-}> = ({ tabId, children }) => (
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Wraps tab content with appropriate ARIA attributes while forwarding
+ * remaining props to the underlying container.
+ */
+export const TabPanel: React.FC<TabPanelProps> = ({
+  tabId,
+  children,
+  ...props
+}) => (
   <div
     id={`panel-${tabId}`}
     role='tabpanel'
-    aria-labelledby={`tab-${tabId}`}>
+    aria-labelledby={`tab-${tabId}`}
+    {...props}>
     {children}
   </div>
 );

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -6,6 +6,7 @@ import { CardProcessor } from '../../board/card-processor';
 import { showError } from '../hooks/notifications';
 import { undoLastImport } from '../hooks/ui-utils';
 import { Grid, IconArrowArcLeft, IconPlus, Text } from '@mirohq/design-system';
+import { TabPanel } from '../components/TabPanel';
 
 /** UI for the Cards tab. */
 export const CardsTab: React.FC = () => {
@@ -60,10 +61,7 @@ export const CardsTab: React.FC = () => {
   };
 
   return (
-    <div
-      id='panel-cards'
-      role='tabpanel'
-      aria-labelledby='tab-cards'>
+    <TabPanel tabId='cards'>
       <JsonDropZone onFiles={handleFiles} />
 
       {files.length > 0 && (
@@ -133,6 +131,6 @@ export const CardsTab: React.FC = () => {
           </Grid.Item>
         </Grid>
       )}
-    </div>
+    </TabPanel>
   );
 };

--- a/src/ui/pages/LayoutEngineTab.tsx
+++ b/src/ui/pages/LayoutEngineTab.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Paragraph } from '../components';
+import { TabPanel } from '../components/TabPanel';
 import { space } from '@mirohq/design-tokens';
 
 /** Placeholder for future layout engine options. */
 export const LayoutEngineTab: React.FC = () => (
-  <div
-    id='panel-layout'
-    role='tabpanel'
-    aria-labelledby='tab-layout'
+  <TabPanel
+    tabId='layout'
     style={{ marginTop: space[200] }}>
     <Paragraph>Layout engine coming soon.</Paragraph>
-  </div>
+  </TabPanel>
 );

--- a/src/ui/pages/StructuredTab.tsx
+++ b/src/ui/pages/StructuredTab.tsx
@@ -7,6 +7,7 @@ import {
   SelectOption,
 } from '../components';
 import { JsonDropZone } from '../components/JsonDropZone';
+import { TabPanel } from '../components/TabPanel';
 import { space } from '@mirohq/design-tokens';
 import {
   GraphProcessor,
@@ -139,10 +140,8 @@ export const StructuredTab: React.FC = () => {
   );
 
   return (
-    <div
-      id='panel-diagram'
-      role='tabpanel'
-      aria-labelledby='tab-diagram'
+    <TabPanel
+      tabId='structured'
       style={{ marginTop: space[200] }}>
       <JsonDropZone onFiles={handleFiles} />
 
@@ -376,6 +375,6 @@ export const StructuredTab: React.FC = () => {
           </Grid.Item>
         </Grid>
       )}
-    </div>
+    </TabPanel>
   );
 };

--- a/tests/tab-panel.test.tsx
+++ b/tests/tab-panel.test.tsx
@@ -1,0 +1,25 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TabPanel } from '../src/ui/components/TabPanel';
+
+test('renders with correct aria attributes', () => {
+  render(<TabPanel tabId='test'>Content</TabPanel>);
+  const panel = screen.getByRole('tabpanel');
+  expect(panel).toHaveAttribute('id', 'panel-test');
+  expect(panel).toHaveAttribute('aria-labelledby', 'tab-test');
+  expect(panel).toHaveTextContent('Content');
+});
+
+test('forwards props to div', () => {
+  render(
+    <TabPanel
+      tabId='other'
+      data-testid='panel'
+      className='extra'
+    />,
+  );
+  const div = screen.getByTestId('panel');
+  expect(div).toHaveClass('extra');
+});


### PR DESCRIPTION
## Summary
- switch FormGroup and JsonDropZone to design-tokens spacing
- remove Mirotone references in code and docs
- document Storybook usage in README
- drop legacy component references from docs

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6869bef3ba10832b843c8615622b36f0