### PR TITLE
Update docs for full stack testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ See the
 [Miro developer documentation](https://developers.miro.com/docs/overview) for a
 step-by-step tutorial on building diagramming apps. When contributing code,
 please follow the formatting rules in [docs/CODE_STYLE.md](docs/CODE_STYLE.md).
-Aim for at least **90 % line and branch test coverage** and keep cyclomatic
-complexity below eight as described in
+Aim for at least **90 % line and branch test coverage** in both Node and .NET
+code and keep cyclomatic complexity below eight as described in
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Commit messages

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Then validate the codebase with:
 ```bash
 npm run typecheck --silent
 npm test --silent
+dotnet test --no-build
 npm run lint --silent
 npm run stylelint --silent
 npm run prettier --silent
@@ -258,15 +259,14 @@ npm run prettier --silent
 
 A Husky pre-commit hook runs these commands automatically. After cloning the
 repository run `npx husky install` once to activate the hooks so every commit is
-validated.
-
-These commands perform TypeScript type checking, execute the **Vitest** suite
-with coverage enabled, run ESLint and format files with Prettier. Aim for at
-least 90 % line and branch coverage and keep cyclomatic complexity under eight
-(see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). ESLint enforces additional
-Sonar rules such as using `readonly` class fields, optional chaining, semantic
-HTML tags and stable React keys. Run these checks before committing so code
-conforms to the repository guidelines.
+validated. These commands perform TypeScript type checking, execute the
+**Vitest** suite and the `.NET` test runner with coverage enabled, run ESLint
+and format files with Prettier. Aim for at least 90 % line and branch coverage
+in both codebases and keep cyclomatic complexity under eight (see
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). Sonar rules such as using
+`readonly` class fields, optional chaining, semantic HTML tags and stable React
+keys. Run these checks before committing so code conforms to the repository
+guidelines.
 
 With `package-lock.json` checked in you can run `npm audit` after each install
 to scan dependencies for vulnerabilities. Include the lock file in commits so

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,8 +38,8 @@ Browser
                          └── OAuth tokens via browser
 ```
 
-The add-on is **client-only**. All persistence is handled by Miro boards.
-Loading Excel workbooks from Microsoft Graph uses a client-side OAuth flow that
+The add-on runs entirely in the browser. All persistence is handled by Miro
+boards. Loading Excel workbooks from Microsoft Graph uses an OAuth flow that
 acquires tokens in the browser—no server component stores credentials.
 
 ---
@@ -96,17 +96,17 @@ Complexity limits enforced automatically by **SonarQube** gate.
 
 ## 6 Quality, Testing & CI/CD
 
-| Stage      | Gate                        | Threshold          |
-| ---------- | --------------------------- | ------------------ |
-| Pre-commit | ESLint, Stylelint, Prettier | zero errors        |
-| Unit       | Vitest (coverage v8)        | 90 % line & branch |
-| UI         | manual visual & a11y review | no critical issues |
-| Metrics    | SonarQube                   | cyclomatic ≤ 8     |
+| Stage      | Gate                        | Threshold            |
+| ---------- | --------------------------- | -------------------- |
+| Pre-commit | ESLint, Stylelint, Prettier | zero errors          |
+| Unit       | `npm test`, `dotnet test`   | ≥ 90 % line & branch |
+| UI         | manual visual & a11y review | no critical issues   |
+| Metrics    | SonarQube                   | cyclomatic ≤ 8       |
 
 **Workflow** (GitHub Actions)
 
-1. Restore Node dependencies from cache.
-2. Lint, type-check, unit tests (Node 24).
+1. Restore Node and .NET dependencies from cache.
+2. Lint, type-check and unit tests for both codebases (Node 24, .NET 8).
 3. Build Storybook and a feature-flagged bundle for staging.
 4. SonarQube analysis and budget checks (configured by
    [sonar-project.properties](../sonar-project.properties)).
@@ -117,6 +117,9 @@ Complexity limits enforced automatically by **SonarQube** gate.
 ---
 
 ## 7 Automated Code Review & Enforcement
+
+- Both the Node and .NET code must maintain ≥ 90 % coverage with cyclomatic
+  complexity under eight.
 
 - CI checks fail pull requests if complexity, coverage or lint targets fall
   short.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -253,12 +253,12 @@ Failing any item blocks the CI gate.
 
 ## 8 Quality gates (automated in GitHub Actions)
 
-| Stage             | Tool                     | Pass threshold          |
-| ----------------- | ------------------------ | ----------------------- |
-| Lint              | ESLint + Stylelint       | 0 errors                |
-| Unit tests        | Vitest                   | ≥ 90 % lines & branches |
-| Visual regression | manual screenshot review | no visual diffs         |
-| Accessibility     | manual a11y review       | 0 critical              |
+| Stage             | Tool                      | Pass threshold          |
+| ----------------- | ------------------------- | ----------------------- |
+| Lint              | ESLint + Stylelint        | 0 errors                |
+| Unit tests        | `npm test`, `dotnet test` | ≥ 90 % lines & branches |
+| Visual regression | manual screenshot review  | no visual diffs         |
+| Accessibility     | manual a11y review        | 0 critical              |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,7 +4,7 @@
 
 ## 0 Purpose
 
-Step-by-step instructions for packaging, hosting and operating the client-only
+Step-by-step instructions for packaging, hosting and operating the browser-based
 add-on. Aimed at junior engineers; every step is explicit.
 
 ---
@@ -58,7 +58,7 @@ Define variables in the host’s dashboard (or `vercel env`).
 | **LOG_LEVEL**            | runtime log verbosity (`info`, `debug`, `trace`)   |
 
 Variables are injected at build time—no runtime secrets are required because the
-add-on is client-only.
+add-on runs entirely in the browser.
 
 ---
 
@@ -146,8 +146,8 @@ If any step fails, do not promote to production.
 ```
 Push → GitHub Action
         ├─ Prettier, ESLint, Stylelint, Typecheck
-        ├─ Unit tests (parallel shards)
-        ├─ Merge coverage
+        ├─ Unit tests (`npm test`, `dotnet test`, parallel shards)
+        ├─ Merge coverage from both suites
         ├─ Sonar analysis
         ├─ CodeQL scan
         ├─ Build Storybook


### PR DESCRIPTION
## Summary
- clarify that the add-on runs entirely in the browser
- mention `npm test` and `dotnet test`
- document 90 % coverage and complexity targets for both codebases
- keep the documentation editor-agnostic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877ae320fb8832bac02e8815eea2b50