### PR TITLE
refactor(server): rename namespace

### DIFF
--- a/fenrick.miro.server.tests/server/BatchControllerTests.cs
+++ b/fenrick.miro.server.tests/server/BatchControllerTests.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using Miro.Server.Api;
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Api;
+using Fenrick.Miro.Server.Domain;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
 #nullable enable
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class BatchControllerTests
 {

--- a/fenrick.miro.server.tests/server/CacheControllerTests.cs
+++ b/fenrick.miro.server.tests/server/CacheControllerTests.cs
@@ -1,13 +1,13 @@
 using System;
-using Miro.Server.Api;
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Api;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
 #nullable enable
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class CacheControllerTests
 {

--- a/fenrick.miro.server.tests/server/ClientLogEntryTests.cs
+++ b/fenrick.miro.server.tests/server/ClientLogEntryTests.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Domain;
 using Xunit;
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class ClientLogEntryTests
 {

--- a/fenrick.miro.server.tests/server/InMemoryCacheServiceTests.cs
+++ b/fenrick.miro.server.tests/server/InMemoryCacheServiceTests.cs
@@ -1,8 +1,8 @@
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 using Xunit;
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class InMemoryCacheServiceTests
 {

--- a/fenrick.miro.server.tests/server/LogsControllerTests.cs
+++ b/fenrick.miro.server.tests/server/LogsControllerTests.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using Miro.Server.Api;
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Api;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class LogsControllerTests
 {

--- a/fenrick.miro.server.tests/server/SerilogSinkTests.cs
+++ b/fenrick.miro.server.tests/server/SerilogSinkTests.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
 using Xunit;
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class SerilogSinkTests
 {

--- a/fenrick.miro.server.tests/server/Server.Tests.csproj
+++ b/fenrick.miro.server.tests/server/Server.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RootNamespace>Fenrick.Miro.Server.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../fenrick.miro.server/src/server/Server.csproj" />

--- a/fenrick.miro.server.tests/server/WebhookControllerTests.cs
+++ b/fenrick.miro.server.tests/server/WebhookControllerTests.cs
@@ -1,12 +1,12 @@
 using System;
-using Miro.Server.Api;
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Api;
+using Fenrick.Miro.Server.Domain;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
 #nullable enable
 
-namespace Miro.Server.Tests;
+namespace Fenrick.Miro.Server.Tests;
 
 public class WebhookControllerTests
 {

--- a/fenrick.miro.server/src/server/Api/BatchController.cs
+++ b/fenrick.miro.server/src/server/Api/BatchController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Domain;
 
-namespace Miro.Server.Api;
+namespace Fenrick.Miro.Server.Api;
 
 /// <summary>
 /// Aggregates REST calls so the client can send them in one request.

--- a/fenrick.miro.server/src/server/Api/CacheController.cs
+++ b/fenrick.miro.server/src/server/Api/CacheController.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 
-namespace Miro.Server.Api;
+namespace Fenrick.Miro.Server.Api;
 
 /// <summary>
 /// Provides cached board metadata used by the React app.

--- a/fenrick.miro.server/src/server/Api/LogsController.cs
+++ b/fenrick.miro.server/src/server/Api/LogsController.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 
-namespace Miro.Server.Api;
+namespace Fenrick.Miro.Server.Api;
 
 /// <summary>
 /// Captures log entries from the client and stores them via <see cref="ILogSink"/>.

--- a/fenrick.miro.server/src/server/Api/WebhookController.cs
+++ b/fenrick.miro.server/src/server/Api/WebhookController.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
-using Miro.Server.Domain;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Domain;
+using Fenrick.Miro.Server.Services;
 
-namespace Miro.Server.Api;
+namespace Fenrick.Miro.Server.Api;
 
 /// <summary>
 /// Receives webhook events and queues them for processing.

--- a/fenrick.miro.server/src/server/Domain/BoardMetadata.cs
+++ b/fenrick.miro.server/src/server/Domain/BoardMetadata.cs
@@ -1,4 +1,4 @@
-namespace Miro.Server.Domain;
+namespace Fenrick.Miro.Server.Domain;
 
 /// <summary>
 /// Basic information about a Miro board used by caching.

--- a/fenrick.miro.server/src/server/Domain/ClientLogEntry.cs
+++ b/fenrick.miro.server/src/server/Domain/ClientLogEntry.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Miro.Server.Domain;
+namespace Fenrick.Miro.Server.Domain;
 
 /// <summary>
 /// Log entry forwarded from the client application.

--- a/fenrick.miro.server/src/server/Domain/MiroRequest.cs
+++ b/fenrick.miro.server/src/server/Domain/MiroRequest.cs
@@ -1,4 +1,4 @@
-namespace Miro.Server.Domain;
+namespace Fenrick.Miro.Server.Domain;
 
 /// <summary>
 /// Lightweight description of a REST request sent to the Miro API.

--- a/fenrick.miro.server/src/server/Domain/MiroResponse.cs
+++ b/fenrick.miro.server/src/server/Domain/MiroResponse.cs
@@ -1,4 +1,4 @@
-namespace Miro.Server.Domain;
+namespace Fenrick.Miro.Server.Domain;
 
 /// <summary>
 /// Response from the Miro API for a single REST request.

--- a/fenrick.miro.server/src/server/Domain/WebhookEvent.cs
+++ b/fenrick.miro.server/src/server/Domain/WebhookEvent.cs
@@ -1,4 +1,4 @@
-namespace Miro.Server.Domain;
+namespace Fenrick.Miro.Server.Domain;
 
 /// <summary>
 /// Simplified representation of a webhook event sent by Miro.

--- a/fenrick.miro.server/src/server/Program.cs
+++ b/fenrick.miro.server/src/server/Program.cs
@@ -1,5 +1,5 @@
-using Miro.Server.Api;
-using Miro.Server.Services;
+using Fenrick.Miro.Server.Api;
+using Fenrick.Miro.Server.Services;
 using Serilog;
 using System.Diagnostics.CodeAnalysis;
 

--- a/fenrick.miro.server/src/server/Server.csproj
+++ b/fenrick.miro.server/src/server/Server.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Fenrick.Miro.Server</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />

--- a/fenrick.miro.server/src/server/Services/ICacheService.cs
+++ b/fenrick.miro.server/src/server/Services/ICacheService.cs
@@ -1,6 +1,6 @@
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Domain;
 
-namespace Miro.Server.Services;
+namespace Fenrick.Miro.Server.Services;
 
 /// <summary>
 /// Provides board metadata caching for quick lookup.

--- a/fenrick.miro.server/src/server/Services/ILogSink.cs
+++ b/fenrick.miro.server/src/server/Services/ILogSink.cs
@@ -1,6 +1,6 @@
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Domain;
 
-namespace Miro.Server.Services;
+namespace Fenrick.Miro.Server.Services;
 
 /// <summary>
 /// Stores log entries sent by the client.

--- a/fenrick.miro.server/src/server/Services/InMemoryCacheService.cs
+++ b/fenrick.miro.server/src/server/Services/InMemoryCacheService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Concurrent;
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Domain;
 
-namespace Miro.Server.Services;
+namespace Fenrick.Miro.Server.Services;
 
 /// <summary>
 /// Simple in-memory implementation of <see cref="ICacheService"/>.

--- a/fenrick.miro.server/src/server/Services/SerilogSink.cs
+++ b/fenrick.miro.server/src/server/Services/SerilogSink.cs
@@ -1,8 +1,8 @@
-using Miro.Server.Domain;
+using Fenrick.Miro.Server.Domain;
 using Serilog;
 using ILogger = Serilog.ILogger;
 
-namespace Miro.Server.Services;
+namespace Fenrick.Miro.Server.Services;
 
 /// <summary>
 /// Writes client logs to the server log via Serilog.


### PR DESCRIPTION
## Summary
- rename namespace `Miro.Server` -> `Fenrick.Miro.Server`
- update Server.csproj and test csproj RootNamespace
- adjust using directives across server code and tests

## Testing
- `npm run typecheck --silent`
- `npm run test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `dotnet test fenrick.miro.server.tests/server/Server.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_6878ea0d7ba4832bb8eb989ec170552b