### PR TITLE
Improve UI branch coverage

### DIFF
--- a/tests/diagrams-tab-switch.test.tsx
+++ b/tests/diagrams-tab-switch.test.tsx
@@ -1,0 +1,17 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DiagramsTab } from '../src/ui/pages/DiagramsTab';
+
+describe('DiagramsTab switching', () => {
+  test('changes sub tabs', () => {
+    render(<DiagramsTab />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Cards' }));
+    expect(
+      screen.getByText('Board-linked items with thumbnail and title'),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'Layout Engine' }));
+    expect(screen.getByText('Layout engine coming soon.')).toBeInTheDocument();
+  });
+});

--- a/tests/excel-tab-branches.test.tsx
+++ b/tests/excel-tab-branches.test.tsx
@@ -1,0 +1,137 @@
+/** @vitest-environment jsdom */
+/* eslint-disable no-var */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ExcelTab } from '../src/ui/pages/ExcelTab';
+
+var localDropMock: vi.Mock;
+var remoteFetchMock: vi.Mock;
+var showErrorMock: vi.Mock;
+var excelLoaderMock: Record<string, unknown>;
+var graphLoaderMock: Record<string, unknown>;
+
+vi.mock('../src/ui/hooks/use-excel-sync', () => ({
+  useExcelSync: () => vi.fn(),
+}));
+vi.mock('../src/ui/hooks/excel-data-context', () => ({
+  useExcelData: () => null,
+}));
+vi.mock('../src/ui/components/Select', () => ({
+  Select: ({
+    value,
+    onChange,
+    children,
+  }: {
+    value?: string;
+    onChange?: (v: string) => void;
+    children?: React.ReactNode;
+  }) => (
+    <select
+      value={value}
+      onChange={(e) => onChange?.(e.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectOption: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => <option value={value}>{children}</option>,
+}));
+vi.mock('../src/ui/hooks/use-excel-handlers', () => {
+  localDropMock = vi.fn();
+  remoteFetchMock = vi.fn();
+  return {
+    useExcelDrop: () => ({
+      dropzone: { getRootProps: () => ({}), getInputProps: () => ({}) },
+      style: {},
+    }),
+    useExcelCreate: () => vi.fn(),
+    handleLocalDrop: (files: File[]) => localDropMock(files),
+    fetchRemoteWorkbook: (url: string) => remoteFetchMock(url),
+  };
+});
+vi.mock('../src/core/utils/excel-loader', () => {
+  excelLoaderMock = {
+    listSheets: vi.fn(() => ['Sheet1']),
+    listNamedTables: vi.fn(() => ['Table1']),
+    loadSheet: vi.fn(() => [{ A: 1 }]),
+    loadNamedTable: vi.fn(() => [{ T: 1 }]),
+  };
+  graphLoaderMock = {
+    listSheets: vi.fn(() => ['Remote']),
+    listNamedTables: vi.fn(() => []),
+    loadSheet: vi.fn(() => [{ B: 2 }]),
+    loadNamedTable: vi.fn(() => []),
+  };
+  return {
+    excelLoader: excelLoaderMock,
+    graphExcelLoader: graphLoaderMock,
+    ExcelLoader: class {},
+    GraphExcelLoader: class {},
+  };
+});
+vi.mock('../src/ui/hooks/notifications', () => {
+  showErrorMock = vi.fn();
+  return { showError: showErrorMock };
+});
+
+describe('ExcelTab branches', () => {
+  test('fetch error displays notification', async () => {
+    remoteFetchMock.mockRejectedValueOnce(new Error('fail'));
+    render(<ExcelTab />);
+    fireEvent.change(screen.getByLabelText('graph file'), {
+      target: { value: 'bad' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Fetch File' }));
+    });
+    expect(showErrorMock).toHaveBeenCalledWith('Error: fail');
+  });
+
+  test('loads rows from sheet and toggles selection', () => {
+    render(<ExcelTab />);
+    const select = screen
+      .getByText('Data source')
+      .parentElement!.querySelector('select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'sheet:Sheet1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Load Rows' }));
+    expect(screen.getByText('{"A":1}')).toBeInTheDocument();
+    const checkbox = screen.getByRole('switch', { name: 'Row 1' });
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(checkbox);
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(checkbox);
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('loads rows from named table', () => {
+    render(<ExcelTab />);
+    const select = screen
+      .getByText('Data source')
+      .parentElement!.querySelector('select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'table:Table1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Load Rows' }));
+    expect(screen.getByText('{"T":1}')).toBeInTheDocument();
+  });
+
+  test('successful remote fetch switches loader', async () => {
+    render(<ExcelTab />);
+    remoteFetchMock.mockResolvedValueOnce(undefined);
+    fireEvent.change(screen.getByLabelText('graph file'), {
+      target: { value: 'url' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Fetch File' }));
+    });
+    const select = screen
+      .getByText('Data source')
+      .parentElement!.querySelector('select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'sheet:Remote' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Load Rows' }));
+    expect(screen.getByText('{"B":2}')).toBeInTheDocument();
+  });
+});

--- a/tests/layout-engine-tab.test.tsx
+++ b/tests/layout-engine-tab.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LayoutEngineTab } from '../src/ui/pages/LayoutEngineTab';
+
+describe('LayoutEngineTab', () => {
+  test('renders placeholder message', () => {
+    render(<LayoutEngineTab />);
+    expect(screen.getByText('Layout engine coming soon.')).toBeInTheDocument();
+  });
+});

--- a/tests/structured-tab-branches.test.tsx
+++ b/tests/structured-tab-branches.test.tsx
@@ -1,0 +1,66 @@
+/** @vitest-environment jsdom */
+/* eslint-disable no-var */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StructuredTab } from '../src/ui/pages/StructuredTab';
+
+var createSpy: vi.Mock;
+var undoSpy: vi.Mock;
+var lastProc: { undoLast: vi.Mock };
+
+vi.mock('../src/ui/hooks/use-diagram-create', () => ({
+  useDiagramCreate: (
+    _queue: File[],
+    _opts: unknown,
+    _setQueue: (f: React.SetStateAction<File[]>) => void,
+    setProgress: (p: number) => void,
+    setError: (e: string | null) => void,
+    setLastProc: (p: unknown) => void,
+  ) => {
+    createSpy = vi.fn(async () => {
+      setProgress(25);
+      setError('boom');
+      lastProc = { undoLast: vi.fn() };
+      setLastProc(lastProc);
+    });
+    return createSpy;
+  },
+  useAdvancedToggle: () => {},
+}));
+vi.mock('../src/ui/hooks/ui-utils', async () => {
+  const actual = await vi.importActual<
+    typeof import('../src/ui/hooks/ui-utils')
+  >('../src/ui/hooks/ui-utils');
+  undoSpy = vi.fn(async (proc: { undoLast: () => void }, clear: () => void) => {
+    proc.undoLast();
+    clear();
+  });
+  return { ...actual, undoLastImport: undoSpy };
+});
+
+function makeFile(name: string): File {
+  return new File(['{}'], name, { type: 'application/json' });
+}
+
+describe('StructuredTab branches', () => {
+  test('shows progress, error and undo workflow', async () => {
+    render(<StructuredTab />);
+    const input = screen.getByTestId('file-input');
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [makeFile('graph.json')] } });
+    });
+    await act(async () => {
+      await createSpy();
+    });
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    const undo = screen.getByRole('button', { name: /undo last import/i });
+    fireEvent.click(undo);
+    expect(lastProc.undoLast).toHaveBeenCalled();
+    expect(undoSpy).toHaveBeenCalled();
+    expect(
+      screen.queryByRole('button', { name: /undo last import/i }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add additional ExcelTab branch tests
- cover StructuredTab progress and undo flow
- test placeholder LayoutEngineTab
- verify DiagramsTab subtab switching

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b3174d750832bb38c55e4852547a4