### PR TITLE
Fix coverage merge path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,11 @@ jobs:
           mkdir -p coverage
           npx --prefix fenrick.miro.client lcov-result-merger "coverage-*/lcov.info" coverage/lcov.info
           cat coverage-*/sonar-report.xml > coverage/sonar-report.xml
-          cp dotnet-coverage/**/coverage.cobertura.xml coverage/coverage.cobertura.xml
+          # globstar is not enabled by default in the bash shell used by
+          # GitHub Actions, so the previous recursive copy failed to match
+          # the coverage file. Use `find` instead to locate the Cobertura
+          # report produced by the .NET tests.
+          find dotnet-coverage -name coverage.cobertura.xml -exec cp {} coverage/coverage.cobertura.xml \;
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- use `find` instead of `globstar` to locate the Cobertura report in CI

## Testing
- `npm run typecheck --silent`
- `npm run test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687b907deff8832b99e807095652da7a