### PR TITLE
Add multi-level pino logging

### DIFF
--- a/src/app/diagram-app.ts
+++ b/src/app/diagram-app.ts
@@ -1,3 +1,5 @@
+import { log } from '../logger';
+
 /**
  * Singleton wrapper that wires the Miro Web SDK UI events.
  */
@@ -16,14 +18,19 @@ export class DiagramApp {
 
   /** Register UI handlers with the Miro board. */
   public async init(): Promise<void> {
+    log.info('Initialising Miro UI handlers');
     if (typeof miro === 'undefined' || !miro?.board?.ui) {
       throw new Error('Miro SDK not available');
     }
     miro.board.ui.on('icon:click', async () => {
+      log.trace('Icon clicked');
       await miro.board.ui.openPanel({ url: 'app.html' });
     });
+    log.debug('Registered icon:click handler');
     miro.board.ui.on('custom:edit-metadata', async () => {
+      log.trace('Edit metadata command received');
       await miro.board.ui.openPanel({ url: 'app.html?command=edit-metadata' });
     });
+    log.debug('Registered edit-metadata handler');
   }
 }

--- a/src/board/board-cache.ts
+++ b/src/board/board-cache.ts
@@ -4,6 +4,7 @@ import {
   getBoardWithQuery,
   getBoard,
 } from './board';
+import { log } from '../logger';
 
 /**
  * Singleton cache for board data.
@@ -21,14 +22,17 @@ export class BoardCache {
     board?: BoardLike,
   ): Promise<Array<Record<string, unknown>>> {
     if (!this.selection) {
+      log.trace('Fetching selection from board');
       const b = getBoard(board);
       this.selection = await b.getSelection();
+      log.debug({ count: this.selection.length }, 'Selection cached');
     }
     return this.selection;
   }
 
   /** Clear the cached selection. */
   public clearSelection(): void {
+    log.info('Clearing selection cache');
     this.selection = undefined;
   }
 
@@ -49,18 +53,21 @@ export class BoardCache {
       else missing.push(t);
     }
     if (missing.length) {
+      log.trace({ missing }, 'Fetching uncached widget types');
       const fetched = await Promise.all(missing.map((t) => b.get({ type: t })));
       for (let i = 0; i < missing.length; i += 1) {
         const list = fetched[i];
         this.widgets.set(missing[i], list);
         results.push(...list);
       }
+      log.info({ types: missing.length }, 'Cached widget query results');
     }
     return results;
   }
 
   /** Reset all cached data. */
   public reset(): void {
+    log.info('Resetting board cache');
     this.selection = undefined;
     this.widgets.clear();
   }

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -1,3 +1,5 @@
+import { log } from '../logger';
+
 export interface BoardUILike {
   on(
     event: 'selection:update',
@@ -36,10 +38,12 @@ export interface BoardQueryLike extends BoardLike {
  * @returns The board API instance.
  */
 export function getBoard(board?: BoardLike): BoardLike {
+  log.trace('Resolving board instance');
   const b =
     board ??
     (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
   if (!b) throw new Error('Miro board not available');
+  log.debug('Board resolved');
   return b;
 }
 
@@ -53,6 +57,7 @@ export function getBoard(board?: BoardLike): BoardLike {
  * @returns Board API exposing query capabilities.
  */
 export function getBoardWithQuery(board?: BoardQueryLike): BoardQueryLike {
+  log.trace('Casting board with query capabilities');
   return getBoard(board) as BoardQueryLike;
 }
 
@@ -70,6 +75,7 @@ export async function getFirstSelection(
 ): Promise<Record<string, unknown> | undefined> {
   const b = getBoard(board);
   const selection = await b.getSelection();
+  log.debug({ count: selection.length }, 'Fetched first selection');
   return selection[0] as Record<string, unknown> | undefined;
 }
 
@@ -88,6 +94,7 @@ export async function forEachSelection(
 ): Promise<void> {
   const b = getBoard(board);
   const selection = await b.getSelection();
+  log.info({ count: selection.length }, 'Processing selection');
   await Promise.all(selection.map((item) => cb(item)));
 }
 
@@ -111,6 +118,7 @@ export interface Syncable {
  */
 export async function maybeSync(item: Syncable): Promise<void> {
   if (typeof item.sync === 'function') {
+    log.trace('Syncing widget');
     await item.sync();
   }
 }

--- a/src/core/utils/file-utils.ts
+++ b/src/core/utils/file-utils.ts
@@ -1,3 +1,5 @@
+import { log } from '../../logger';
+
 /**
  * Read the contents of a `File` as UTF-8 text.
  *
@@ -22,11 +24,15 @@ export class FileUtils {
    * a `FileReader` when `file.text()` is unavailable.
    */
   public async readFileAsText(file: File): Promise<string> {
+    log.debug({ name: file.name }, 'Reading file');
     if (
       'text' in file &&
       typeof (file as { text: () => Promise<string> }).text === 'function'
     ) {
-      return (file as { text: () => Promise<string> }).text();
+      log.trace('Using File.text API');
+      const data = await (file as { text: () => Promise<string> }).text();
+      log.info('File read via text API');
+      return data;
     }
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
@@ -35,6 +41,7 @@ export class FileUtils {
           reject(new Error('Failed to load file'));
           return;
         }
+        log.info('File loaded via FileReader');
         resolve(e.target.result as string);
       };
       reader.onerror = () => reject(new Error('Failed to load file'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { DiagramApp } from './app/diagram-app';
 import { log } from './logger';
 
+log.info('Starting application');
 DiagramApp.getInstance()
   .init()
   .catch((err) => {

--- a/src/ui/hooks/notifications.ts
+++ b/src/ui/hooks/notifications.ts
@@ -16,5 +16,9 @@ export async function showError(message: string): Promise<void> {
   // Log the original message for troubleshooting and pass the trimmed version
   // to the Miro notification API.
   log.error(message);
+  if (trimmed !== message) {
+    log.debug('Trimmed long error message');
+  }
+  log.info('Showing error notification');
   await miro.board.notifications.showError(trimmed);
 }


### PR DESCRIPTION
## Summary
- add pino logger calls at info, debug and trace levels

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875c5f1c45c832bb72031fed0baee16