### PR TITLE
fix(board): cache newly created tags

### DIFF
--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -181,10 +181,9 @@ export class CardProcessor extends UndoableProcessor<Card | Frame> {
       if (!tag) {
         tag = await miro.board.createTag({ title: name });
         tagMap.set(name, tag);
+        this.tagsCache?.push(tag);
       }
-      if (tag.id) {
-        ids.push(tag.id);
-      }
+      if (tag.id) ids.push(tag.id);
     }
     return ids;
   }

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -143,6 +143,12 @@ describe('CardProcessor', () => {
     expect(args.tagIds).toEqual(['t1']);
   });
 
+  test('new tags update cache', async () => {
+    await processor.processCards([{ title: 'A', tags: ['gamma'] }]);
+    const cache = (processor as unknown as { tagsCache: unknown[] }).tagsCache;
+    expect(cache).toHaveLength(1);
+  });
+
   test('updates card when id matches', async () => {
     const existing = {
       id: 'c2',


### PR DESCRIPTION
## Summary
- add newly created tags to the board tag cache
- verify cache update in CardProcessor tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6875b5b4f718832ba34dd2ccc5e4a7d8