### PR TITLE
Fix code smells and break board cache cycle

### DIFF
--- a/src/board/board-cache.ts
+++ b/src/board/board-cache.ts
@@ -1,10 +1,17 @@
-import {
-  BoardLike,
-  BoardQueryLike,
-  getBoardWithQuery,
-  getBoard,
-} from './board';
+import type { BoardLike, BoardQueryLike } from './types';
 import { log } from '../logger';
+
+function resolveBoard(board?: BoardLike): BoardLike {
+  const b =
+    board ??
+    (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
+  if (!b) throw new Error('Miro board not available');
+  return b;
+}
+
+function resolveBoardWithQuery(board?: BoardQueryLike): BoardQueryLike {
+  return resolveBoard(board) as BoardQueryLike;
+}
 
 /**
  * Singleton cache for board data.
@@ -29,7 +36,7 @@ export class BoardCache {
   ): Promise<Array<Record<string, unknown>>> {
     if (!this.selection) {
       log.trace('Fetching selection from board');
-      const b = getBoard(board);
+      const b = resolveBoard(board);
       this.selection = await b.getSelection();
       log.debug({ count: this.selection.length }, 'Selection cached');
     } else {
@@ -52,7 +59,7 @@ export class BoardCache {
     types: string[],
     board?: BoardQueryLike,
   ): Promise<Array<Record<string, unknown>>> {
-    const b = getBoardWithQuery(board);
+    const b = resolveBoardWithQuery(board);
     const results: Array<Record<string, unknown>> = [];
     const missing: string[] = [];
     for (const t of types) {

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -1,36 +1,8 @@
 import { boardCache } from './board-cache';
 import { log } from '../logger';
+import type { BoardLike, BoardQueryLike } from './types';
 
-export interface BoardUILike {
-  on(
-    event: 'selection:update',
-    handler: (ev: { items: unknown[] }) => void,
-  ): void;
-  off?(
-    event: 'selection:update',
-    handler: (ev: { items: unknown[] }) => void,
-  ): void;
-}
-
-export interface BoardLike {
-  getSelection(): Promise<Array<Record<string, unknown>>>;
-  group?(opts: { items: Array<Record<string, unknown>> }): Promise<unknown>;
-  ui?: BoardUILike;
-  startBatch?(): Promise<void>;
-  endBatch?(): Promise<void>;
-  abortBatch?(): Promise<void>;
-}
-
-/**
- * Board API that supports querying widgets by type.
- *
- * This extends {@link BoardLike} with a `get` method, mirroring the
- * `miro.board.get()` call. Search utilities rely on this method to gather
- * candidate widgets when scanning the board.
- */
-export interface BoardQueryLike extends BoardLike {
-  get(opts: { type: string }): Promise<Array<Record<string, unknown>>>;
-}
+export type { BoardUILike, BoardLike, BoardQueryLike } from './types';
 
 /**
  * Resolve the active board instance.

--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -21,6 +21,10 @@ export interface CardProcessOptions {
 export class CardProcessor extends UndoableProcessor<Card | Frame> {
   /** Prefix used to embed identifiers in descriptions. */
   private static readonly ID_PREFIX = 'ID:';
+  /** Regex capturing an embedded identifier. */
+  private static readonly ID_REGEX = /ID:(\S+)/;
+  /** Regex removing any embedded identifier from text. */
+  private static readonly ID_REMOVE_REGEX = /\n?ID:[^\n]*/;
   /** Default width used for card widgets. */
   private static readonly CARD_WIDTH = 320;
   /** Default height used for card widgets. */
@@ -275,16 +279,13 @@ export class CardProcessor extends UndoableProcessor<Card | Frame> {
 
   /** Extract identifier from the description text. */
   private extractId(desc: string | undefined): string | undefined {
-    const match = desc?.match(new RegExp(`${CardProcessor.ID_PREFIX}(\S+)`));
+    const match = desc?.match(CardProcessor.ID_REGEX);
     return match ? match[1] : undefined;
   }
 
   /** Embed the identifier inside the description. */
   private encodeDescription(desc: string | undefined, id?: string): string {
-    const base = (desc ?? '').replace(
-      new RegExp(`\n?${CardProcessor.ID_PREFIX}[^\n]*`),
-      '',
-    );
+    const base = (desc ?? '').replace(CardProcessor.ID_REMOVE_REGEX, '');
     if (!id) return base.trim();
     const trimmed = base.trimEnd();
     return `${trimmed}${trimmed ? '\n' : ''}${CardProcessor.ID_PREFIX}${id}`;

--- a/src/board/types.ts
+++ b/src/board/types.ts
@@ -1,0 +1,23 @@
+export interface BoardUILike {
+  on(
+    event: 'selection:update',
+    handler: (ev: { items: unknown[] }) => void,
+  ): void;
+  off?(
+    event: 'selection:update',
+    handler: (ev: { items: unknown[] }) => void,
+  ): void;
+}
+
+export interface BoardLike {
+  getSelection(): Promise<Array<Record<string, unknown>>>;
+  group?(opts: { items: Array<Record<string, unknown>> }): Promise<unknown>;
+  ui?: BoardUILike;
+  startBatch?(): Promise<void>;
+  endBatch?(): Promise<void>;
+  abortBatch?(): Promise<void>;
+}
+
+export interface BoardQueryLike extends BoardLike {
+  get(opts: { type: string }): Promise<Array<Record<string, unknown>>>;
+}

--- a/src/core/data-mapper.ts
+++ b/src/core/data-mapper.ts
@@ -1,6 +1,7 @@
 /**
  * Mapping configuration describing column headers for various fields.
  */
+
 export interface ColumnMapping {
   /** Column used for the optional unique identifier. */
   idColumn?: string;
@@ -27,6 +28,8 @@ export interface CardDefinition {
   description?: string;
   style?: { cardTheme?: string };
 }
+
+import { toSafeString } from './utils/string-utils';
 
 /**
  * Add a property to the target object when the provided value is defined.
@@ -77,7 +80,7 @@ export function buildMetadata(
     if (value != null) metadata[key] = value;
   });
   const idVal = mapping.idColumn ? row[mapping.idColumn] : undefined;
-  metadata.rowId = idVal != null ? String(idVal) : String(index);
+  metadata.rowId = idVal != null ? toSafeString(idVal) : String(index);
   return metadata;
 }
 
@@ -95,9 +98,9 @@ export function resolveIdLabelType(
     ? row[mapping.templateColumn]
     : undefined;
   return {
-    id: idVal != null ? String(idVal) : String(index),
-    label: labelVal != null ? String(labelVal) : '',
-    type: typeVal != null ? String(typeVal) : 'default',
+    id: idVal != null ? toSafeString(idVal) : String(index),
+    label: labelVal != null ? toSafeString(labelVal) : '',
+    type: typeVal != null ? toSafeString(typeVal) : 'default',
   };
 }
 
@@ -139,18 +142,18 @@ export function mapRowToCard(
   const descVal = readColumn(row, mapping.textColumn);
   const themeVal = readColumn(row, mapping.templateColumn);
   const card: CardDefinition = {
-    title: titleVal != null ? String(titleVal) : '',
+    title: titleVal != null ? toSafeString(titleVal) : '',
   };
-  assignIfDefined(card, 'id', idVal != null ? String(idVal) : undefined);
+  assignIfDefined(card, 'id', idVal != null ? toSafeString(idVal) : undefined);
   assignIfDefined(
     card,
     'description',
-    descVal != null ? String(descVal) : undefined,
+    descVal != null ? toSafeString(descVal) : undefined,
   );
   assignIfDefined(
     card,
     'style',
-    themeVal != null ? { cardTheme: String(themeVal) } : undefined,
+    themeVal != null ? { cardTheme: toSafeString(themeVal) } : undefined,
   );
 
   return card;

--- a/src/core/excel-sync-service.ts
+++ b/src/core/excel-sync-service.ts
@@ -5,6 +5,7 @@ import { applyElementToItem } from '../board/element-utils';
 import { searchGroups, searchShapes } from '../board/node-search';
 import type { BaseItem, Group } from '@mirohq/websdk-types';
 import type { BoardQueryLike } from '../board/board';
+import { toSafeString } from './utils/string-utils';
 
 /** Item supporting text content on the board. */
 export interface ContentItem extends BaseItem {
@@ -55,7 +56,7 @@ export class ExcelSyncService {
     for (const def of nodes) {
       const rowId = def.metadata?.rowId;
       if (!rowId) continue;
-      const idStr = String(rowId);
+      const idStr = toSafeString(rowId);
       const widget = await this.findWidget(idStr, def.label);
       if (!widget) continue;
       await this.applyTemplate(widget, def.label, def.type);
@@ -79,8 +80,10 @@ export class ExcelSyncService {
     const updated: ExcelRow[] = [];
     for (const [i, r] of rows.entries()) {
       const rowId = mapping.idColumn ? r[mapping.idColumn] : undefined;
-      const idStr = String(rowId ?? i);
-      const label = mapping.labelColumn ? String(r[mapping.labelColumn]) : '';
+      const idStr = toSafeString(rowId ?? i);
+      const label = mapping.labelColumn
+        ? toSafeString(r[mapping.labelColumn])
+        : '';
       const widget = await this.lookupWidget(idStr, label);
       let row = { ...r };
       if (widget) {

--- a/src/core/utils/string-utils.ts
+++ b/src/core/utils/string-utils.ts
@@ -1,0 +1,5 @@
+/** Safely convert a value to string, JSON encoding objects. */
+export function toSafeString(value: unknown): string {
+  if (value == null) return '';
+  return typeof value === 'object' ? JSON.stringify(value) : String(value);
+}


### PR DESCRIPTION
## Summary
- remove dependency cycle between board.ts and board-cache.ts by creating `Board` types file and local board resolvers
- add ID regex helpers to CardProcessor
- update data-mapper and Excel sync service to use safe string conversion
- introduce `toSafeString` utility

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68776833b474832b84822f54422c0353