### PR TITLE
Configure coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,15 @@ jobs:
       - name: Restore
         run: dotnet restore fenrick.miro.server.tests/server/Server.Tests.csproj
       - name: Test
-        run:
-          dotnet test fenrick.miro.server.tests/server/Server.Tests.csproj
-          --logger "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage"
+        run: |
+          dotnet test fenrick.miro.server.tests/server/Server.Tests.csproj \
+            --logger "trx;LogFileName=results.trx" \
+            /p:CollectCoverage=true \
+            /p:CoverletOutputFormat=cobertura \
+            /p:CoverletOutput=coverage/coverage.cobertura.xml \
+            /p:Threshold=90 \
+            /p:ThresholdType=line,branch \
+            /p:ThresholdStat=total
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
@@ -241,6 +247,9 @@ jobs:
             /p:CollectCoverage=true `
             /p:CoverletOutputFormat=opencover `
             /p:CoverletOutput="coverage/coverage.opencover.xml" `
+            /p:Threshold=90 `
+            /p:ThresholdType=line,branch `
+            /p:ThresholdStat=total `
             --logger "trx"
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       reportsDirectory: 'coverage',
+      thresholds: { lines: 90, functions: 90, branches: 90, statements: 90 },
       exclude: [
         'commitlint.config.cjs',
         'scripts/**',


### PR DESCRIPTION
## Summary
- enforce 90% coverage in Vitest config
- make dotnet test fail if coverage < 90%
- update CI workflow to use coverage thresholds

## Testing
- `npm run typecheck`
- `npm test` *(fails: Execution interrupted)*
- `npm run lint`
- `npm run stylelint`
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_6878f011ed98832bb7c2abd49ee6c8a0