### PR TITLE
Fix tests with PointerEvent polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,15 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@storybook/addon-docs": "^8",
-        "@storybook/addon-essentials": "^8",
-        "@storybook/addon-links": "^8",
+        "@storybook/addon-essentials": "^8.6.14",
+        "@storybook/addon-links": "^8.6.14",
         "@storybook/addon-viewport": "^8",
         "@storybook/blocks": "^8",
-        "@storybook/react-vite": "^8",
+        "@storybook/react-vite": "^8.6.14",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/d3-dsv": "^3.0.7",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.14",
@@ -47,12 +48,12 @@
         "jsdom": "^26.1.0",
         "prettier": "^3.6.2",
         "semantic-release": "^24.2.7",
-        "storybook": "^8",
+        "storybook": "^8.6.14",
         "stylelint": "^16.21.1",
         "stylelint-config-standard": "^38.0.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.37.0",
-        "vite": "^6",
+        "vite": "^6.3.5",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -7813,6 +7814,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.37.0",
     "vite": "^6.3.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@testing-library/user-event": "^14.6.1"
   },
   "commitlint": {
     "extends": [

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -14,6 +14,15 @@ afterEach(() => {
   delete (globalThis as { miro?: unknown }).miro;
 });
 
+// Provide a minimal PointerEvent implementation for jsdom
+if (typeof window !== 'undefined' && !('PointerEvent' in window)) {
+  class PointerEvent extends MouseEvent {}
+  window.PointerEvent = PointerEvent as typeof globalThis.PointerEvent;
+  (
+    globalThis as unknown as { PointerEvent: typeof window.PointerEvent }
+  ).PointerEvent = PointerEvent as unknown as typeof window.PointerEvent;
+}
+
 afterAll(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();


### PR DESCRIPTION
## Summary
- include `@testing-library/user-event` for tab switch test
- polyfill `PointerEvent` for jsdom in setup

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68775025bc24832b9ea8b732df672efb