### PR TITLE
Add Aspire AppHost for serving UX

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -220,7 +220,14 @@ Define these variables in the hosting environment:
 
 ```bash
 dotnet restore
+npm --prefix ../fenrick.miro.ux run build
 dotnet publish -c Release -o publish --nologo
+```
+
+Run the app locally with:
+
+```bash
+dotnet run --project fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost
 ```
 
 The `publish/` folder then contains the compiled API along with the React

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Fenrick.Miro.AppHost.AppHost.csproj
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Fenrick.Miro.AppHost.AppHost.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>a9d2fbb4-2324-4ad7-aa90-24ffc7940a31</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
+    <ProjectReference Include="../../fenrick.miro.server/fenrick.miro.server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Program.cs
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Program.cs
@@ -1,0 +1,4 @@
+using Server = Fenrick.Miro.Server.Program;
+
+var app = Server.BuildApp(args);
+await app.RunAsync();

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Properties/launchSettings.json
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17244;http://localhost:15110",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21242",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22157"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15110",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19088",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20195"
+      }
+    }
+  }
+}

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/appsettings.Development.json
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/appsettings.json
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.ServiceDefaults/Extensions.cs
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.ServiceDefaults/Extensions.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.ServiceDefaults/Fenrick.Miro.AppHost.ServiceDefaults.csproj
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.ServiceDefaults/Fenrick.Miro.AppHost.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/fenrick.miro.apphost/Fenrick.Miro.AppHost.sln
+++ b/fenrick.miro.apphost/Fenrick.Miro.AppHost.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.0.0
+MinimumVisualStudioVersion = 17.8.0.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fenrick.Miro.AppHost.AppHost", "Fenrick.Miro.AppHost.AppHost\Fenrick.Miro.AppHost.AppHost.csproj", "{776826F0-A1F4-40D0-AD69-B8EB6BA6A9CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fenrick.Miro.AppHost.ServiceDefaults", "Fenrick.Miro.AppHost.ServiceDefaults\Fenrick.Miro.AppHost.ServiceDefaults.csproj", "{60027F8D-3C66-4612-B5FA-4DC5EE3A2C2A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{776826F0-A1F4-40D0-AD69-B8EB6BA6A9CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{776826F0-A1F4-40D0-AD69-B8EB6BA6A9CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{776826F0-A1F4-40D0-AD69-B8EB6BA6A9CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{776826F0-A1F4-40D0-AD69-B8EB6BA6A9CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60027F8D-3C66-4612-B5FA-4DC5EE3A2C2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60027F8D-3C66-4612-B5FA-4DC5EE3A2C2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60027F8D-3C66-4612-B5FA-4DC5EE3A2C2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60027F8D-3C66-4612-B5FA-4DC5EE3A2C2A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {098E33F7-64EB-4E00-B256-63E43CBC67B1}
+	EndGlobalSection
+EndGlobal

--- a/fenrick.miro.server.tests/tests/UseUxStaticFilesTests.cs
+++ b/fenrick.miro.server.tests/tests/UseUxStaticFilesTests.cs
@@ -1,0 +1,27 @@
+using Fenrick.Miro.Server;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Fenrick.Miro.Server.Tests;
+
+public class UseUxStaticFilesTests
+{
+    [Fact]
+    public void GetUxPath_CombinesRootAndRelativePath()
+    {
+        var env = new HostEnvironment { ContentRootPath = "/app" };
+
+        var path = UxStaticFileExtensions.GetUxPath(env);
+
+        Assert.EndsWith("fenrick.miro.ux/dist", path.Replace('\', ' / '));
+    }
+
+    private sealed class HostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "Test";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/fenrick.miro.server/src/Program.cs
+++ b/fenrick.miro.server/src/Program.cs
@@ -3,22 +3,36 @@ using Fenrick.Miro.Server.Services;
 using Serilog;
 using System.Diagnostics.CodeAnalysis;
 
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Host.UseSerilog((_, cfg) =>
-{
-    cfg.MinimumLevel.Information()
-        .Enrich.FromLogContext()
-        .WriteTo.Console();
-});
-
-builder.Services.AddControllers();
-builder.Services.AddSingleton<ICacheService, InMemoryCacheService>();
-builder.Services.AddSingleton<ILogSink, SerilogSink>();
-
-var app = builder.Build();
-app.MapControllers();
+var app = Program.BuildApp(args);
 await app.RunAsync();
 
 [ExcludeFromCodeCoverage]
-public static partial class Program { }
+public static partial class Program
+{
+    /// <summary>
+    /// Configure and build the web application.
+    /// </summary>
+    /// <param name="args">Command line arguments.</param>
+    /// <returns>The configured <see cref="WebApplication"/>.</returns>
+    public static WebApplication BuildApp(string[]? args = null)
+    {
+        var builder = WebApplication.CreateBuilder(args ?? []);
+
+        builder.Host.UseSerilog((_, cfg) =>
+        {
+            cfg.MinimumLevel.Information()
+                .Enrich.FromLogContext()
+                .WriteTo.Console();
+        });
+
+        builder.Services.AddControllers();
+        builder.Services.AddSingleton<ICacheService, InMemoryCacheService>();
+        builder.Services.AddSingleton<ILogSink, SerilogSink>();
+
+        var app = builder.Build();
+        app.UseUxStaticFiles(builder.Environment);
+        app.MapControllers();
+
+        return app;
+    }
+}

--- a/fenrick.miro.server/src/UxStaticFileExtensions.cs
+++ b/fenrick.miro.server/src/UxStaticFileExtensions.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using System.IO;
+
+namespace Fenrick.Miro.Server;
+
+/// <summary>
+/// Provides helpers for serving the built React application.
+/// </summary>
+public static class UxStaticFileExtensions
+{
+    private const string UxRelativePath = "../fenrick.miro.ux/dist";
+
+    /// <summary>
+    /// Configure the application to serve static files from the UX build output.
+    /// </summary>
+    /// <param name="app">The web application.</param>
+    /// <param name="env">The host environment.</param>
+    public static void UseUxStaticFiles(this WebApplication app, IHostEnvironment env)
+    {
+        var path = GetUxPath(env);
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        var provider = new PhysicalFileProvider(path);
+        app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = provider });
+        app.UseStaticFiles(new StaticFileOptions { FileProvider = provider, ServeUnknownFileTypes = true });
+    }
+
+    /// <summary>
+    /// Get the absolute path to the UX build output directory.
+    /// </summary>
+    /// <param name="env">The host environment.</param>
+    /// <returns>Absolute path to the dist folder.</returns>
+    public static string GetUxPath(IHostEnvironment env) =>
+        Path.GetFullPath(Path.Combine(env.ContentRootPath, UxRelativePath));
+}

--- a/fenrick.miro.slnx
+++ b/fenrick.miro.slnx
@@ -4,4 +4,5 @@
   </Project>
   <Project Path="fenrick.miro.server/fenrick.miro.server.csproj" />
   <Project Path="fenrick.miro.server.tests/fenrick.miro.server.tests.csproj" />
+  <Project Path="fenrick.miro.apphost/Fenrick.Miro.AppHost.AppHost/Fenrick.Miro.AppHost.AppHost.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- create `Fenrick.Miro.AppHost` using `dotnet new aspire`
- reference the server project and configure UX static file serving
- update solution file to include new AppHost
- describe build and run steps for the host in deployment docs
- add tests for UX static file utilities

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `dotnet test --no-build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_687a548a979c832b88246f216f309d9d