### PR TITLE
docs: update .NET AppHost deployment guide

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -202,8 +202,9 @@ automatically.
 
 Some teams host the React bundle alongside an ASP.NET Core API. The backend
 publishes to a `publish/` directory and serves static files from the `wwwroot`
-folder. The `dist/` bundle can be copied into `wwwroot` during the publish step
-so front-end assets and API endpoints share the same origin.
+folder. When `dotnet publish` runs the front‑end build output is copied from
+`fenrick.miro.ux/dist` into `fenrick.miro.server/wwwroot` so front-end assets
+and API endpoints share the same origin.
 
 ### 12.1 Environment variables
 
@@ -215,19 +216,31 @@ Define these variables in the hosting environment:
 | **ASPNETCORE_URLS**                | HTTP bind address, e.g. `http://*:5000` |
 | **APPINSIGHTS_INSTRUMENTATIONKEY** | Azure Application Insights key          |
 | **JWT\_\_Issuer**                  | Token issuer for API auth               |
+| **APPHOST_PORT**                   | Port used when running the AppHost      |
 
 ### 12.2 Build & publish
 
 ```bash
-dotnet restore
-dotnet publish -c Release -o publish --nologo
+npm --prefix fenrick.miro.ux run build
+dotnet publish fenrick.miro.server -c Release -o publish --nologo
 ```
 
-The `publish/` folder then contains the compiled API along with the React
-`dist/` assets. Copy the directory into a container image or deploy it straight
-to a platform like **Azure App Service**.
+The front-end build creates `fenrick.miro.ux/dist`. During `dotnet publish`
+those files are copied into `publish/wwwroot` so the compiled API and static
+assets ship together. Deploy the `publish/` directory or copy it into a
+container image.
 
-### 12.3 Containerisation and hosting
+### 12.3 Run the AppHost
+
+Execute the compiled server from the `publish/` folder. The `ASPNETCORE_URLS`
+value decides the bind address while `APPHOST_PORT` overrides the default port.
+
+```bash
+cd publish
+ASPNETCORE_URLS="http://*:5000" dotnet fenrick.miro.server.dll
+```
+
+### 12.4 Containerisation and hosting
 
 **Docker**
 


### PR DESCRIPTION
## Summary
- clarify how `dotnet publish` copies the node build to `wwwroot`
- document environment variables including the new `APPHOST_PORT`
- add steps for running the AppHost
- update containerisation section numbering

## Testing
- `npm --prefix fenrick.miro.ux run typecheck --silent`
- `npm --prefix fenrick.miro.ux test --silent`
- `npm --prefix fenrick.miro.ux run lint --silent`
- `npm --prefix fenrick.miro.ux run stylelint --silent`
- `npm --prefix fenrick.miro.ux run prettier --silent`
- `dotnet test fenrick.miro.server.tests/fenrick.miro.server.tests.csproj`
- `dotnet format --verify-no-changes fenrick.miro.server/fenrick.miro.server.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687a54942138832b8763345b48175288