### PR TITLE
Update test imports to use alias

### DIFF
--- a/fenrick.miro.ux.tests/app-ui-options.test.ts
+++ b/fenrick.miro.ux.tests/app-ui-options.test.ts
@@ -2,8 +2,8 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { App } from '../fenrick.miro.ux/src/app/App';
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
+import { App } from 'fenrick.miro.ux/app/App';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
 
 function selectFile(): File {
   const file = new File(['{}'], 'graph.json', { type: 'application/json' });

--- a/fenrick.miro.ux.tests/app-ui.test.ts
+++ b/fenrick.miro.ux.tests/app-ui.test.ts
@@ -2,13 +2,13 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { App } from '../fenrick.miro.ux/src/app/App';
+import { App } from 'fenrick.miro.ux/app/App';
 import {
   getDropzoneStyle,
   undoLastImport,
-} from '../fenrick.miro.ux/src/ui/hooks/ui-utils';
+} from 'fenrick.miro.ux/ui/hooks/ui-utils';
 import { colors } from '@mirohq/design-tokens';
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/arrange-tab.test.tsx
+++ b/fenrick.miro.ux.tests/arrange-tab.test.tsx
@@ -2,9 +2,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ArrangeTab } from '../fenrick.miro.ux/src/ui/pages/ArrangeTab';
-import * as grid from '../fenrick.miro.ux/src/board/grid-tools';
-import * as spacing from '../fenrick.miro.ux/src/board/spacing-tools';
+import { ArrangeTab } from 'fenrick.miro.ux/ui/pages/ArrangeTab';
+import * as grid from 'fenrick.miro.ux/board/grid-tools';
+import * as spacing from 'fenrick.miro.ux/board/spacing-tools';
 
 class ResizeObserverMock {
   observe() {}

--- a/fenrick.miro.ux.tests/aspect-ratio.test.ts
+++ b/fenrick.miro.ux.tests/aspect-ratio.test.ts
@@ -1,7 +1,7 @@
 import {
   aspectRatioValue,
   ratioHeight,
-} from '../fenrick.miro.ux/src/core/utils/aspect-ratio';
+} from 'fenrick.miro.ux/core/utils/aspect-ratio';
 
 describe('aspect-ratio utilities', () => {
   test('aspectRatioValue returns numeric ratios', () => {

--- a/fenrick.miro.ux.tests/base64.test.ts
+++ b/fenrick.miro.ux.tests/base64.test.ts
@@ -1,7 +1,7 @@
 import {
   encodeBase64,
   decodeBase64,
-} from '../fenrick.miro.ux/src/core/utils/base64';
+} from 'fenrick.miro.ux/core/utils/base64';
 
 function expected(input: string): string {
   return Buffer.from(input, 'utf8')

--- a/fenrick.miro.ux.tests/board-builder.test.ts
+++ b/fenrick.miro.ux.tests/board-builder.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 
 test('stores and retrieves frame', () => {
   const builder = new BoardBuilder();

--- a/fenrick.miro.ux.tests/board-cache.test.ts
+++ b/fenrick.miro.ux.tests/board-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
-import type { BoardQueryLike } from '../fenrick.miro.ux/src/board/board';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
+import type { BoardQueryLike } from 'fenrick.miro.ux/board/board';
 
 describe('BoardCache', () => {
   afterEach(() => {

--- a/fenrick.miro.ux.tests/board-utils.test.ts
+++ b/fenrick.miro.ux.tests/board-utils.test.ts
@@ -2,8 +2,8 @@ import {
   forEachSelection,
   getFirstSelection,
   maybeSync,
-} from '../fenrick.miro.ux/src/board/board';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/board';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 beforeEach(() => {
   boardCache.reset();

--- a/fenrick.miro.ux.tests/boardbuilder-batch.test.ts
+++ b/fenrick.miro.ux.tests/boardbuilder-batch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 import { mockBoard } from './mock-board';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 beforeEach(() => {
   boardCache.reset();

--- a/fenrick.miro.ux.tests/boardbuilder-cache.test.ts
+++ b/fenrick.miro.ux.tests/boardbuilder-cache.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test, vi } from 'vitest';
 import {
   BoardBuilder,
   updateConnector,
-} from '../fenrick.miro.ux/src/board/board-builder';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/board-builder';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 import { mockBoard } from './mock-board';
 
 interface GlobalWithMiro {
@@ -96,7 +96,7 @@ describe('BoardBuilder lookup and connector updates', () => {
       {
         from: 'n1',
         to: 'n2',
-      } as unknown as import('../fenrick.miro.ux/src/core/graph').EdgeData,
+      } as unknown as import('fenrick.miro.ux/core/graph').EdgeData,
       { shape: 'curved', style: { strokeStyle: 'dashed' } },
       undefined,
     );

--- a/fenrick.miro.ux.tests/boardbuilder-remove.test.ts
+++ b/fenrick.miro.ux.tests/boardbuilder-remove.test.ts
@@ -1,4 +1,4 @@
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/boardbuilder-resize.test.ts
+++ b/fenrick.miro.ux.tests/boardbuilder-resize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 import { mockBoard } from './mock-board';
 import type { BaseItem, GroupableItem } from '@mirohq/websdk-types';
 

--- a/fenrick.miro.ux.tests/button-icon.test.tsx
+++ b/fenrick.miro.ux.tests/button-icon.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Button } from '../fenrick.miro.ux/src/ui/components/Button';
+import { Button } from 'fenrick.miro.ux/ui/components/Button';
 const DummyIcon = () => <svg data-icon-component />;
 
 describe('Button icon support', () => {

--- a/fenrick.miro.ux.tests/button-size.test.tsx
+++ b/fenrick.miro.ux.tests/button-size.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Button } from '../fenrick.miro.ux/src/ui/components/Button';
+import { Button } from 'fenrick.miro.ux/ui/components/Button';
 
 it('defaults to large size for primary', () => {
   const { getByRole } = render(<Button variant='primary'>Ok</Button>);

--- a/fenrick.miro.ux.tests/card-load.test.ts
+++ b/fenrick.miro.ux.tests/card-load.test.ts
@@ -1,7 +1,7 @@
 import {
   cardLoader,
   CardLoader,
-} from '../fenrick.miro.ux/src/core/utils/cards';
+} from 'fenrick.miro.ux/core/utils/cards';
 
 interface ReaderEvent {
   target: { result?: string | null } | null;

--- a/fenrick.miro.ux.tests/card-normalize.test.ts
+++ b/fenrick.miro.ux.tests/card-normalize.test.ts
@@ -2,7 +2,7 @@ import {
   cardLoader,
   CardLoader,
   parseCardStyle,
-} from '../fenrick.miro.ux/src/core/utils/cards';
+} from 'fenrick.miro.ux/core/utils/cards';
 
 interface ReaderEvent {
   target: { result?: string | null } | null;

--- a/fenrick.miro.ux.tests/cards-tab-branches.test.tsx
+++ b/fenrick.miro.ux.tests/cards-tab-branches.test.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { CardsTab } from '../fenrick.miro.ux/src/ui/pages/CardsTab';
-import { CardProcessor } from '../fenrick.miro.ux/src/board/card-processor';
+import { CardsTab } from 'fenrick.miro.ux/ui/pages/CardsTab';
+import { CardProcessor } from 'fenrick.miro.ux/board/card-processor';
 
-vi.mock('../fenrick.miro.ux/src/board/card-processor');
+vi.mock('fenrick.miro.ux/board/card-processor');
 
 describe('CardsTab extra paths', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/cards-tab-undo.test.tsx
+++ b/fenrick.miro.ux.tests/cards-tab-undo.test.tsx
@@ -2,11 +2,11 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { CardsTab } from '../fenrick.miro.ux/src/ui/pages/CardsTab';
-import { CardProcessor } from '../fenrick.miro.ux/src/board/card-processor';
-import * as uiUtils from '../fenrick.miro.ux/src/ui/hooks/ui-utils';
+import { CardsTab } from 'fenrick.miro.ux/ui/pages/CardsTab';
+import { CardProcessor } from 'fenrick.miro.ux/board/card-processor';
+import * as uiUtils from 'fenrick.miro.ux/ui/hooks/ui-utils';
 
-vi.mock('../fenrick.miro.ux/src/board/card-processor');
+vi.mock('fenrick.miro.ux/board/card-processor');
 
 describe('CardsTab undo paths', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/checkbox.test.tsx
+++ b/fenrick.miro.ux.tests/checkbox.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Checkbox } from '../fenrick.miro.ux/src/ui/components/Checkbox';
+import { Checkbox } from 'fenrick.miro.ux/ui/components/Checkbox';
 
 test('renders label connected via htmlFor', () => {
   render(

--- a/fenrick.miro.ux.tests/color-utils.test.ts
+++ b/fenrick.miro.ux.tests/color-utils.test.ts
@@ -7,7 +7,7 @@ import {
   hexToRgb,
   rgbToHex,
   mixColors,
-} from '../fenrick.miro.ux/src/core/utils/color-utils';
+} from 'fenrick.miro.ux/core/utils/color-utils';
 
 describe('color-utils', () => {
   test('adjustColor lightens and darkens', () => {

--- a/fenrick.miro.ux.tests/data-mapper-branches.test.ts
+++ b/fenrick.miro.ux.tests/data-mapper-branches.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
   mapRowsToNodes,
   mapRowsToCards,
-} from '../fenrick.miro.ux/src/core/data-mapper';
+} from 'fenrick.miro.ux/core/data-mapper';
 
 describe('data-mapper branches', () => {
   test('mapRowsToNodes uses defaults when mapping is empty', () => {

--- a/fenrick.miro.ux.tests/data-mapper.test.ts
+++ b/fenrick.miro.ux.tests/data-mapper.test.ts
@@ -7,7 +7,7 @@ import {
   mapRowsWith,
   buildMetadata,
   resolveIdLabelType,
-} from '../fenrick.miro.ux/src/core/data-mapper';
+} from 'fenrick.miro.ux/core/data-mapper';
 
 describe('data mapper', () => {
   test('maps rows to nodes with metadata', () => {

--- a/fenrick.miro.ux.tests/diagram-app.test.ts
+++ b/fenrick.miro.ux.tests/diagram-app.test.ts
@@ -1,4 +1,4 @@
-import { DiagramApp } from '../fenrick.miro.ux/src/app/diagram-app';
+import { DiagramApp } from 'fenrick.miro.ux/app/diagram-app';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/diagram-tab-advanced.test.tsx
+++ b/fenrick.miro.ux.tests/diagram-tab-advanced.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { StructuredTab } from '../fenrick.miro.ux/src/ui/pages/StructuredTab';
+import { StructuredTab } from 'fenrick.miro.ux/ui/pages/StructuredTab';
 
 /** Ensure advanced options panel can be toggled via details element. */
 

--- a/fenrick.miro.ux.tests/diagram-tab-existing.test.tsx
+++ b/fenrick.miro.ux.tests/diagram-tab-existing.test.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { DiagramsTab } from '../fenrick.miro.ux/src/ui/pages/DiagramsTab';
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
+import { DiagramsTab } from 'fenrick.miro.ux/ui/pages/DiagramsTab';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
 
-vi.mock('../fenrick.miro.ux/src/core/graph/graph-processor');
+vi.mock('fenrick.miro.ux/core/graph/graph-processor');
 
 describe('DiagramsTab existing node option', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/diagrams-tab-switch.test.tsx
+++ b/fenrick.miro.ux.tests/diagrams-tab-switch.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { DiagramsTab } from '../fenrick.miro.ux/src/ui/pages/DiagramsTab';
+import { DiagramsTab } from 'fenrick.miro.ux/ui/pages/DiagramsTab';
 
 describe('DiagramsTab switching', () => {
   test('changes sub tabs', async () => {

--- a/fenrick.miro.ux.tests/diagrams-tab.test.tsx
+++ b/fenrick.miro.ux.tests/diagrams-tab.test.tsx
@@ -2,11 +2,11 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { DiagramsTab } from '../fenrick.miro.ux/src/ui/pages/DiagramsTab';
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
+import { DiagramsTab } from 'fenrick.miro.ux/ui/pages/DiagramsTab';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
 
-vi.mock('../fenrick.miro.ux/src/core/graph/graph-processor');
-vi.mock('../fenrick.miro.ux/src/board/card-processor');
+vi.mock('fenrick.miro.ux/core/graph/graph-processor');
+vi.mock('fenrick.miro.ux/board/card-processor');
 
 describe('DiagramsTab', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/dummy-tab.test.tsx
+++ b/fenrick.miro.ux.tests/dummy-tab.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { DummyTab, tabDef } from '../fenrick.miro.ux/src/ui/pages/DummyTab';
+import { DummyTab, tabDef } from 'fenrick.miro.ux/ui/pages/DummyTab';
 
 /**
  * Renders DummyTab and asserts accessible role and text label.

--- a/fenrick.miro.ux.tests/edges.test.ts
+++ b/fenrick.miro.ux.tests/edges.test.ts
@@ -1,4 +1,4 @@
-import { graphService } from '../fenrick.miro.ux/src/core/graph';
+import { graphService } from 'fenrick.miro.ux/core/graph';
 
 // Tests for the createEdges helper covering edge reuse and hints
 

--- a/fenrick.miro.ux.tests/element-utils.test.ts
+++ b/fenrick.miro.ux.tests/element-utils.test.ts
@@ -1,5 +1,5 @@
-import { buildShapeStyle } from '../fenrick.miro.ux/src/board/element-utils';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+import { buildShapeStyle } from 'fenrick.miro.ux/board/element-utils';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 
 describe('buildShapeStyle', () => {
   afterEach(() => {

--- a/fenrick.miro.ux.tests/elk-loader.test.ts
+++ b/fenrick.miro.ux.tests/elk-loader.test.ts
@@ -1,4 +1,4 @@
-import { loadElk } from '../fenrick.miro.ux/src/core/layout/elk-loader';
+import { loadElk } from 'fenrick.miro.ux/core/layout/elk-loader';
 import ELK from 'elkjs/lib/elk.bundled.js';
 
 /** Tests for the dynamic ELK loader. */

--- a/fenrick.miro.ux.tests/elk-options.test.ts
+++ b/fenrick.miro.ux.tests/elk-options.test.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_LAYOUT_OPTIONS,
   validateLayoutOptions,
-} from '../fenrick.miro.ux/src/core/layout/elk-options';
+} from 'fenrick.miro.ux/core/layout/elk-options';
 
 describe('validateLayoutOptions', () => {
   test('returns defaults for invalid options', () => {

--- a/fenrick.miro.ux.tests/elk-preprocessor.test.ts
+++ b/fenrick.miro.ux.tests/elk-preprocessor.test.ts
@@ -1,5 +1,5 @@
-import type { LayoutNode } from '../fenrick.miro.ux/src/core/layout/elk-preprocessor';
-import { prepareForElk } from '../fenrick.miro.ux/src/core/layout/elk-preprocessor';
+import type { LayoutNode } from 'fenrick.miro.ux/core/layout/elk-preprocessor';
+import { prepareForElk } from 'fenrick.miro.ux/core/layout/elk-preprocessor';
 
 describe('prepareForElk', () => {
   test('assigns algorithm and inserts spacer', () => {

--- a/fenrick.miro.ux.tests/excel-loader.test.ts
+++ b/fenrick.miro.ux.tests/excel-loader.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import ExcelJS from 'exceljs';
 import { readFileSync } from 'fs';
-import { ExcelLoader } from '../fenrick.miro.ux/src/core/utils/excel-loader';
+import { ExcelLoader } from 'fenrick.miro.ux/core/utils/excel-loader';
 
 async function createFile(): Promise<File> {
   const wb = new ExcelJS.Workbook();

--- a/fenrick.miro.ux.tests/excel-tab-branches.test.tsx
+++ b/fenrick.miro.ux.tests/excel-tab-branches.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ExcelTab } from '../fenrick.miro.ux/src/ui/pages/ExcelTab';
+import { ExcelTab } from 'fenrick.miro.ux/ui/pages/ExcelTab';
 
 var localDropMock: vi.Mock;
 var remoteFetchMock: vi.Mock;
@@ -11,13 +11,13 @@ var showErrorMock: vi.Mock;
 var excelLoaderMock: Record<string, unknown>;
 var graphLoaderMock: Record<string, unknown>;
 
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-excel-sync', () => ({
+vi.mock('fenrick.miro.ux/ui/hooks/use-excel-sync', () => ({
   useExcelSync: () => vi.fn(),
 }));
-vi.mock('../fenrick.miro.ux/src/ui/hooks/excel-data-context', () => ({
+vi.mock('fenrick.miro.ux/ui/hooks/excel-data-context', () => ({
   useExcelData: () => null,
 }));
-vi.mock('../fenrick.miro.ux/src/ui/components/Select', () => ({
+vi.mock('fenrick.miro.ux/ui/components/Select', () => ({
   Select: ({
     value,
     onChange,
@@ -41,7 +41,7 @@ vi.mock('../fenrick.miro.ux/src/ui/components/Select', () => ({
     children: React.ReactNode;
   }) => <option value={value}>{children}</option>,
 }));
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-excel-handlers', () => {
+vi.mock('fenrick.miro.ux/ui/hooks/use-excel-handlers', () => {
   localDropMock = vi.fn();
   remoteFetchMock = vi.fn();
   return {
@@ -54,7 +54,7 @@ vi.mock('../fenrick.miro.ux/src/ui/hooks/use-excel-handlers', () => {
     fetchRemoteWorkbook: (url: string) => remoteFetchMock(url),
   };
 });
-vi.mock('../fenrick.miro.ux/src/core/utils/excel-loader', () => {
+vi.mock('fenrick.miro.ux/core/utils/excel-loader', () => {
   excelLoaderMock = {
     listSheets: vi.fn(() => ['Sheet1']),
     listNamedTables: vi.fn(() => ['Table1']),
@@ -74,7 +74,7 @@ vi.mock('../fenrick.miro.ux/src/core/utils/excel-loader', () => {
     GraphExcelLoader: class {},
   };
 });
-vi.mock('../fenrick.miro.ux/src/ui/hooks/notifications', () => {
+vi.mock('fenrick.miro.ux/ui/hooks/notifications', () => {
   showErrorMock = vi.fn();
   return { showError: showErrorMock };
 });

--- a/fenrick.miro.ux.tests/excel-tab.test.tsx
+++ b/fenrick.miro.ux.tests/excel-tab.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ExcelTab } from '../fenrick.miro.ux/src/ui/pages/ExcelTab';
+import { ExcelTab } from 'fenrick.miro.ux/ui/pages/ExcelTab';
 
 let dropHandler: (files: File[]) => Promise<void>;
 var localDropMock: vi.Mock;
@@ -11,13 +11,13 @@ var remoteFetchMock: vi.Mock;
 var excelLoaderMock: Record<string, unknown>;
 var graphLoaderMock: Record<string, unknown>;
 
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-excel-sync', () => ({
+vi.mock('fenrick.miro.ux/ui/hooks/use-excel-sync', () => ({
   useExcelSync: () => vi.fn(),
 }));
-vi.mock('../fenrick.miro.ux/src/ui/hooks/excel-data-context', () => ({
+vi.mock('fenrick.miro.ux/ui/hooks/excel-data-context', () => ({
   useExcelData: () => null,
 }));
-vi.mock('../fenrick.miro.ux/src/ui/components/Select', () => ({
+vi.mock('fenrick.miro.ux/ui/components/Select', () => ({
   Select: ({
     value,
     onChange,
@@ -41,7 +41,7 @@ vi.mock('../fenrick.miro.ux/src/ui/components/Select', () => ({
     children: React.ReactNode;
   }) => <option value={value}>{children}</option>,
 }));
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-excel-handlers', () => {
+vi.mock('fenrick.miro.ux/ui/hooks/use-excel-handlers', () => {
   localDropMock = vi.fn();
   remoteFetchMock = vi.fn();
   return {
@@ -57,7 +57,7 @@ vi.mock('../fenrick.miro.ux/src/ui/hooks/use-excel-handlers', () => {
     fetchRemoteWorkbook: (url: string) => remoteFetchMock(url),
   };
 });
-vi.mock('../fenrick.miro.ux/src/core/utils/excel-loader', () => {
+vi.mock('fenrick.miro.ux/core/utils/excel-loader', () => {
   excelLoaderMock = {
     listSheets: vi.fn(() => ['Sheet1']),
     listNamedTables: vi.fn(() => []),

--- a/fenrick.miro.ux.tests/exceljs-loader.test.ts
+++ b/fenrick.miro.ux.tests/exceljs-loader.test.ts
@@ -1,4 +1,4 @@
-import { loadExcelJS } from '../fenrick.miro.ux/src/core/utils/exceljs-loader';
+import { loadExcelJS } from 'fenrick.miro.ux/core/utils/exceljs-loader';
 import ExcelJS from 'exceljs';
 
 describe('loadExcelJS', () => {

--- a/fenrick.miro.ux.tests/file-utils-error.test.ts
+++ b/fenrick.miro.ux.tests/file-utils-error.test.ts
@@ -1,4 +1,4 @@
-import { fileUtils } from '../fenrick.miro.ux/src/core/utils/file-utils';
+import { fileUtils } from 'fenrick.miro.ux/core/utils/file-utils';
 
 describe('FileUtils error handling', () => {
   afterEach(() => {

--- a/fenrick.miro.ux.tests/file-utils-instance.test.ts
+++ b/fenrick.miro.ux.tests/file-utils-instance.test.ts
@@ -1,4 +1,4 @@
-import { FileUtils } from '../fenrick.miro.ux/src/core/utils/file-utils';
+import { FileUtils } from 'fenrick.miro.ux/core/utils/file-utils';
 
 describe('FileUtils singleton', () => {
   test('getInstance returns same instance', () => {

--- a/fenrick.miro.ux.tests/file-utils.test.ts
+++ b/fenrick.miro.ux.tests/file-utils.test.ts
@@ -1,4 +1,4 @@
-import { fileUtils } from '../fenrick.miro.ux/src/core/utils/file-utils';
+import { fileUtils } from 'fenrick.miro.ux/core/utils/file-utils';
 
 interface ReaderEvent {
   target: { result?: string | null } | null;

--- a/fenrick.miro.ux.tests/filter-dropdown.test.tsx
+++ b/fenrick.miro.ux.tests/filter-dropdown.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { FilterDropdown } from '../fenrick.miro.ux/src/ui/components/FilterDropdown';
+import { FilterDropdown } from 'fenrick.miro.ux/ui/components/FilterDropdown';
 
 test('handlers fire when filters change', () => {
   const onCase = vi.fn();

--- a/fenrick.miro.ux.tests/form-group.test.tsx
+++ b/fenrick.miro.ux.tests/form-group.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { FormGroup } from '../fenrick.miro.ux/src/ui/components/FormGroup';
+import { FormGroup } from 'fenrick.miro.ux/ui/components/FormGroup';
 
 test('renders child content', () => {
   render(<FormGroup>Text</FormGroup>);

--- a/fenrick.miro.ux.tests/format-tools.test.ts
+++ b/fenrick.miro.ux.tests/format-tools.test.ts
@@ -2,9 +2,9 @@
 import {
   applyStylePreset,
   presetStyle,
-} from '../fenrick.miro.ux/src/board/format-tools';
-import type { StylePreset } from '../fenrick.miro.ux/src/ui/style-presets';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/format-tools';
+import type { StylePreset } from 'fenrick.miro.ux/ui/style-presets';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 describe('format-tools', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/frame-tools.test.ts
+++ b/fenrick.miro.ux.tests/frame-tools.test.ts
@@ -1,9 +1,9 @@
 import {
   renameSelectedFrames,
   lockSelectedFrames,
-} from '../fenrick.miro.ux/src/board/frame-tools';
-import { BoardLike } from '../fenrick.miro.ux/src/board/board';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/frame-tools';
+import { BoardLike } from 'fenrick.miro.ux/board/board';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 describe('frame-tools', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/frame-utils.test.ts
+++ b/fenrick.miro.ux.tests/frame-utils.test.ts
@@ -1,9 +1,9 @@
 import {
   registerFrame,
   clearActiveFrame,
-} from '../fenrick.miro.ux/src/board/frame-utils';
+} from 'fenrick.miro.ux/board/frame-utils';
 import type { Frame } from '@mirohq/websdk-types';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 
 describe('frame-utils', () => {
   test('registerFrame creates frame and records it', async () => {

--- a/fenrick.miro.ux.tests/frames-tab.test.tsx
+++ b/fenrick.miro.ux.tests/frames-tab.test.tsx
@@ -3,11 +3,11 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { FramesTab } from '../fenrick.miro.ux/src/ui/pages/FramesTab';
+import { FramesTab } from 'fenrick.miro.ux/ui/pages/FramesTab';
 
 var renameMock: vi.Mock;
 var lockMock: vi.Mock;
-vi.mock('../fenrick.miro.ux/src/board/frame-tools', () => {
+vi.mock('fenrick.miro.ux/board/frame-tools', () => {
   renameMock = vi.fn();
   lockMock = vi.fn();
   return { renameSelectedFrames: renameMock, lockSelectedFrames: lockMock };

--- a/fenrick.miro.ux.tests/graph-auth.test.ts
+++ b/fenrick.miro.ux.tests/graph-auth.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { GraphAuth } from '../fenrick.miro.ux/src/core/utils/graph-auth';
+import { GraphAuth } from 'fenrick.miro.ux/core/utils/graph-auth';
 
 describe('GraphAuth', () => {
   test('set, get and clear token', () => {

--- a/fenrick.miro.ux.tests/graph-client.test.ts
+++ b/fenrick.miro.ux.tests/graph-client.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
-import { GraphClient } from '../fenrick.miro.ux/src/core/utils/graph-client';
-import { GraphAuth } from '../fenrick.miro.ux/src/core/utils/graph-auth';
+import { GraphClient } from 'fenrick.miro.ux/core/utils/graph-client';
+import { GraphAuth } from 'fenrick.miro.ux/core/utils/graph-auth';
 
 vi.stubGlobal('fetch', vi.fn());
 

--- a/fenrick.miro.ux.tests/graph-convert.test.ts
+++ b/fenrick.miro.ux.tests/graph-convert.test.ts
@@ -1,12 +1,12 @@
 import {
   edgesToHierarchy,
   hierarchyToEdges,
-} from '../fenrick.miro.ux/src/core/graph/convert';
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
-import { HierarchyProcessor } from '../fenrick.miro.ux/src/core/graph/hierarchy-processor';
-import { layoutEngine } from '../fenrick.miro.ux/src/core/layout/elk-layout';
-import * as nestedLayout from '../fenrick.miro.ux/src/core/layout/nested-layout';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+} from 'fenrick.miro.ux/core/graph/convert';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
+import { HierarchyProcessor } from 'fenrick.miro.ux/core/graph/hierarchy-processor';
+import { layoutEngine } from 'fenrick.miro.ux/core/layout/elk-layout';
+import * as nestedLayout from 'fenrick.miro.ux/core/layout/nested-layout';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/graph-excel-loader.test.ts
+++ b/fenrick.miro.ux.tests/graph-excel-loader.test.ts
@@ -1,8 +1,8 @@
-import { GraphExcelLoader } from '../fenrick.miro.ux/src/core/utils/excel-loader';
-import { GraphClient } from '../fenrick.miro.ux/src/core/utils/graph-client';
+import { GraphExcelLoader } from 'fenrick.miro.ux/core/utils/excel-loader';
+import { GraphClient } from 'fenrick.miro.ux/core/utils/graph-client';
 import ExcelJS from 'exceljs';
 
-vi.mock('../fenrick.miro.ux/src/core/utils/graph-client');
+vi.mock('fenrick.miro.ux/core/utils/graph-client');
 
 let buf: ArrayBuffer;
 beforeAll(async () => {

--- a/fenrick.miro.ux.tests/graph-load-any.test.ts
+++ b/fenrick.miro.ux.tests/graph-load-any.test.ts
@@ -1,7 +1,7 @@
 import {
   defaultBuilder,
   graphService,
-} from '../fenrick.miro.ux/src/core/graph';
+} from 'fenrick.miro.ux/core/graph';
 
 interface ReaderEvent {
   target: { result?: string | null } | null;

--- a/fenrick.miro.ux.tests/graph-load.test.ts
+++ b/fenrick.miro.ux.tests/graph-load.test.ts
@@ -1,7 +1,7 @@
 import {
   defaultBuilder,
   graphService,
-} from '../fenrick.miro.ux/src/core/graph';
+} from 'fenrick.miro.ux/core/graph';
 
 interface ReaderEvent {
   target: { result?: string | null } | null;

--- a/fenrick.miro.ux.tests/graph-service-singleton.test.ts
+++ b/fenrick.miro.ux.tests/graph-service-singleton.test.ts
@@ -1,4 +1,4 @@
-import { GraphService } from '../fenrick.miro.ux/src/core/graph';
+import { GraphService } from 'fenrick.miro.ux/core/graph';
 
 describe('GraphService singleton', () => {
   test('getInstance returns the same object', () => {

--- a/fenrick.miro.ux.tests/graph-wrappers.test.ts
+++ b/fenrick.miro.ux.tests/graph-wrappers.test.ts
@@ -1,7 +1,7 @@
 import {
   defaultBuilder,
   graphService,
-} from '../fenrick.miro.ux/src/core/graph';
+} from 'fenrick.miro.ux/core/graph';
 
 /**
  * Verify that service methods delegate to the default BoardBuilder instance.

--- a/fenrick.miro.ux.tests/grid-tools.test.ts
+++ b/fenrick.miro.ux.tests/grid-tools.test.ts
@@ -1,10 +1,10 @@
-import { applyGridLayout } from '../fenrick.miro.ux/src/board/grid-tools';
+import { applyGridLayout } from 'fenrick.miro.ux/board/grid-tools';
 import {
   calculateGrid,
   calculateGridPositions,
-} from '../fenrick.miro.ux/src/board/grid-layout';
-import { BoardLike } from '../fenrick.miro.ux/src/board/board';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/grid-layout';
+import { BoardLike } from 'fenrick.miro.ux/board/board';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 beforeEach(() => {
   boardCache.reset();

--- a/fenrick.miro.ux.tests/help-tab.test.tsx
+++ b/fenrick.miro.ux.tests/help-tab.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { HelpTab } from '../fenrick.miro.ux/src/ui/pages/HelpTab';
+import { HelpTab } from 'fenrick.miro.ux/ui/pages/HelpTab';
 
 describe('HelpTab', () => {
   test('lists diagram options', () => {

--- a/fenrick.miro.ux.tests/hierarchy-bounds.test.ts
+++ b/fenrick.miro.ux.tests/hierarchy-bounds.test.ts
@@ -1,5 +1,5 @@
-import { HierarchyProcessor } from '../fenrick.miro.ux/src/core/graph/hierarchy-processor';
-import { layoutHierarchy } from '../fenrick.miro.ux/src/core/layout/nested-layout';
+import { HierarchyProcessor } from 'fenrick.miro.ux/core/graph/hierarchy-processor';
+import { layoutHierarchy } from 'fenrick.miro.ux/core/layout/nested-layout';
 
 interface Node {
   id: string;

--- a/fenrick.miro.ux.tests/hierarchy-processor.test.ts
+++ b/fenrick.miro.ux.tests/hierarchy-processor.test.ts
@@ -1,5 +1,5 @@
-import { HierarchyProcessor } from '../fenrick.miro.ux/src/core/graph/hierarchy-processor';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+import { HierarchyProcessor } from 'fenrick.miro.ux/core/graph/hierarchy-processor';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/index-error.test.ts
+++ b/fenrick.miro.ux.tests/index-error.test.ts
@@ -1,5 +1,5 @@
 /** Entry index error handling */
-vi.mock('../fenrick.miro.ux/src/app/diagram-app', () => {
+vi.mock('fenrick.miro.ux/app/diagram-app', () => {
   return {
     DiagramApp: {
       getInstance: vi.fn(() => ({
@@ -9,10 +9,10 @@ vi.mock('../fenrick.miro.ux/src/app/diagram-app', () => {
   };
 });
 
-import { log } from '../fenrick.miro.ux/src/logger';
+import { log } from 'fenrick.miro.ux/logger';
 
 test('logs error when initialization fails', async () => {
   const errorSpy = jest.spyOn(log, 'error').mockImplementation(() => {});
-  await import('../fenrick.miro.ux/src/index');
+  await import('fenrick.miro.ux/index');
   expect(errorSpy).toHaveBeenCalled();
 });

--- a/fenrick.miro.ux.tests/index-import.test.ts
+++ b/fenrick.miro.ux.tests/index-import.test.ts
@@ -1,5 +1,5 @@
 /** Entry index tests */
-vi.mock('../fenrick.miro.ux/src/app/diagram-app', () => {
+vi.mock('fenrick.miro.ux/app/diagram-app', () => {
   return {
     DiagramApp: {
       getInstance: vi.fn(() => ({
@@ -11,9 +11,9 @@ vi.mock('../fenrick.miro.ux/src/app/diagram-app', () => {
 
 describe('index entrypoint', () => {
   test('initializes DiagramApp on import', async () => {
-    await import('../fenrick.miro.ux/src/index');
+    await import('fenrick.miro.ux/index');
     const { DiagramApp } = await import(
-      '../fenrick.miro.ux/src/app/diagram-app'
+      'fenrick.miro.ux/app/diagram-app'
     );
     expect(DiagramApp.getInstance).toHaveBeenCalled();
     const instance = (DiagramApp.getInstance as jest.Mock).mock.results[0]

--- a/fenrick.miro.ux.tests/inputfield.test.tsx
+++ b/fenrick.miro.ux.tests/inputfield.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { InputField } from '../fenrick.miro.ux/src/ui/components/InputField';
+import { InputField } from 'fenrick.miro.ux/ui/components/InputField';
 
 test('renders label and input', () => {
   render(

--- a/fenrick.miro.ux.tests/intro-screen.test.tsx
+++ b/fenrick.miro.ux.tests/intro-screen.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { IntroScreen } from '../fenrick.miro.ux/src/ui/components/IntroScreen';
+import { IntroScreen } from 'fenrick.miro.ux/ui/components/IntroScreen';
 
 describe('IntroScreen', () => {
   test('calls onStart when button clicked', () => {

--- a/fenrick.miro.ux.tests/json-dropzone.test.tsx
+++ b/fenrick.miro.ux.tests/json-dropzone.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { JsonDropZone } from '../fenrick.miro.ux/src/ui/components/JsonDropZone';
+import { JsonDropZone } from 'fenrick.miro.ux/ui/components/JsonDropZone';
 
 test('invokes callback when file selected', async () => {
   const handle = vi.fn();

--- a/fenrick.miro.ux.tests/layout-branches.test.ts
+++ b/fenrick.miro.ux.tests/layout-branches.test.ts
@@ -1,4 +1,4 @@
-import { layoutEngine } from '../fenrick.miro.ux/src/core/layout/elk-layout';
+import { layoutEngine } from 'fenrick.miro.ux/core/layout/elk-layout';
 import ELK from 'elkjs/lib/elk.bundled.js';
 
 /**

--- a/fenrick.miro.ux.tests/layout-core.test.ts
+++ b/fenrick.miro.ux.tests/layout-core.test.ts
@@ -3,8 +3,8 @@ import {
   performLayout,
   getNodeDimensions,
   buildElkGraphOptions,
-} from '../fenrick.miro.ux/src/core/layout/layout-core';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+} from 'fenrick.miro.ux/core/layout/layout-core';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 import ELK from 'elkjs/lib/elk.bundled.js';
 
 /** Branch coverage tests for performLayout. */

--- a/fenrick.miro.ux.tests/layout-engine-tab.test.tsx
+++ b/fenrick.miro.ux.tests/layout-engine-tab.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { LayoutEngineTab } from '../fenrick.miro.ux/src/ui/pages/LayoutEngineTab';
+import { LayoutEngineTab } from 'fenrick.miro.ux/ui/pages/LayoutEngineTab';
 
 describe('LayoutEngineTab', () => {
   test('renders placeholder message', () => {

--- a/fenrick.miro.ux.tests/layout-engine.test.ts
+++ b/fenrick.miro.ux.tests/layout-engine.test.ts
@@ -1,7 +1,7 @@
 import {
   LayoutEngine,
   layoutEngine,
-} from '../fenrick.miro.ux/src/core/layout/elk-layout';
+} from 'fenrick.miro.ux/core/layout/elk-layout';
 import ELK from 'elkjs/lib/elk.bundled.js';
 
 /** Verify singleton behaviour and minimal layout handling. */

--- a/fenrick.miro.ux.tests/layout-modes.test.ts
+++ b/fenrick.miro.ux.tests/layout-modes.test.ts
@@ -1,7 +1,7 @@
 import {
   NESTED_ALGORITHMS,
   isNestedAlgorithm,
-} from '../fenrick.miro.ux/src/core/graph/layout-modes';
+} from 'fenrick.miro.ux/core/graph/layout-modes';
 
 describe('layout-modes', () => {
   test('NESTED_ALGORITHMS lists supported algorithms', () => {

--- a/fenrick.miro.ux.tests/layout-utils.test.ts
+++ b/fenrick.miro.ux.tests/layout-utils.test.ts
@@ -4,7 +4,7 @@ import {
   boundingBoxFromCenter,
   boundingBoxFromTopLeft,
   frameOffset,
-} from '../fenrick.miro.ux/src/core/layout/layout-utils';
+} from 'fenrick.miro.ux/core/layout/layout-utils';
 
 describe('layout-utils', () => {
   test('relativePosition computes fractions', () => {

--- a/fenrick.miro.ux.tests/layout-worker.test.ts
+++ b/fenrick.miro.ux.tests/layout-worker.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
-import { LayoutEngine } from '../fenrick.miro.ux/src/core/layout/elk-layout';
-import * as layoutCore from '../fenrick.miro.ux/src/core/layout/layout-core';
+import { LayoutEngine } from 'fenrick.miro.ux/core/layout/elk-layout';
+import * as layoutCore from 'fenrick.miro.ux/core/layout/layout-core';
 
 /** Ensure layout runs inline even when Web Worker exists. */
 test('layoutGraph runs without Web Worker', async () => {

--- a/fenrick.miro.ux.tests/layout.test.ts
+++ b/fenrick.miro.ux.tests/layout.test.ts
@@ -1,4 +1,4 @@
-import { layoutEngine } from '../fenrick.miro.ux/src/core/layout/elk-layout';
+import { layoutEngine } from 'fenrick.miro.ux/core/layout/elk-layout';
 
 const graph = {
   nodes: [

--- a/fenrick.miro.ux.tests/logger.test.ts
+++ b/fenrick.miro.ux.tests/logger.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test, vi } from 'vitest';
-import { HttpLogSink } from '../fenrick.miro.ux/src/log-sink';
+import { HttpLogSink } from 'fenrick.miro.ux/log-sink';
 
 const ORIG_LEVEL = process.env.LOG_LEVEL;
 const ORIG_ENV = process.env.NODE_ENV;
@@ -13,13 +13,13 @@ afterEach(() => {
 
 test('defaults to info level', async () => {
   delete process.env.LOG_LEVEL;
-  const { log } = await import('../fenrick.miro.ux/src/logger');
+  const { log } = await import('fenrick.miro.ux/logger');
   expect(log.level).toBe('info');
 });
 
 test('respects LOG_LEVEL environment variable', async () => {
   process.env.LOG_LEVEL = 'trace';
-  const { log } = await import('../fenrick.miro.ux/src/logger');
+  const { log } = await import('fenrick.miro.ux/logger');
   expect(log.level).toBe('trace');
 });
 
@@ -28,7 +28,7 @@ test('forwards log entries to sink', async () => {
   process.env.NODE_ENV = 'development';
   global.fetch = vi.fn().mockResolvedValue({ ok: true });
   const sink = new HttpLogSink('/test');
-  const { createLogger } = await import('../fenrick.miro.ux/src/logger');
+  const { createLogger } = await import('fenrick.miro.ux/logger');
   const logger = createLogger(sink);
   logger.info('hello');
   expect(global.fetch).toHaveBeenCalledWith(

--- a/fenrick.miro.ux.tests/meta-constants.test.ts
+++ b/fenrick.miro.ux.tests/meta-constants.test.ts
@@ -1,4 +1,4 @@
-import { STRUCT_GRAPH_KEY } from '../fenrick.miro.ux/src/board/meta-constants';
+import { STRUCT_GRAPH_KEY } from 'fenrick.miro.ux/board/meta-constants';
 
 describe('meta-constants', () => {
   test('STRUCT_GRAPH_KEY has expected value', () => {

--- a/fenrick.miro.ux.tests/metadata-command.test.tsx
+++ b/fenrick.miro.ux.tests/metadata-command.test.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { App } from '../fenrick.miro.ux/src/app/App';
-import { EditMetadataModal } from '../fenrick.miro.ux/src/ui/components/EditMetadataModal';
-import { useRowData } from '../fenrick.miro.ux/src/ui/hooks/use-row-data';
-import { ExcelSyncService } from '../fenrick.miro.ux/src/core/excel-sync-service';
+import { App } from 'fenrick.miro.ux/app/App';
+import { EditMetadataModal } from 'fenrick.miro.ux/ui/components/EditMetadataModal';
+import { useRowData } from 'fenrick.miro.ux/ui/hooks/use-row-data';
+import { ExcelSyncService } from 'fenrick.miro.ux/core/excel-sync-service';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };
@@ -13,8 +13,8 @@ interface GlobalWithMiro {
 
 declare const global: GlobalWithMiro;
 
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-row-data');
-vi.mock('../fenrick.miro.ux/src/core/excel-sync-service');
+vi.mock('fenrick.miro.ux/ui/hooks/use-row-data');
+vi.mock('fenrick.miro.ux/core/excel-sync-service');
 
 describe('Edit Metadata command', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/mock-board.ts
+++ b/fenrick.miro.ux.tests/mock-board.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import type { BoardLike } from '../fenrick.miro.ux/src/board/board';
+import type { BoardLike } from 'fenrick.miro.ux/board/board';
 
 /**
  * Provide a basic Miro board mock for tests.

--- a/fenrick.miro.ux.tests/modal.test.tsx
+++ b/fenrick.miro.ux.tests/modal.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Modal } from '../fenrick.miro.ux/src/ui/components/Modal';
+import { Modal } from 'fenrick.miro.ux/ui/components/Modal';
 
 describe('Modal', () => {
   test('renders title and children', () => {

--- a/fenrick.miro.ux.tests/nested-layout.test.ts
+++ b/fenrick.miro.ux.tests/nested-layout.test.ts
@@ -2,7 +2,7 @@ import {
   layoutHierarchy,
   NestedLayouter,
   nestedLayouter,
-} from '../fenrick.miro.ux/src/core/layout/nested-layout';
+} from 'fenrick.miro.ux/core/layout/nested-layout';
 import ELK from 'elkjs/lib/elk.bundled.js';
 import type { ElkNode } from 'elkjs/lib/elk-api';
 import sampleHier from './fixtures/sample-hier.json';

--- a/fenrick.miro.ux.tests/node-search.test.ts
+++ b/fenrick.miro.ux.tests/node-search.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test, vi } from 'vitest';
 import {
   searchShapes,
   searchGroups,
-} from '../fenrick.miro.ux/src/board/node-search';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
-import type { BoardQueryLike } from '../fenrick.miro.ux/src/board/board';
+} from 'fenrick.miro.ux/board/node-search';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
+import type { BoardQueryLike } from 'fenrick.miro.ux/board/board';
 
 const board: BoardQueryLike = {
   get: vi.fn(({ type }) => {

--- a/fenrick.miro.ux.tests/node.test.ts
+++ b/fenrick.miro.ux.tests/node.test.ts
@@ -1,5 +1,5 @@
-import { graphService } from '../fenrick.miro.ux/src/core/graph';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+import { graphService } from 'fenrick.miro.ux/core/graph';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/notifications.test.ts
+++ b/fenrick.miro.ux.tests/notifications.test.ts
@@ -1,5 +1,5 @@
-import { showError } from '../fenrick.miro.ux/src/ui/hooks/notifications';
-import { log } from '../fenrick.miro.ux/src/logger';
+import { showError } from 'fenrick.miro.ux/ui/hooks/notifications';
+import { log } from 'fenrick.miro.ux/logger';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/page-help.test.tsx
+++ b/fenrick.miro.ux.tests/page-help.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { PageHelp } from '../fenrick.miro.ux/src/ui/components/PageHelp';
+import { PageHelp } from 'fenrick.miro.ux/ui/components/PageHelp';
 
 class ResizeObserverMock {
   observe() {}

--- a/fenrick.miro.ux.tests/processor-existing.test.ts
+++ b/fenrick.miro.ux.tests/processor-existing.test.ts
@@ -1,6 +1,6 @@
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
-import { layoutEngine } from '../fenrick.miro.ux/src/core/layout/elk-layout';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
+import { layoutEngine } from 'fenrick.miro.ux/core/layout/elk-layout';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/processor-file.test.ts
+++ b/fenrick.miro.ux.tests/processor-file.test.ts
@@ -1,5 +1,5 @@
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
-import { graphService } from '../fenrick.miro.ux/src/core/graph';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
+import { graphService } from 'fenrick.miro.ux/core/graph';
 
 /**
  * Tests for the processFile helper method which loads a graph

--- a/fenrick.miro.ux.tests/processor.test.ts
+++ b/fenrick.miro.ux.tests/processor.test.ts
@@ -1,9 +1,9 @@
-import { GraphProcessor } from '../fenrick.miro.ux/src/core/graph/graph-processor';
-import { graphService } from '../fenrick.miro.ux/src/core/graph';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
-import { layoutEngine } from '../fenrick.miro.ux/src/core/layout/elk-layout';
-import * as frameUtils from '../fenrick.miro.ux/src/board/frame-utils';
+import { GraphProcessor } from 'fenrick.miro.ux/core/graph/graph-processor';
+import { graphService } from 'fenrick.miro.ux/core/graph';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
+import { layoutEngine } from 'fenrick.miro.ux/core/layout/elk-layout';
+import * as frameUtils from 'fenrick.miro.ux/board/frame-utils';
 import type { Frame } from '@mirohq/websdk-types';
 import sample from './fixtures/sample-graph.json';
 

--- a/fenrick.miro.ux.tests/regex-search-field.test.tsx
+++ b/fenrick.miro.ux.tests/regex-search-field.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { RegexSearchField } from '../fenrick.miro.ux/src/ui/components/RegexSearchField';
+import { RegexSearchField } from 'fenrick.miro.ux/ui/components/RegexSearchField';
 
 test('input and toggle trigger callbacks', () => {
   const onChange = vi.fn();

--- a/fenrick.miro.ux.tests/render-utils.tsx
+++ b/fenrick.miro.ux.tests/render-utils.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { SearchTab } from '../fenrick.miro.ux/src/ui/pages/SearchTab';
+import { SearchTab } from 'fenrick.miro.ux/ui/pages/SearchTab';
 
 /**
  * Helper to render the SearchTab and return the search input element.

--- a/fenrick.miro.ux.tests/resize-tab-extra.test.tsx
+++ b/fenrick.miro.ux.tests/resize-tab-extra.test.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ResizeTab } from '../fenrick.miro.ux/src/ui/pages/ResizeTab';
-import * as resizeTools from '../fenrick.miro.ux/src/board/resize-tools';
+import { ResizeTab } from 'fenrick.miro.ux/ui/pages/ResizeTab';
+import * as resizeTools from 'fenrick.miro.ux/board/resize-tools';
 
 // Helper to provide a mock Miro board API
 function setupBoard(): void {

--- a/fenrick.miro.ux.tests/resize-tools.test.ts
+++ b/fenrick.miro.ux.tests/resize-tools.test.ts
@@ -2,8 +2,8 @@ import {
   applySizeToSelection,
   copySizeFromSelection,
   scaleSelection,
-} from '../fenrick.miro.ux/src/board/resize-tools';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/resize-tools';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 describe('resize-tools', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/row-inspector.test.tsx
+++ b/fenrick.miro.ux.tests/row-inspector.test.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { RowInspector } from '../fenrick.miro.ux/src/ui/components/RowInspector';
-import { useRowData } from '../fenrick.miro.ux/src/ui/hooks/use-row-data';
+import { RowInspector } from 'fenrick.miro.ux/ui/components/RowInspector';
+import { useRowData } from 'fenrick.miro.ux/ui/hooks/use-row-data';
 
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-row-data');
+vi.mock('fenrick.miro.ux/ui/hooks/use-row-data');
 
 describe('RowInspector', () => {
   test('renders list of row values', () => {

--- a/fenrick.miro.ux.tests/search-tab.test.tsx
+++ b/fenrick.miro.ux.tests/search-tab.test.tsx
@@ -2,7 +2,7 @@
 import { fireEvent, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { renderSearchTab } from './render-utils';
-import * as searchTools from '../fenrick.miro.ux/src/board/search-tools';
+import * as searchTools from 'fenrick.miro.ux/board/search-tools';
 
 vi.useFakeTimers();
 

--- a/fenrick.miro.ux.tests/search-tools.test.ts
+++ b/fenrick.miro.ux.tests/search-tools.test.ts
@@ -2,9 +2,9 @@ import {
   searchBoardContent,
   replaceBoardContent,
   getTextFields,
-} from '../fenrick.miro.ux/src/board/search-tools';
-import { BoardQueryLike } from '../fenrick.miro.ux/src/board/board';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/search-tools';
+import { BoardQueryLike } from 'fenrick.miro.ux/board/board';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 beforeEach(() => {
   boardCache.reset();
@@ -244,7 +244,7 @@ describe('search-tools', () => {
 
   test('setStringAtPath guards prototype pollution', async () => {
     const { _setStringAtPath: fn } = (await import(
-      '../fenrick.miro.ux/src/board/search-tools'
+      'fenrick.miro.ux/board/search-tools'
     )) as {
       _setStringAtPath: (
         o: Record<string, unknown>,

--- a/fenrick.miro.ux.tests/segmented-control.test.tsx
+++ b/fenrick.miro.ux.tests/segmented-control.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { SegmentedControl } from '../fenrick.miro.ux/src/ui/components/SegmentedControl';
+import { SegmentedControl } from 'fenrick.miro.ux/ui/components/SegmentedControl';
 
 describe('SegmentedControl', () => {
   test('click triggers onChange with value', () => {

--- a/fenrick.miro.ux.tests/selectfield.test.tsx
+++ b/fenrick.miro.ux.tests/selectfield.test.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { SelectField } from '../fenrick.miro.ux/src/ui/components/SelectField';
-import { SelectOption } from '../fenrick.miro.ux/src/ui/components';
+import { SelectField } from 'fenrick.miro.ux/ui/components/SelectField';
+import { SelectOption } from 'fenrick.miro.ux/ui/components';
 
 test('renders label and select', () => {
   render(

--- a/fenrick.miro.ux.tests/setupTests.ts
+++ b/fenrick.miro.ux.tests/setupTests.ts
@@ -1,3 +1,4 @@
+import 'tsconfig-paths/register';
 import { vi, afterEach } from 'vitest';
 
 // alias jest global to vitest for compatibility

--- a/fenrick.miro.ux.tests/spacing-tools.test.ts
+++ b/fenrick.miro.ux.tests/spacing-tools.test.ts
@@ -1,7 +1,7 @@
-import { applySpacingLayout } from '../fenrick.miro.ux/src/board/spacing-tools';
-import { calculateSpacingOffsets } from '../fenrick.miro.ux/src/board/spacing-layout';
-import { BoardLike } from '../fenrick.miro.ux/src/board/board';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+import { applySpacingLayout } from 'fenrick.miro.ux/board/spacing-tools';
+import { calculateSpacingOffsets } from 'fenrick.miro.ux/board/spacing-layout';
+import { BoardLike } from 'fenrick.miro.ux/board/board';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 beforeEach(() => {
   boardCache.reset();

--- a/fenrick.miro.ux.tests/story-wrapper.test.tsx
+++ b/fenrick.miro.ux.tests/story-wrapper.test.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ExcelStoryWrapper } from '../fenrick.miro.ux/src/stories/ExcelStoryWrapper';
-import { useExcelData } from '../fenrick.miro.ux/src/ui/hooks/excel-data-context';
+import { ExcelStoryWrapper } from 'fenrick.miro.ux/stories/ExcelStoryWrapper';
+import { useExcelData } from 'fenrick.miro.ux/ui/hooks/excel-data-context';
 
 declare const global: {
   miro?: { board?: { getSelection: () => Promise<unknown> } };

--- a/fenrick.miro.ux.tests/string-utils.test.ts
+++ b/fenrick.miro.ux.tests/string-utils.test.ts
@@ -1,4 +1,4 @@
-import { toSafeString } from '../fenrick.miro.ux/src/core/utils/string-utils';
+import { toSafeString } from 'fenrick.miro.ux/core/utils/string-utils';
 
 describe('toSafeString', () => {
   test('returns empty string for null or undefined', () => {

--- a/fenrick.miro.ux.tests/structured-tab-branches.test.tsx
+++ b/fenrick.miro.ux.tests/structured-tab-branches.test.tsx
@@ -3,13 +3,13 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { StructuredTab } from '../fenrick.miro.ux/src/ui/pages/StructuredTab';
+import { StructuredTab } from 'fenrick.miro.ux/ui/pages/StructuredTab';
 
 var createSpy: vi.Mock;
 var undoSpy: vi.Mock;
 var lastProc: { undoLast: vi.Mock };
 
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-diagram-create', () => ({
+vi.mock('fenrick.miro.ux/ui/hooks/use-diagram-create', () => ({
   useDiagramCreate: (
     _queue: File[],
     _opts: unknown,
@@ -28,10 +28,10 @@ vi.mock('../fenrick.miro.ux/src/ui/hooks/use-diagram-create', () => ({
   },
   useAdvancedToggle: () => {},
 }));
-vi.mock('../fenrick.miro.ux/src/ui/hooks/ui-utils', async () => {
+vi.mock('fenrick.miro.ux/ui/hooks/ui-utils', async () => {
   const actual = await vi.importActual<
-    typeof import('../fenrick.miro.ux/src/ui/hooks/ui-utils')
-  >('../fenrick.miro.ux/src/ui/hooks/ui-utils');
+    typeof import('fenrick.miro.ux/ui/hooks/ui-utils')
+  >('fenrick.miro.ux/ui/hooks/ui-utils');
   undoSpy = vi.fn(async (proc: { undoLast: () => void }, clear: () => void) => {
     proc.undoLast();
     clear();

--- a/fenrick.miro.ux.tests/structured-tab.test.tsx
+++ b/fenrick.miro.ux.tests/structured-tab.test.tsx
@@ -6,22 +6,22 @@ import '@testing-library/jest-dom';
 import {
   StructuredTab,
   handleFileDrop,
-} from '../fenrick.miro.ux/src/ui/pages/StructuredTab';
+} from 'fenrick.miro.ux/ui/pages/StructuredTab';
 
-vi.mock('../fenrick.miro.ux/src/core/graph/graph-processor', () => ({
+vi.mock('fenrick.miro.ux/core/graph/graph-processor', () => ({
   GraphProcessor: class {
     processFile = vi.fn();
   },
   ExistingNodeMode: { move: 'move' },
 }));
-vi.mock('../fenrick.miro.ux/src/core/graph/hierarchy-processor', () => ({
+vi.mock('fenrick.miro.ux/core/graph/hierarchy-processor', () => ({
   HierarchyProcessor: class {
     processFile = vi.fn();
   },
 }));
 
 var createSpy: vi.Mock;
-vi.mock('../fenrick.miro.ux/src/ui/hooks/use-diagram-create', () => ({
+vi.mock('fenrick.miro.ux/ui/hooks/use-diagram-create', () => ({
   useDiagramCreate: () => {
     createSpy = vi.fn();
     return createSpy;

--- a/fenrick.miro.ux.tests/style-presets.test.ts
+++ b/fenrick.miro.ux.tests/style-presets.test.ts
@@ -5,12 +5,12 @@ import templatesJson from '../templates/shapeTemplates.json';
 import {
   stylePresets,
   STYLE_PRESET_NAMES,
-} from '../fenrick.miro.ux/src/ui/style-presets';
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
-import type { TemplateDefinition } from '../fenrick.miro.ux/src/board/templates';
+} from 'fenrick.miro.ux/ui/style-presets';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
+import type { TemplateDefinition } from 'fenrick.miro.ux/board/templates';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { StyleTab } from '../fenrick.miro.ux/src/ui/pages/StyleTab';
+import { StyleTab } from 'fenrick.miro.ux/ui/pages/StyleTab';
 
 // Ensure presets derive from templates
 describe('style-presets', () => {

--- a/fenrick.miro.ux.tests/style-tab-extra.test.tsx
+++ b/fenrick.miro.ux.tests/style-tab-extra.test.tsx
@@ -2,15 +2,15 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { StyleTab } from '../fenrick.miro.ux/src/ui/pages/StyleTab';
-import * as styleTools from '../fenrick.miro.ux/src/board/style-tools';
+import { StyleTab } from 'fenrick.miro.ux/ui/pages/StyleTab';
+import * as styleTools from 'fenrick.miro.ux/board/style-tools';
 import {
   stylePresets,
   STYLE_PRESET_NAMES,
-} from '../fenrick.miro.ux/src/ui/style-presets';
-import * as formatTools from '../fenrick.miro.ux/src/board/format-tools';
+} from 'fenrick.miro.ux/ui/style-presets';
+import * as formatTools from 'fenrick.miro.ux/board/format-tools';
 
-vi.mock('../fenrick.miro.ux/src/board/style-tools');
+vi.mock('fenrick.miro.ux/board/style-tools');
 
 describe('StyleTab extra features', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/style-tools.test.ts
+++ b/fenrick.miro.ux.tests/style-tools.test.ts
@@ -9,8 +9,8 @@ import {
   // but tests rely on it to validate key detection
   // coverage of this utility supports maintainability
   findStyleKey,
-} from '../fenrick.miro.ux/src/board/style-tools';
-import { boardCache } from '../fenrick.miro.ux/src/board/board-cache';
+} from 'fenrick.miro.ux/board/style-tools';
+import { boardCache } from 'fenrick.miro.ux/board/board-cache';
 
 describe('style-tools', () => {
   beforeEach(() => {

--- a/fenrick.miro.ux.tests/tab-panel.test.tsx
+++ b/fenrick.miro.ux.tests/tab-panel.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { TabPanel } from '../fenrick.miro.ux/src/ui/components/TabPanel';
+import { TabPanel } from 'fenrick.miro.ux/ui/components/TabPanel';
 
 test('renders with correct aria attributes', () => {
   render(<TabPanel tabId='test'>Content</TabPanel>);

--- a/fenrick.miro.ux.tests/tabbar.test.tsx
+++ b/fenrick.miro.ux.tests/tabbar.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { fireEvent, render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { App } from '../fenrick.miro.ux/src/app/App';
+import { App } from 'fenrick.miro.ux/app/App';
 
 beforeEach(() => {
   (globalThis as { miro?: { board?: unknown } }).miro = {

--- a/fenrick.miro.ux.tests/tabs-stories.test.ts
+++ b/fenrick.miro.ux.tests/tabs-stories.test.ts
@@ -1,4 +1,4 @@
-import * as stories from '../fenrick.miro.ux/src/stories/Tabs.stories';
+import * as stories from 'fenrick.miro.ux/stories/Tabs.stories';
 
 describe('Tabs stories', () => {
   test('provides parent tab examples', () => {

--- a/fenrick.miro.ux.tests/template.test.ts
+++ b/fenrick.miro.ux.tests/template.test.ts
@@ -1,4 +1,4 @@
-import { templateManager } from '../fenrick.miro.ux/src/board/templates';
+import { templateManager } from 'fenrick.miro.ux/board/templates';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };

--- a/fenrick.miro.ux.tests/templates-functions.test.ts
+++ b/fenrick.miro.ux.tests/templates-functions.test.ts
@@ -1,7 +1,7 @@
 import {
   connectorTemplates,
   templateManager,
-} from '../fenrick.miro.ux/src/board/templates';
+} from 'fenrick.miro.ux/board/templates';
 
 // Simple tests for template helper functions
 

--- a/fenrick.miro.ux.tests/tools-tab.test.tsx
+++ b/fenrick.miro.ux.tests/tools-tab.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ToolsTab } from '../fenrick.miro.ux/src/ui/pages/ToolsTab';
+import { ToolsTab } from 'fenrick.miro.ux/ui/pages/ToolsTab';
 
 vi.mock('@mirohq/design-system', async () => {
   const React = await import('react');
@@ -82,23 +82,23 @@ vi.mock('@mirohq/design-system', async () => {
   return { Tabs, IconButton, IconQuestionMarkCircle, Tooltip };
 });
 
-vi.mock('../fenrick.miro.ux/src/ui/pages/ResizeTab', () => {
+vi.mock('fenrick.miro.ux/ui/pages/ResizeTab', () => {
   const ResizeTabMock: React.FC = () => (
     <div data-testid='resize-tab'>Resize</div>
   );
   return { ResizeTab: ResizeTabMock };
 });
-vi.mock('../fenrick.miro.ux/src/ui/pages/StyleTab', () => {
+vi.mock('fenrick.miro.ux/ui/pages/StyleTab', () => {
   const StyleTabMock: React.FC = () => <div data-testid='style-tab'>Style</div>;
   return { StyleTab: StyleTabMock };
 });
-vi.mock('../fenrick.miro.ux/src/ui/pages/ArrangeTab', () => {
+vi.mock('fenrick.miro.ux/ui/pages/ArrangeTab', () => {
   const ArrangeTabMock: React.FC = () => (
     <div data-testid='arrange-tab'>Arrange</div>
   );
   return { ArrangeTab: ArrangeTabMock };
 });
-vi.mock('../fenrick.miro.ux/src/ui/pages/FramesTab', () => {
+vi.mock('fenrick.miro.ux/ui/pages/FramesTab', () => {
   const FramesTabMock: React.FC = () => (
     <div data-testid='frames-tab'>Frames</div>
   );

--- a/fenrick.miro.ux.tests/tooltip.test.tsx
+++ b/fenrick.miro.ux.tests/tooltip.test.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Tooltip } from '../fenrick.miro.ux/src/ui/components/Tooltip';
-import { Button } from '../fenrick.miro.ux/src/ui/components/Button';
+import { Tooltip } from 'fenrick.miro.ux/ui/components/Tooltip';
+import { Button } from 'fenrick.miro.ux/ui/components/Button';
 
 class ResizeObserverMock {
   observe() {}

--- a/fenrick.miro.ux.tests/undo-utils.test.ts
+++ b/fenrick.miro.ux.tests/undo-utils.test.ts
@@ -1,8 +1,8 @@
 import {
   undoWidgets,
   syncOrUndo,
-} from '../fenrick.miro.ux/src/board/undo-utils';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+} from 'fenrick.miro.ux/board/undo-utils';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 import type { Frame } from '@mirohq/websdk-types';
 
 describe('undoWidgets', () => {

--- a/fenrick.miro.ux.tests/undoable-processor.test.ts
+++ b/fenrick.miro.ux.tests/undoable-processor.test.ts
@@ -1,5 +1,5 @@
-import { UndoableProcessor } from '../fenrick.miro.ux/src/core/graph/undoable-processor';
-import { BoardBuilder } from '../fenrick.miro.ux/src/board/board-builder';
+import { UndoableProcessor } from 'fenrick.miro.ux/core/graph/undoable-processor';
+import { BoardBuilder } from 'fenrick.miro.ux/board/board-builder';
 import type { BaseItem } from '@mirohq/websdk-types';
 
 class Dummy extends UndoableProcessor<BaseItem> {

--- a/fenrick.miro.ux.tests/unit-utils.test.ts
+++ b/fenrick.miro.ux.tests/unit-utils.test.ts
@@ -3,7 +3,7 @@ import {
   boardUnitsToInches,
   mmToBoardUnits,
   inchesToBoardUnits,
-} from '../fenrick.miro.ux/src/core/utils/unit-utils';
+} from 'fenrick.miro.ux/core/utils/unit-utils';
 
 describe('unit-utils', () => {
   test('boardUnitsToMm converts units', () => {

--- a/fenrick.miro.ux.tests/use-excel-sync.test.tsx
+++ b/fenrick.miro.ux.tests/use-excel-sync.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
-import { ExcelDataProvider } from '../fenrick.miro.ux/src/ui/hooks/excel-data-context';
-import { useExcelSync } from '../fenrick.miro.ux/src/ui/hooks/use-excel-sync';
-import { ExcelSyncService } from '../fenrick.miro.ux/src/core/excel-sync-service';
+import { ExcelDataProvider } from 'fenrick.miro.ux/ui/hooks/excel-data-context';
+import { useExcelSync } from 'fenrick.miro.ux/ui/hooks/use-excel-sync';
+import { ExcelSyncService } from 'fenrick.miro.ux/core/excel-sync-service';
 
-vi.mock('../fenrick.miro.ux/src/core/excel-sync-service');
+vi.mock('fenrick.miro.ux/core/excel-sync-service');
 
 const rows = [{ ID: '1', Name: 'A' }];
 

--- a/fenrick.miro.ux.tests/useSelection.test.ts
+++ b/fenrick.miro.ux.tests/useSelection.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
-import { useSelection } from '../fenrick.miro.ux/src/ui/hooks/use-selection';
-import { BoardLike } from '../fenrick.miro.ux/src/board/board';
+import { useSelection } from 'fenrick.miro.ux/ui/hooks/use-selection';
+import { BoardLike } from 'fenrick.miro.ux/board/board';
 
 describe('useSelection', () => {
   test('fetches initial selection', async () => {

--- a/fenrick.miro.ux.tests/workbook-utils.test.ts
+++ b/fenrick.miro.ux.tests/workbook-utils.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect, vi } from 'vitest';
 import {
   addMiroIds,
   downloadWorkbook,
-} from '../fenrick.miro.ux/src/core/utils/workbook-writer';
+} from 'fenrick.miro.ux/core/utils/workbook-writer';
 
 describe('workbook writer', () => {
   test('adds ids to rows', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.37.0",
         "vite": "^6.3.5",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -12367,6 +12368,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -21115,6 +21123,27 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -21686,6 +21715,26 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/d3-dsv": "^3.0.7",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.14",
@@ -76,8 +77,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.37.0",
     "vite": "^6.3.5",
-    "vitest": "^3.2.4",
-    "@testing-library/user-event": "^14.6.1"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
## Summary
- refactor tests to use `fenrick.miro.ux` path alias
- register tsconfig paths in test setup

## Testing
- `npm run lint --silent`
- `npm test --silent` *(fails: failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6878f54a8488832b88ecb0a34e433328