### PR TITLE
Refactor story wrappers

### DIFF
--- a/src/stories/EditMetadataModal.stories.tsx
+++ b/src/stories/EditMetadataModal.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import type { JSX } from 'react';
 import React from 'react';
 import { EditMetadataModal } from '../ui/components/EditMetadataModal';
-import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
+import { ExcelStoryWrapper } from './ExcelStoryWrapper';
 
 const meta: Meta<typeof EditMetadataModal> = {
   title: 'Components/EditMetadataModal',
@@ -12,44 +12,15 @@ export default meta;
 
 type Story = StoryObj<typeof EditMetadataModal>;
 
-interface BoardItem {
-  getMetadata: () => Promise<{ rowId: string }>;
-}
-
-interface StubBoard {
-  getSelection: () => Promise<BoardItem[]>;
-  ui: { on: () => void; off: () => void };
-}
-
 function Wrapper(): JSX.Element {
   const rows = React.useMemo(() => [{ ID: '1', Name: 'Alice' }], []);
-  React.useEffect(() => {
-    (globalThis as unknown as { miro?: { board?: StubBoard } }).miro = {
-      board: {
-        getSelection: async () => [
-          { getMetadata: async () => ({ rowId: '1' }) },
-        ],
-        ui: { on: () => {}, off: () => {} },
-      },
-    };
-  }, []);
   return (
-    <ExcelDataProvider
-      value={{
-        rows,
-        idColumn: 'ID',
-        labelColumn: 'Name',
-        templateColumn: undefined,
-        setRows: () => {},
-        setIdColumn: () => {},
-        setLabelColumn: () => {},
-        setTemplateColumn: () => {},
-      }}>
+    <ExcelStoryWrapper rows={rows}>
       <EditMetadataModal
         isOpen
         onClose={() => {}}
       />
-    </ExcelDataProvider>
+    </ExcelStoryWrapper>
   );
 }
 

--- a/src/stories/ExcelStoryWrapper.tsx
+++ b/src/stories/ExcelStoryWrapper.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { JSX } from 'react';
+import type { ExcelRow } from '../core/utils/excel-loader';
+import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
+
+interface BoardItem {
+  getMetadata: () => Promise<{ rowId: string }>;
+}
+
+interface StubBoard {
+  getSelection: () => Promise<BoardItem[]>;
+  ui: { on: () => void; off: () => void };
+}
+
+export interface ExcelStoryWrapperProps {
+  /**
+   * Initial rows to expose via {@link ExcelDataProvider}.
+   */
+  rows: ExcelRow[];
+  /**
+   * React nodes to render within the provider.
+   */
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper component for Storybook examples that need Excel context.
+ *
+ * It stubs the Miro board selection API and provides the
+ * {@link ExcelDataProvider} with static row data.
+ */
+export function ExcelStoryWrapper({
+  rows,
+  children,
+}: ExcelStoryWrapperProps): JSX.Element {
+  const memoRows = React.useMemo(() => rows, [rows]);
+  React.useEffect(() => {
+    const rowId = String(memoRows[0]?.ID ?? '1');
+    (globalThis as unknown as { miro?: { board?: StubBoard } }).miro = {
+      board: {
+        getSelection: async () => [{ getMetadata: async () => ({ rowId }) }],
+        ui: { on: () => {}, off: () => {} },
+      },
+    };
+  }, [memoRows]);
+  return (
+    <ExcelDataProvider
+      value={{
+        rows: memoRows,
+        idColumn: 'ID',
+        labelColumn: 'Name',
+        templateColumn: undefined,
+        setRows: () => {},
+        setIdColumn: () => {},
+        setLabelColumn: () => {},
+        setTemplateColumn: () => {},
+      }}>
+      {children}
+    </ExcelDataProvider>
+  );
+}

--- a/src/stories/RowInspector.stories.tsx
+++ b/src/stories/RowInspector.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import type { JSX } from 'react';
 import React from 'react';
 import { RowInspector } from '../ui/components/RowInspector';
-import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
+import { ExcelStoryWrapper } from './ExcelStoryWrapper';
 
 const meta: Meta<typeof RowInspector> = {
   title: 'Components/RowInspector',
@@ -12,45 +12,15 @@ export default meta;
 
 type Story = StoryObj<typeof RowInspector>;
 
-interface BoardItem {
-  getMetadata: () => Promise<{ rowId: string }>;
-}
-
-interface StubBoard {
-  getSelection: () => Promise<BoardItem[]>;
-  ui: { on: () => void; off: () => void };
-}
-
 function Wrapper(): JSX.Element {
   const rows = React.useMemo(() => [{ ID: '1', Name: 'A' }], []);
-  React.useEffect(() => {
-    // stub board selection
-    (globalThis as unknown as { miro?: { board?: StubBoard } }).miro = {
-      board: {
-        getSelection: async () => [
-          { getMetadata: async () => ({ rowId: '1' }) },
-        ],
-        ui: { on: () => {}, off: () => {} },
-      },
-    };
-  }, []);
   return (
-    <ExcelDataProvider
-      value={{
-        rows,
-        idColumn: 'ID',
-        labelColumn: 'Name',
-        templateColumn: undefined,
-        setRows: () => {},
-        setIdColumn: () => {},
-        setLabelColumn: () => {},
-        setTemplateColumn: () => {},
-      }}>
+    <ExcelStoryWrapper rows={rows}>
       <RowInspector
         rows={rows}
         idColumn='ID'
       />
-    </ExcelDataProvider>
+    </ExcelStoryWrapper>
   );
 }
 

--- a/tests/story-wrapper.test.tsx
+++ b/tests/story-wrapper.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ExcelStoryWrapper } from '../src/stories/ExcelStoryWrapper';
+import { useExcelData } from '../src/ui/hooks/excel-data-context';
+
+declare const global: {
+  miro?: { board?: { getSelection: () => Promise<unknown> } };
+};
+
+function ShowFirstName(): JSX.Element {
+  const ctx = useExcelData();
+  return <span>{String(ctx?.rows[0]?.Name)}</span>;
+}
+
+describe('ExcelStoryWrapper', () => {
+  test('provides context and stubs miro board', async () => {
+    render(
+      <ExcelStoryWrapper rows={[{ ID: '1', Name: 'Bob' }]}>
+        <ShowFirstName />
+      </ExcelStoryWrapper>,
+    );
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    const items = await global.miro!.board!.getSelection();
+    // @ts-expect-error testing stub
+    const meta = await items[0].getMetadata();
+    expect(meta.rowId).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- extract `ExcelStoryWrapper` to centralize stub board and provider
- simplify `RowInspector` and `EditMetadataModal` stories
- test the new wrapper

## Testing
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent src/stories/ExcelStoryWrapper.tsx src/stories/RowInspector.stories.tsx src/stories/EditMetadataModal.stories.tsx tests/story-wrapper.test.tsx`
- `npm run typecheck --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68776fcbcd40832b8f4b721ee5144787