### PR TITLE
Fix ExcelStoryWrapper props and rowId handling

### DIFF
--- a/src/stories/ExcelStoryWrapper.tsx
+++ b/src/stories/ExcelStoryWrapper.tsx
@@ -16,11 +16,11 @@ export interface ExcelStoryWrapperProps {
   /**
    * Initial rows to expose via {@link ExcelDataProvider}.
    */
-  rows: ExcelRow[];
+  readonly rows: readonly ExcelRow[];
   /**
    * React nodes to render within the provider.
    */
-  children: React.ReactNode;
+  readonly children: React.ReactNode;
 }
 
 /**
@@ -33,9 +33,11 @@ export function ExcelStoryWrapper({
   rows,
   children,
 }: ExcelStoryWrapperProps): JSX.Element {
-  const memoRows = React.useMemo(() => rows, [rows]);
+  const memoRows = React.useMemo(() => [...rows], [rows]);
   React.useEffect(() => {
-    const rowId = String(memoRows[0]?.ID ?? '1');
+    const id = memoRows[0]?.ID;
+    const rowId =
+      typeof id === 'string' || typeof id === 'number' ? String(id) : '1';
     (globalThis as unknown as { miro?: { board?: StubBoard } }).miro = {
       board: {
         getSelection: async () => [{ getMetadata: async () => ({ rowId }) }],


### PR DESCRIPTION
## Summary
- mark props of `ExcelStoryWrapper` as readonly
- ensure row ID fallback handles non-string/number values

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_68777ccfc464832ba07b0743d6a615c1