### PR TITLE
Update Storybook docs and CI integration

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -43,3 +43,22 @@ This project enforces consistent formatting with
 - Event handlers should not return Promises; use `void` to fire-and-forget.
 
 For additional architectural guidelines see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Storybook
+
+Run the Storybook dev server during component development to preview UI changes.
+Execute:
+
+```bash
+npm run storybook
+```
+
+This command launches Storybook on `http://localhost:6006`. Generate a static
+version with:
+
+```bash
+npm run build-storybook
+```
+
+The CI workflow defined in `.github/workflows/ci.yml` also builds Storybook to
+verify component integrity as part of each pull request.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -268,7 +268,7 @@ Failing any item blocks the CI gate.
 - Design tokens and minimal-CSS policy – **FOUNDATION.md**
 - Deployment guidance – **DEPLOYMENT.md**
 - Sidebar behaviour and validation flows – **TABS.md**
-- Storybook playground – run `npm start`, open `http://localhost:6006`
+- Storybook playground – run `npm run storybook`, open `http://localhost:6006`
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -156,6 +156,13 @@ Push → GitHub Action
 All gates and complexity budgets are defined in **ARCHITECTURE.md** (sections
 4–6).
 
+The pipeline is orchestrated by the GitHub Actions workflow in
+`.github/workflows/ci.yml`. Every push or pull request triggers the jobs listed
+above using Node 24. Artefacts from the build and Storybook steps are uploaded
+as workflow artefacts so deployment jobs can promote the exact output. Run
+`npm run ci:local` to replicate the pipeline on your machine before opening a
+pull request.
+
 ---
 
 ## 10 Troubleshooting tips


### PR DESCRIPTION
## Summary
- document Storybook usage in CODE_STYLE.md
- clarify CI workflow integration in DEPLOYMENT.md
- fix Storybook command in COMPONENTS.md

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686a3d2e6678832b9b4d016683ea75a8