### PR TITLE
Add App story and style import

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,6 +6,7 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-docs',
+    '@storybook/addon-viewport',
   ],
   framework: { name: '@storybook/react-vite', options: {} },
   docs: { autodocs: 'tag' },

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Decorator, Preview } from '@storybook/react';
 import '@mirohq/design-system-themes/base.css';
 import '@mirohq/design-system-themes/light.css';
+import '../src/assets/style.css';
 
 /**
  * Custom viewport definitions for Storybook. Miro restricts embedded

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@storybook/addon-docs": "^9.0.0-alpha.12",
         "@storybook/addon-essentials": "^9.0.0-alpha.12",
         "@storybook/addon-links": "^9.0.0-alpha.12",
+        "@storybook/addon-viewport": "^9.0.0-alpha.12",
         "@storybook/react-vite": "^9.0.0-alpha.12",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -7363,6 +7364,17 @@
       },
       "peerDependencies": {
         "storybook": "^9.0.0-alpha.12"
+      }
+    },
+    "node_modules/@storybook/addon-viewport": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-9.0.8.tgz",
+      "integrity": "sha512-HgIFDzNXvMx0zQBM5mhwBoAJlrF9KRlxNCZnJbqrFLCJO4Ps2PMtB0HRGHcg0gm3RLcqyps0DpiF7wll3udb7Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/blocks": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/addon-docs": "^9.0.0-alpha.12",
     "@storybook/addon-essentials": "^9.0.0-alpha.12",
     "@storybook/addon-links": "^9.0.0-alpha.12",
+    "@storybook/addon-viewport": "^9.0.0-alpha.12",
     "@storybook/react-vite": "^9.0.0-alpha.12",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/stories/App.stories.tsx
+++ b/src/stories/App.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { App } from '../app/App';
+
+const meta: Meta<typeof App> = {
+  title: 'Pages/App',
+  component: App,
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj<typeof App>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- add Storybook viewport addon
- include app styles in Storybook
- show `App` page in Storybook

## Testing
- `npm run test --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686a6d24a320832b9acb2f851f1ca4e1