### PR TITLE
Update fixture paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ each element can carry metadata that controls its appearance and placement.
 4. Once processed, widgets are placed on the board using the selected mode.
    Cards are automatically arranged in a grid with a calculated number of
    columns. Pass `columns` when invoking the importer to override this value.
-5. See [`tests/fixtures/sample-cards.json`](tests/fixtures/sample-cards.json)
+5. See
+   [`fenrick.miro.ux.tests/fixtures/sample-cards.json`](fenrick.miro.ux.tests/fixtures/sample-cards.json)
    for a cards format example.
 
 ### Card JSON Format
@@ -70,7 +71,7 @@ in the description using the `ID:` prefix.
 ## Sample Graph
 
 A small example is provided in
-[tests/fixtures/sample-graph.json](tests/fixtures/sample-graph.json):
+[fenrick.miro.ux.tests/fixtures/sample-graph.json](fenrick.miro.ux.tests/fixtures/sample-graph.json):
 
 ```json
 {
@@ -89,9 +90,9 @@ visualised using the **Nested** layout option in the Diagram tab. Positions and
 container sizes are computed entirely by the ELK engine for consistent spacing.
 Nodes are sorted alphabetically by default or via a custom metadata key. A
 three‑level sample dataset is available at
-[tests/fixtures/sample-hier.json](tests/fixtures/sample-hier.json). Simply
-select **Nested** and import this file to see parent widgets sized to fit their
-children. Flat graph data is automatically converted when necessary.
+[fenrick.miro.ux.tests/fixtures/sample-hier.json](fenrick.miro.ux.tests/fixtures/sample-hier.json).
+Simply select **Nested** and import this file to see parent widgets sized to fit
+their children. Flat graph data is automatically converted when necessary.
 
 ## Accessibility
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -131,7 +131,7 @@ collection sit in **ARCHITECTURE.md** (section 13).
 
 ```
 ▢ Load a fresh board; sidebar icon appears.
-▢ Import a sample data file (tests/fixtures/kanban.csv).
+▢ Import a sample data file (fenrick.miro.ux.tests/fixtures/kanban.csv).
 ▢ Verify widgets render and undo works.
 ▢ Switch to Dark theme; no colour regressions.
 ▢ Run npm run a11y:e2e – all critical checks pass.

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -57,8 +57,8 @@ value.
 ## 3 Sample Data
 
 A three-level hierarchical dataset can be found in
-[`tests/fixtures/sample-hier.json`](../tests/fixtures/sample-hier.json). It
-contains four top-level groups, each with four subgroups and four items per
+[`fenrick.miro.ux.tests/fixtures/sample-hier.json`](../fenrick.miro.ux.tests/fixtures/sample-hier.json).
+It contains four top-level groups, each with four subgroups and four items per
 subgroup. This is useful when experimenting with the ELK-based nested layout
 algorithm. Import the JSON in the **Create** tab and choose the **Nested**
 diagram layout to see child nodes arranged inside their parents with containers


### PR DESCRIPTION
## Summary
- update references to `tests/fixtures/` with `fenrick.miro.ux.tests/fixtures/`
- keep markdown link formatting intact

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6878f53910d0832b84859be6bd00c4c0