### PR TITLE
Add pino logger with LOG_LEVEL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,19 @@ With `package-lock.json` checked in you can run `npm audit` after each install
 to scan dependencies for vulnerabilities. Include the lock file in commits so
 everyone uses the exact dependency versions when installing.
 
+## Logging
+
+All runtime messages are emitted through a shared logger defined in
+[`src/logger.ts`](src/logger.ts). Set the `LOG_LEVEL` environment variable to
+`trace`, `debug`, `info`, `warn`, `error` or `silent` to control verbosity. It
+defaults to `info`.
+
+Example:
+
+```bash
+LOG_LEVEL=debug npm start
+```
+
 ## Commit message checks
 
 Commit messages must follow the Conventional Commits specification. A

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,6 +55,7 @@ Define variables in the host’s dashboard (or `vercel env`).
 | **FEATURE_FLAG_SDK_KEY** | LaunchDarkly SDK key (client-side)                 |
 | **SENTRY_DSN**           | Error-reporting endpoint                           |
 | **NODE_ENV**             | build-time optimisation flag (production, staging) |
+| **LOG_LEVEL**            | runtime log verbosity (`info`, `debug`, `trace`)   |
 
 Variables are injected at build time—no runtime secrets are required because the
 add-on is client-only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "d3-dsv": "^3.0.1",
         "elkjs": "^0.10.0",
         "exceljs": "^4.4.0",
+        "pino": "^8.21.0",
         "react-dropzone": "^14.3.8"
       },
       "devDependencies": {
@@ -8222,6 +8223,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -8717,6 +8730,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/attr-accept": {
@@ -11134,6 +11156,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exceljs": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
@@ -11286,6 +11326,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
@@ -17274,6 +17323,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -17662,6 +17720,84 @@
         "node": ">=4"
       }
     },
+    "node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
     "node_modules/pkg-conf": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
@@ -17890,10 +18026,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -17949,6 +18100,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/rc": {
@@ -18339,6 +18496,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -18708,6 +18874,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -19385,6 +19560,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -19452,7 +19636,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -20333,6 +20516,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "d3-dsv": "^3.0.1",
     "elkjs": "^0.10.0",
     "exceljs": "^4.4.0",
+    "pino": "^8.21.0",
     "react-dropzone": "^14.3.8"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { DiagramApp } from './app/diagram-app';
+import { log } from './logger';
 
 DiagramApp.getInstance()
   .init()
   .catch((err) => {
-    // eslint-disable-next-line no-console
-    console.error(err);
+    log.error(err);
   });
 
 export {};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,16 @@
+import pino from 'pino';
+
+/**
+ * Centralised application logger.
+ *
+ * The log level defaults to `info` but can be overridden via the
+ * `LOG_LEVEL` environment variable. Supported levels are `trace`,
+ * `debug`, `info`, `warn`, `error` and `silent`.
+ */
+export function createLogger() {
+  const level = (process.env.LOG_LEVEL || 'info') as pino.LevelWithSilent;
+  return pino({ level, browser: { asObject: true } });
+}
+
+/** Shared logger instance used throughout the application. */
+export const log = createLogger();

--- a/src/ui/hooks/notifications.ts
+++ b/src/ui/hooks/notifications.ts
@@ -9,12 +9,12 @@
  *
  * @param message - The text to display.
  */
+import { log } from '../../logger';
+
 export async function showError(message: string): Promise<void> {
   const trimmed = message.length > 80 ? `${message.slice(0, 77)}...` : message;
-  // Log the original message to the browser console for troubleshooting.
-  // The raw message is logged to preserve detail, while the trimmed version is
-  // passed to the Miro notification API.
-  // eslint-disable-next-line no-console
-  console.error(message);
+  // Log the original message for troubleshooting and pass the trimmed version
+  // to the Miro notification API.
+  log.error(message);
   await miro.board.notifications.showError(trimmed);
 }

--- a/tests/index-error.test.ts
+++ b/tests/index-error.test.ts
@@ -9,8 +9,10 @@ vi.mock('../src/app/diagram-app', () => {
   };
 });
 
+import { log } from '../src/logger';
+
 test('logs error when initialization fails', async () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const errorSpy = jest.spyOn(log, 'error').mockImplementation(() => {});
   await import('../src/index');
   expect(errorSpy).toHaveBeenCalled();
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const ORIG_LEVEL = process.env.LOG_LEVEL;
+
+afterEach(() => {
+  process.env.LOG_LEVEL = ORIG_LEVEL;
+  vi.resetModules();
+});
+
+test('defaults to info level', async () => {
+  delete process.env.LOG_LEVEL;
+  const { log } = await import('../src/logger');
+  expect(log.level).toBe('info');
+});
+
+test('respects LOG_LEVEL environment variable', async () => {
+  process.env.LOG_LEVEL = 'trace';
+  const { log } = await import('../src/logger');
+  expect(log.level).toBe('trace');
+});

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,4 +1,5 @@
 import { showError } from '../src/ui/hooks/notifications';
+import { log } from '../src/logger';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };
@@ -13,7 +14,7 @@ describe('showError', () => {
         notifications: { showError: jest.fn().mockResolvedValue(undefined) },
       },
     };
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(log, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -23,7 +24,7 @@ describe('showError', () => {
 
   test('passes through short messages', async () => {
     await showError('fail');
-    expect(console.error).toHaveBeenCalledWith('fail');
+    expect(log.error).toHaveBeenCalledWith('fail');
     expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
       'fail',
     );
@@ -32,7 +33,7 @@ describe('showError', () => {
   test('truncates long messages', async () => {
     const long = 'a'.repeat(90);
     await showError(long);
-    expect(console.error).toHaveBeenCalledWith(long);
+    expect(log.error).toHaveBeenCalledWith(long);
     const arg = (global.miro.board.notifications.showError as jest.Mock).mock
       .calls[0][0];
     expect(arg.length).toBeLessThanOrEqual(80);


### PR DESCRIPTION
## Summary
- introduce `src/logger.ts` with pino for info/debug/trace logging
- hook logger into notifications and app initialization
- document `LOG_LEVEL` in README and deployment docs
- provide basic logger tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875b59432ac832bb6fa9d4a9c628de5