### PR TITLE
Update UX directory imports

### DIFF
--- a/app.html
+++ b/app.html
@@ -6,7 +6,7 @@
       content="width=device-width, initial-scale=1.0"
       name="viewport" />
     <link
-      href="/src/assets/style.css"
+      href="/fenrick.miro.ux/src/assets/style.css"
       rel="stylesheet" />
     <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
     <title>Quick Tools</title>
@@ -16,7 +16,7 @@
     <div id="root"></div>
 
     <script
-      src="/src/app/App.tsx"
+      src="/fenrick.miro.ux/src/app/App.tsx"
       type="module"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
       content="width=device-width, initial-scale=1.0"
       name="viewport" />
     <link
-      href="/src/assets/style.css"
+      href="/fenrick.miro.ux/src/assets/style.css"
       rel="stylesheet" />
     <script src="https://miro.com/app/static/sdk/v2/miro.js"></script>
     <title>Miro Quick Tools</title>
@@ -17,7 +17,7 @@
       <div class="cs1 ce12">
         <img
           alt=""
-          src="/src/assets/welcome.png" />
+          src="/fenrick.miro.ux/src/assets/welcome.png" />
       </div>
       <div class="cs1 ce12">
         <h1>Quick Tools is running locally</h1>
@@ -36,7 +36,7 @@
       </div>
     </div>
     <script
-      src="/src/index.ts"
+      src="/fenrick.miro.ux/src/index.ts"
       type="module"></script>
   </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,10 @@
     "typeRoots": ["./node_modules/@types", "./node_modules/@mirohq"],
     "allowJs": true,
     "incremental": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": { "fenrick.miro.ux/*": ["fenrick.miro.ux/src/*"] }
   },
-  "include": ["fenrick.miro.ux/src", "*.ts", "vite-env.d.ts"],
+  "include": ["fenrick.miro.ux/src/**/*", "*.ts", "vite-env.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,22 +7,29 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/server-options.html#server-host
 dns.setDefaultResultOrder('verbatim');
 
-// make sure vite picks up all html files in root, needed for vite build
+const rootDir = path.resolve(__dirname, 'fenrick.miro.ux');
+// make sure vite picks up all html files in rootDir, needed for vite build
 const allHtmlEntries = fs
-  .readdirSync('.')
+  .readdirSync(rootDir)
   .filter((file) => path.extname(file) === '.html')
   .reduce((acc: Record<string, string>, file) => {
-    acc[path.basename(file, '.html')] = path.resolve(__dirname, file);
+    acc[path.basename(file, '.html')] = path.resolve(rootDir, file);
 
     return acc;
   }, {});
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  root: path.resolve(__dirname, 'fenrick.miro.ux'),
   build: {
     rollupOptions: {
       input: allHtmlEntries,
       external: ['elkjs/lib/elk.bundled.js', 'exceljs'],
+    },
+  },
+  resolve: {
+    alias: {
+      'fenrick.miro.ux': path.resolve(__dirname, 'fenrick.miro.ux/src'),
     },
   },
   plugins: [react()],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'fenrick.miro.ux': path.resolve(__dirname, 'fenrick.miro.ux/src'),
+    },
+  },
   plugins: [react()],
   test: {
     coverage: {


### PR DESCRIPTION
## Summary
- serve HTML from new `fenrick.miro.ux` folder
- alias `fenrick.miro.ux` module path for tooling
- include `fenrick.miro.ux/src` in TypeScript build

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6878ea16470c832ba4dd9aa2b93782f6