### PR TITLE
Add tooltip overlay and storybook

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -168,12 +168,12 @@ Review these points manually during pull requests (see **ARCHITECTURE.md**).
 
 ## 7 Additional Patterns (brief stubs)
 
-| Name                   | Purpose                                   | Status              |
-| ---------------------- | ----------------------------------------- | ------------------- |
-| Accordion              | Progressive disclosure in forms           | Implemented         |
-| Tooltip                | Contextual help on icon buttons           | Needs React wrapper |
-| Data table (read-only) | Present static tabular info; no sorting   | Planned Q4-2025     |
-| Card list              | Board-linked items with thumbnail + title | Implemented         |
+| Name                   | Purpose                                   | Status          |
+| ---------------------- | ----------------------------------------- | --------------- |
+| Accordion              | Progressive disclosure in forms           | Implemented     |
+| Tooltip                | Contextual help on icon buttons           | Implemented     |
+| Data table (read-only) | Present static tabular info; no sorting   | Planned Q4-2025 |
+| Card list              | Board-linked items with thumbnail + title | Implemented     |
 
 Detailed specs will be added as these patterns stabilise.
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -139,3 +139,9 @@ body {
 .custom-modal-content {
   overflow-y: auto;
 }
+
+.page-help {
+  position: absolute;
+  top: var(--space-100);
+  right: var(--space-100);
+}

--- a/src/stories/Tooltip.stories.tsx
+++ b/src/stories/Tooltip.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tooltip } from '../ui/components/Tooltip';
+import { IconButton, IconQuestionMarkCircle } from '@mirohq/design-system';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  args: {
+    content: 'Helpful info',
+    children: (
+      <IconButton aria-label='Help'>
+        <IconQuestionMarkCircle />
+      </IconButton>
+    ),
+  },
+};

