### PR TITLE
Split lint and test jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 permissions: write-all
 
 jobs:
-  lint-test:
+  static-analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,11 +31,30 @@ jobs:
         run: npm run stylelint
       - name: Typecheck
         run: npm run typecheck
+
+  unit-tests:
+    needs: static-analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: corepack enable
+      - run: npm install --frozen-lockfile || npm install
+      - name: Audit dependencies
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Unit tests
         run: npm test
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
 
   sonar:
-    needs: lint-test
+    needs: unit-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +68,11 @@ jobs:
       - run: npm install --frozen-lockfile || npm install
       - name: Audit dependencies
         run: npm audit --omit=dev --audit-level=moderate
-      - run: npm test
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: coverage
       - name: SonarCloud Scan
         uses: sonarsource/sonarqube-scan-action@v5
         with:


### PR DESCRIPTION
## Summary
- split lint job into `static-analysis` and `unit-tests`
- reuse unit test coverage for the sonar scan

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_686bba8f6f1c832b83af77d1c37fd14c