### PR TITLE
Fix docs stories missing Meta references

### DIFF
--- a/src/stories/BoardBuilder.mdx
+++ b/src/stories/BoardBuilder.mdx
@@ -1,14 +1,17 @@
 import { Meta, Story, Canvas } from '@storybook/blocks';
 import { BoardBuilder } from '../board/board-builder';
 
-<Meta title="Core/BoardBuilder" />
+<Meta
+  title='Core/BoardBuilder'
+  of={BoardBuilder}
+/>
 
 # BoardBuilder
 
 Helper responsible for finding, creating and updating widgets on the board.
 
 <Canvas>
-  <Story name="usage">
+  <Story name='usage'>
     {() => {
       const builder = new BoardBuilder();
       builder.findSpace(400, 300);

--- a/src/stories/CardProcessor.mdx
+++ b/src/stories/CardProcessor.mdx
@@ -1,14 +1,17 @@
 import { Meta, Story, Canvas } from '@storybook/blocks';
 import { CardProcessor } from '../board/card-processor';
 
-<Meta title="Core/CardProcessor" />
+<Meta
+  title='Core/CardProcessor'
+  of={CardProcessor}
+/>
 
 # CardProcessor
 
 Places card widgets in a grid layout and attaches metadata for undo.
 
 <Canvas>
-  <Story name="usage">
+  <Story name='usage'>
     {() => {
       const processor = new CardProcessor();
       processor.processFile(new File([], 'cards.csv'));

--- a/src/stories/GraphProcessor.mdx
+++ b/src/stories/GraphProcessor.mdx
@@ -1,14 +1,18 @@
 import { Meta, Story, Canvas } from '@storybook/blocks';
 import { GraphProcessor } from '../core/graph/graph-processor';
 
-<Meta title="Core/GraphProcessor" />
+<Meta
+  title='Core/GraphProcessor'
+  of={GraphProcessor}
+/>
 
 # GraphProcessor
 
-High level orchestrator that loads graph data, runs layout and creates widgets on the board.
+High level orchestrator that loads graph data, runs layout and creates widgets
+on the board.
 
 <Canvas>
-  <Story name="usage">
+  <Story name='usage'>
     {() => {
       const processor = new GraphProcessor();
       processor.processFile(new File([], 'graph.json'));


### PR DESCRIPTION
## Summary
- reference components in MDX docs using the `<Meta of={}>` syntax

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686a60deeff4832ba599b4e713f4ad67