### PR TITLE
Fix dotnet test coverage

### DIFF
--- a/fenrick.miro.tests/fenrick.miro.tests.csproj
+++ b/fenrick.miro.tests/fenrick.miro.tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
     <!-- Ensure patched runtime libraries for tests -->
     <PackageReference Include="System.Text.Json" Version="9.0.7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
## Summary
- use coverlet.msbuild instead of the collector

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj --logger "trx;LogFileName=results.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=coverage/coverage.cobertura.xml --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687b8ce8e088832baa56e198958e6478