### PR TITLE
Update CI paths and env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: write-all
 
+env:
+  NODE_VERSION: 24
+  DOTNET_VERSION: '9.0.x'
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
@@ -29,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
@@ -44,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
@@ -59,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
@@ -74,11 +78,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Format check
         run:
           dotnet format --no-restore --verify-no-changes
-          src/server/Server.csproj
+          fenrick.miro.server/src/server/Server.csproj
 
   dotnet-tests:
     runs-on: ubuntu-latest
@@ -86,18 +90,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Restore
-        run: dotnet restore tests/server/Server.Tests.csproj
+        run: dotnet restore fenrick.miro.server.tests/server/Server.Tests.csproj
       - name: Test
         run:
-          dotnet test tests/server/Server.Tests.csproj --logger
-          "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage"
+          dotnet test fenrick.miro.server.tests/server/Server.Tests.csproj
+          --logger "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage"
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage
-          path: tests/server/TestResults
+          path: fenrick.miro.server.tests/server/TestResults
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -109,7 +113,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
@@ -139,7 +143,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - name: Download coverage shard 1
@@ -188,9 +192,9 @@ jobs:
       - name: Set up Node & install front‑end deps
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
       - run: corepack enable && npm ci
-        working-directory: src/Frontend
+        working-directory: fenrick.miro.ux
 
       - name: Download coverage
         uses: actions/download-artifact@v4
@@ -218,22 +222,22 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
-        run: | 
+        run: |
           .\.sonar\scanner\dotnet-sonarscanner begin `
             /k:"fenrick_MiroDiagraming" /o:"fenrick" `
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" `
             /d:sonar.host.url="https://sonarcloud.io" `
-            /d:sonar.sources="src/server;src/Frontend" `
+            /d:sonar.sources="fenrick.miro.server/src/server;fenrick.miro.ux/src" `
             /d:sonar.exclusions="**/node_modules/**,**/obj/**" `
             /d:sonar.cs.opencover.reportsPaths="coverage\coverage.opencover.xml" `
             /d:sonar.javascript.lcov.reportPaths="coverage\lcov.info"
-          dotnet build src/server/Server.csproj
-          dotnet test tests/server/Server.Tests.csproj --no-build `
+          dotnet build fenrick.miro.server/src/server/Server.csproj
+          dotnet test fenrick.miro.server.tests/server/Server.Tests.csproj --no-build `
             /p:CollectCoverage=true `
             /p:CoverletOutputFormat=opencover `
             /p:CoverletOutput="coverage/coverage.opencover.xml" `
@@ -262,14 +266,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - if: matrix.language == 'csharp'
-        run: dotnet build src/server/Server.csproj --configuration Release
+        run:
+          dotnet build fenrick.miro.server/src/server/Server.csproj
+          --configuration Release
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
 
@@ -280,7 +286,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
@@ -325,7 +331,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install


### PR DESCRIPTION
## Summary
- use environment variables for node and dotnet versions
- update CI workflow paths for new `fenrick.miro.server` structure
- adjust coverage artefact path and frontend directory

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6878ee0eaec4832ba7f9472083f3e687