--- a/src/ui/components/PageHelp.tsx
+++ b/src/ui/components/PageHelp.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { IconButton, IconQuestionMarkCircle } from '@mirohq/design-system';
+import { Tooltip } from './Tooltip';
+
+export interface PageHelpProps {
+  /** Descriptive text explaining the current page. */
+  readonly content: React.ReactNode;
+  /** Accessible label for the help icon. @default 'Help' */
+  readonly ariaLabel?: string;
+}
+
+/**
+ * Displays a question mark icon with a tooltip describing the page.
+ *
+ * Position this component inside a relatively positioned container so the icon
+ * overlays the top-right corner via CSS class `page-help`.
+ */
+export function PageHelp({
+  content,
+  ariaLabel = 'Help',
+}: PageHelpProps): React.JSX.Element {
+  return (
+    <div className='page-help'>
+      <Tooltip
+        content={content}
+        side='left'
+        align='start'>
+        <IconButton
+          aria-label={ariaLabel}
+          size='small'
+          variant='ghost'>
+          <IconQuestionMarkCircle />
+        </IconButton>
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/ui/components/TabPanel.tsx
+++ b/src/ui/components/TabPanel.tsx
@@ -17,12 +17,14 @@ export interface TabPanelProps extends React.ComponentPropsWithoutRef<'div'> {
 export const TabPanel: React.FC<TabPanelProps> = ({
   tabId,
   children,
+  style,
   ...props
 }) => (
   <div
     id={`panel-${tabId}`}
     role='tabpanel'
     aria-labelledby={`tab-${tabId}`}
+    style={{ position: 'relative', ...style }}
     {...props}>
     {children}
   </div>

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Tooltip as DSTooltip } from '@mirohq/design-system';
+
+export interface TooltipProps {
+  /** Text displayed inside the tooltip. */
+  readonly content: React.ReactNode;
+  /** Element triggering the tooltip on hover or focus. */
+  readonly children: React.ReactElement;
+  /** Preferred side of the trigger to render against. @default 'top' */
+  readonly side?: 'top' | 'right' | 'bottom' | 'left';
+  /** Alignment along the trigger axis. @default 'center' */
+  readonly align?: 'start' | 'center' | 'end';
+}
+
+/**
+ * Simplified wrapper around the design-system Tooltip.
+ *
+ * Encapsulates the standard Trigger/Content structure so callers only
+ * provide the trigger element and tooltip label.
+ */
+export function Tooltip({
+  content,
+  children,
+  side = 'top',
+  align = 'center',
+}: TooltipProps): React.JSX.Element {
+  return (
+    <DSTooltip.Provider
+      delayDuration={0}
+      skipDelayDuration={0}>
+      <DSTooltip
+        delayDuration={0}
+        skipDelayDuration={0}>
+        <DSTooltip.Trigger asChild>{children}</DSTooltip.Trigger>
+        <DSTooltip.Portal>
+          <DSTooltip.Content
+            side={side}
+            align={align}>
+            {content}
+          </DSTooltip.Content>
+        </DSTooltip.Portal>
+      </DSTooltip>
+    </DSTooltip.Provider>
+  );
+}

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -15,3 +15,5 @@ export { Markdown } from './Markdown';
 export { RegexSearchField } from './RegexSearchField';
 export { FilterDropdown } from './FilterDropdown';
 export { FormGroup } from './FormGroup';
+export { Tooltip } from './Tooltip';
+export { PageHelp } from './PageHelp';

--- a/src/ui/pages/ArrangeTab.tsx
+++ b/src/ui/pages/ArrangeTab.tsx
@@ -9,6 +9,7 @@ import {
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import {
   Grid,
@@ -64,6 +65,7 @@ export const ArrangeTab: React.FC = () => {
 
   return (
     <TabPanel tabId='arrange'>
+      <PageHelp content='Grid and spacing tools' />
       <Grid columns={2}>
         <Grid.Item>
           <InputField

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -7,6 +7,7 @@ import { showError } from '../hooks/notifications';
 import { undoLastImport } from '../hooks/ui-utils';
 import { Grid, IconArrowArcLeft, IconPlus, Text } from '@mirohq/design-system';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 
 /** UI for the Cards tab. */
 export const CardsTab: React.FC = () => {
@@ -62,6 +63,7 @@ export const CardsTab: React.FC = () => {
 
   return (
     <TabPanel tabId='cards'>
+      <PageHelp content='Board-linked items with thumbnail and title' />
       <JsonDropZone onFiles={handleFiles} />
 
       {files.length > 0 && (

--- a/src/ui/pages/DiagramsTab.tsx
+++ b/src/ui/pages/DiagramsTab.tsx
@@ -3,6 +3,7 @@ import { StructuredTab } from './StructuredTab';
 import { CardsTab } from './CardsTab';
 import { LayoutEngineTab } from './LayoutEngineTab';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import { Tabs } from '@mirohq/design-system';
 
@@ -32,6 +33,7 @@ export const DiagramsTab: React.FC = () => {
   }
   return (
     <TabPanel tabId='diagrams'>
+      <PageHelp content='Import data or experiment with the layout engine' />
       <Tabs
         value={sub}
         variant={'tabs'}

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../core/utils/excel-loader';
 import { templateManager } from '../../board/templates';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import { showError } from '../hooks/notifications';
 import { RowInspector } from '../components/RowInspector';
 import type { TabTuple } from './tab-definitions';
@@ -133,6 +134,7 @@ export const ExcelTab: React.FC = () => {
 
   return (
     <TabPanel tabId='excel'>
+      <PageHelp content='Import nodes from Excel workbooks' />
       <div
         {...dropzone.getRootProps({ style })}
         aria-label='Excel drop area'>

--- a/src/ui/pages/FramesTab.tsx
+++ b/src/ui/pages/FramesTab.tsx
@@ -5,6 +5,7 @@ import {
   renameSelectedFrames,
 } from '../../board/frame-tools';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import {
   Grid,
@@ -26,6 +27,7 @@ export const FramesTab: React.FC = () => {
   };
   return (
     <TabPanel tabId='frames'>
+      <PageHelp content='Rename or lock selected frames' />
       <Grid columns={2}>
         <Grid.Item>
           <Heading level={2}>Rename Frames</Heading>

--- a/src/ui/pages/HelpTab.tsx
+++ b/src/ui/pages/HelpTab.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Paragraph, Button, Markdown } from '../components';
 import changelog from '../../../CHANGELOG.md?raw';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import { Heading } from '@mirohq/design-system';
 
@@ -11,6 +12,7 @@ export const HelpTab: React.FC = () => {
 
   return (
     <TabPanel tabId='help'>
+      <PageHelp content='Overview of diagram options and tools' />
       <Heading level={2}>Getting Started</Heading>
       <Paragraph>
         Use the Create tab to import diagrams or cards from a JSON file. Nodes

--- a/src/ui/pages/LayoutEngineTab.tsx
+++ b/src/ui/pages/LayoutEngineTab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Paragraph } from '../components';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import { space } from '@mirohq/design-tokens';
 
 /** Placeholder for future layout engine options. */
@@ -8,6 +9,7 @@ export const LayoutEngineTab: React.FC = () => (
   <TabPanel
     tabId='layout'
     style={{ marginTop: space[200] }}>
+    <PageHelp content='Layout engine coming soon' />
     <Paragraph>Layout engine coming soon.</Paragraph>
   </TabPanel>
 );

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -25,6 +25,7 @@ import {
   AspectRatioId,
 } from '../../core/utils/aspect-ratio';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import {
   Heading,
   Text,
@@ -127,6 +128,7 @@ export const ResizeTab: React.FC = () => {
 
   return (
     <TabPanel tabId='size'>
+      <PageHelp content='Adjust size manually or copy from selection' />
       <Paragraph data-testid='size-display'>
         {copiedSize
           ? `Copied: ${copiedSize.width}×${copiedSize.height}`

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -14,6 +14,7 @@ import {
   useReplaceCurrent,
 } from '../hooks/use-search-handlers';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import {
   IconArrowRight,
@@ -128,6 +129,7 @@ export const SearchTab: React.FC = () => {
 
   return (
     <TabPanel tabId='search'>
+      <PageHelp content='Find and replace text on the board' />
       <Grid columns={2}>
         <Grid.Item>
           <RegexSearchField

--- a/src/ui/pages/StructuredTab.tsx
+++ b/src/ui/pages/StructuredTab.tsx
@@ -8,6 +8,7 @@ import {
 } from '../components';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import { space } from '@mirohq/design-tokens';
 import {
   GraphProcessor,
@@ -143,6 +144,7 @@ export const StructuredTab: React.FC = () => {
     <TabPanel
       tabId='structured'
       style={{ marginTop: space[200] }}>
+      <PageHelp content='Flow or tree diagrams with advanced options' />
       <JsonDropZone onFiles={handleFiles} />
 
       {importQueue.length > 0 && (

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -13,6 +13,7 @@ import { adjustColor } from '../../core/utils/color-utils';
 import { useSelection } from '../hooks/use-selection';
 import { colors, space } from '@mirohq/design-tokens';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import { Grid, Form, Heading, IconSlidersX, Text } from '@mirohq/design-system';
 
@@ -48,6 +49,7 @@ export const StyleTab: React.FC = () => {
   const sliderId = React.useId();
   return (
     <TabPanel tabId='style'>
+      <PageHelp content='Lighten or darken the fill colour of selected shapes' />
       <Grid columns={2}>
         <Grid.Item>
           <Form.Field>

--- a/src/ui/pages/ToolsTab.tsx
+++ b/src/ui/pages/ToolsTab.tsx
@@ -4,6 +4,7 @@ import { StyleTab } from './StyleTab';
 import { ArrangeTab } from './ArrangeTab';
 import { FramesTab } from './FramesTab';
 import { TabPanel } from '../components/TabPanel';
+import { PageHelp } from '../components/PageHelp';
 import type { TabTuple } from './tab-definitions';
 import { Tabs } from '@mirohq/design-system';
 
@@ -42,6 +43,7 @@ export const ToolsTab: React.FC = () => {
   const Current = SUB_TAB_COMPONENTS[sub];
   return (
     <TabPanel tabId='tools'>
+      <PageHelp content='Adjust size, style, arrange and frame utilities' />
       <Tabs
         value={sub}
         variant={'tabs'}

--- a/tests/arrange-tab.test.tsx
+++ b/tests/arrange-tab.test.tsx
@@ -6,6 +6,15 @@ import { ArrangeTab } from '../src/ui/pages/ArrangeTab';
 import * as grid from '../src/board/grid-tools';
 import * as spacing from '../src/board/spacing-tools';
 
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(
+  global as unknown as { ResizeObserver: typeof ResizeObserver }
+).ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
 beforeEach(() => {
   vi.spyOn(grid, 'applyGridLayout').mockResolvedValue(undefined);
   vi.spyOn(spacing, 'applySpacingLayout').mockResolvedValue(undefined);
@@ -36,5 +45,13 @@ describe('ArrangeTab', () => {
     render(<ArrangeTab />);
     fireEvent.click(screen.getByRole('button', { name: 'Distribute' }));
     expect(spy).toHaveBeenCalled();
+  });
+
+  test('shows page help tooltip', async () => {
+    render(<ArrangeTab />);
+    const helpButton = screen.getByRole('button', { name: 'Help' });
+    fireEvent.focus(helpButton);
+    const tip = await screen.findByRole('tooltip');
+    expect(tip).toHaveTextContent('Grid and spacing tools');
   });
 });

--- a/tests/page-help.test.tsx
+++ b/tests/page-help.test.tsx
@@ -1,0 +1,24 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PageHelp } from '../src/ui/components/PageHelp';
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(
+  global as unknown as { ResizeObserver: typeof ResizeObserver }
+).ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+describe('PageHelp', () => {
+  test('shows tooltip on focus', async () => {
+    render(<PageHelp content='Example help' />);
+    const button = screen.getByRole('button', { name: 'Help' });
+    fireEvent.focus(button);
+    const tip = await screen.findByRole('tooltip');
+    expect(tip).toHaveTextContent('Example help');
+  });
+});

--- a/tests/tools-tab.test.tsx
+++ b/tests/tools-tab.test.tsx
@@ -50,7 +50,36 @@ vi.mock('@mirohq/design-system', async () => {
   Tabs.displayName = 'TabsMock';
   Tabs.List.displayName = 'TabsListMock';
   Tabs.Trigger.displayName = 'TabsTriggerMock';
-  return { Tabs };
+  const IconButton = ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+  }) => <button {...props}>{children}</button>;
+  const IconQuestionMarkCircle = () => <svg data-testid='icon' />;
+  const Tooltip = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  Tooltip.Provider = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  Tooltip.Trigger = ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  );
+  Tooltip.Content = ({ children }: { children: React.ReactNode }) => (
+    <div role='tooltip'>{children}</div>
+  );
+  Tooltip.Portal = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  IconButton.displayName = 'IconButtonMock';
+  IconQuestionMarkCircle.displayName = 'IconQuestionMarkCircleMock';
+  Tooltip.displayName = 'TooltipMock';
+  Tooltip.Provider.displayName = 'TooltipProviderMock';
+  Tooltip.Trigger.displayName = 'TooltipTriggerMock';
+  Tooltip.Content.displayName = 'TooltipContentMock';
+  Tooltip.Portal.displayName = 'TooltipPortalMock';
+  return { Tabs, IconButton, IconQuestionMarkCircle, Tooltip };
 });
 
 vi.mock('../src/ui/pages/ResizeTab', () => {

--- a/tests/tooltip.test.tsx
+++ b/tests/tooltip.test.tsx
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Tooltip } from '../src/ui/components/Tooltip';
+import { Button } from '../src/ui/components/Button';
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(
+  global as unknown as { ResizeObserver: typeof ResizeObserver }
+).ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+describe('Tooltip', () => {
+  test('renders when focusing trigger', async () => {
+    render(
+      <Tooltip
+        content='Focus text'
+        side='left'
+        align='start'>
+        <Button variant='secondary'>?</Button>
+      </Tooltip>,
+    );
+    const button = screen.getByRole('button');
+    fireEvent.focus(button);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Focus text');
+  });
+});


### PR DESCRIPTION
## Summary
- overlay help tooltip on every tab page
- provide PageHelp wrapper
- document tooltip in Storybook
- style for overlay icon
- update tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686a2a66d834832b8d7438f1b1d2a116