### PR TITLE
Fix safe stringification

### DIFF
--- a/src/core/utils/string-utils.ts
+++ b/src/core/utils/string-utils.ts
@@ -1,5 +1,22 @@
 /** Safely convert a value to string, JSON encoding objects. */
 export function toSafeString(value: unknown): string {
-  if (value == null) return '';
-  return typeof value === 'object' ? JSON.stringify(value) : String(value);
+  if (value == null) {
+    return '';
+  }
+
+  const primitive =
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint';
+
+  if (primitive) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
 }

--- a/tests/string-utils.test.ts
+++ b/tests/string-utils.test.ts
@@ -1,0 +1,25 @@
+import { toSafeString } from '../src/core/utils/string-utils';
+
+describe('toSafeString', () => {
+  test('returns empty string for null or undefined', () => {
+    expect(toSafeString(null)).toBe('');
+    expect(toSafeString(undefined)).toBe('');
+  });
+
+  test('stringifies primitive values', () => {
+    expect(toSafeString('test')).toBe('test');
+    expect(toSafeString(5)).toBe('5');
+    expect(toSafeString(true)).toBe('true');
+    expect(toSafeString(BigInt(10))).toBe('10');
+  });
+
+  test('stringifies objects using JSON', () => {
+    expect(toSafeString({ a: 1 })).toBe('{"a":1}');
+  });
+
+  test('falls back when JSON.stringify throws', () => {
+    const a: { self?: unknown } = {};
+    a.self = a; // circular
+    expect(toSafeString(a)).toBe('[object Object]');
+  });
+});


### PR DESCRIPTION
## Summary
- improve object handling in `toSafeString`
- add tests for `toSafeString`

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68776d92c5e8832b9390c8593c27a748