### PR TITLE
Fix C# naming rule warnings

### DIFF
--- a/fenrick.miro.server/src/Api/BatchController.cs
+++ b/fenrick.miro.server/src/Api/BatchController.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 [Route("api/batch")]
 public class BatchController(IMiroClient client) : ControllerBase
 {
-    private readonly IMiroClient _client = client;
+    private readonly IMiroClient miroClient = client;
 
     [HttpPost]
     public async Task<IActionResult> ForwardAsync(
@@ -19,7 +19,7 @@ public class BatchController(IMiroClient client) : ControllerBase
         var responses = new List<MiroResponse>(requests.Length);
         foreach (var req in requests)
         {
-            var res = await this._client.SendAsync(req);
+            var res = await this.miroClient.SendAsync(req);
             responses.Add(res);
         }
 

--- a/fenrick.miro.server/src/Api/CacheController.cs
+++ b/fenrick.miro.server/src/Api/CacheController.cs
@@ -11,9 +11,9 @@ using Services;
 [Route("api/cache")]
 public class CacheController(ICacheService cache) : ControllerBase
 {
-    private readonly ICacheService _cache = cache;
+    private readonly ICacheService cacheService = cache;
 
     [HttpGet("{boardId}")]
     public ActionResult<BoardMetadata?> Get(string boardId) =>
-        this.Ok(this._cache.Get(boardId));
+        this.Ok(this.cacheService.Retrieve(boardId));
 }

--- a/fenrick.miro.server/src/Api/LogsController.cs
+++ b/fenrick.miro.server/src/Api/LogsController.cs
@@ -12,12 +12,12 @@ using Services;
 [Route("api/logs")]
 public class LogsController(ILogSink sink) : ControllerBase
 {
-    private readonly ILogSink _sink = sink;
+    private readonly ILogSink logSink = sink;
 
     [HttpPost]
     public IActionResult Capture([FromBody] ClientLogEntry[] entries)
     {
-        this._sink.Store(entries);
+        this.logSink.Store(entries);
         return this.Accepted();
     }
 }

--- a/fenrick.miro.server/src/Api/WebhookController.cs
+++ b/fenrick.miro.server/src/Api/WebhookController.cs
@@ -8,19 +8,19 @@ using Microsoft.AspNetCore.Mvc;
 /// </summary>
 [ApiController]
 [Route("api/webhook")]
-public class WebhookController(IEventQueue queue) : ControllerBase
+public class WebhookController(IEventSink sink) : ControllerBase
 {
-    private readonly IEventQueue _queue = queue;
+    private readonly IEventSink eventSink = sink;
 
     [HttpPost]
     public IActionResult Handle([FromBody] WebhookEvent evt)
     {
-        this._queue.Enqueue(evt);
+        this.eventSink.Enqueue(evt);
         return this.Accepted();
     }
 }
 
-public interface IEventQueue
+public interface IEventSink
 {
     public void Enqueue(WebhookEvent evt);
 }

--- a/fenrick.miro.server/src/Services/ICacheService.cs
+++ b/fenrick.miro.server/src/Services/ICacheService.cs
@@ -7,6 +7,6 @@ using Domain;
 /// </summary>
 public interface ICacheService
 {
-    public BoardMetadata? Get(string boardId);
+    public BoardMetadata? Retrieve(string boardId);
     public void Store(BoardMetadata metadata);
 }

--- a/fenrick.miro.server/src/Services/InMemoryCacheService.cs
+++ b/fenrick.miro.server/src/Services/InMemoryCacheService.cs
@@ -8,11 +8,11 @@ using Domain;
 /// </summary>
 public class InMemoryCacheService : ICacheService
 {
-    private readonly ConcurrentDictionary<string, BoardMetadata> _cache = new();
+    private readonly ConcurrentDictionary<string, BoardMetadata> cache = new();
 
-    public BoardMetadata? Get(string boardId) =>
-        this._cache.TryGetValue(boardId, out var value) ? value : null;
+    public BoardMetadata? Retrieve(string boardId) =>
+        this.cache.TryGetValue(boardId, out var value) ? value : null;
 
     public void Store(BoardMetadata metadata) =>
-        this._cache[metadata.Id] = metadata;
+        this.cache[metadata.Id] = metadata;
 }

--- a/fenrick.miro.server/src/Services/SerilogSink.cs
+++ b/fenrick.miro.server/src/Services/SerilogSink.cs
@@ -8,14 +8,14 @@ using ILogger = Serilog.ILogger;
 /// </summary>
 public class SerilogSink(ILogger logger) : ILogSink
 {
-    private readonly ILogger _logger = logger;
+    private readonly ILogger loggerInstance = logger;
 
     /// <inheritdoc />
     public void Store(IEnumerable<ClientLogEntry> entries)
     {
         foreach (var e in entries)
         {
-            this._logger
+            this.loggerInstance
                 .ForContext("Source", "Client")
                 .ForContext("Level", e.Level)
                 .ForContext("Context", e.Context, true)

--- a/fenrick.miro.tests/tests/BatchControllerTests.cs
+++ b/fenrick.miro.tests/tests/BatchControllerTests.cs
@@ -54,9 +54,9 @@ public class BatchControllerTests
     private sealed class StubClient(Func<MiroRequest, Task<MiroResponse>> cb)
         : IMiroClient
     {
-        private readonly Func<MiroRequest, Task<MiroResponse>> _cb = cb;
+        private readonly Func<MiroRequest, Task<MiroResponse>> callback = cb;
 
         public Task<MiroResponse> SendAsync(MiroRequest request) =>
-            this._cb(request);
+            this.callback(request);
     }
 }

--- a/fenrick.miro.tests/tests/CacheControllerTests.cs
+++ b/fenrick.miro.tests/tests/CacheControllerTests.cs
@@ -39,15 +39,15 @@ public class CacheControllerTests
 
     private sealed class StubCache(BoardMetadata value) : ICacheService
     {
-        private readonly BoardMetadata _value = value;
+        private readonly BoardMetadata board = value;
 
-        public BoardMetadata? Get(string boardId) => this._value;
+        public BoardMetadata? Retrieve(string boardId) => this.board;
         public void Store(BoardMetadata metadata) { }
     }
 
     private sealed class NullCache : ICacheService
     {
-        public BoardMetadata? Get(string boardId) => null;
+        public BoardMetadata? Retrieve(string boardId) => null;
         public void Store(BoardMetadata metadata) { }
     }
 }

--- a/fenrick.miro.tests/tests/InMemoryCacheServiceTests.cs
+++ b/fenrick.miro.tests/tests/InMemoryCacheServiceTests.cs
@@ -10,10 +10,10 @@ public class InMemoryCacheServiceTests
     public void GetReturnsValueWhenPresentOtherwiseNull()
     {
         var service = new InMemoryCacheService();
-        Assert.Null(service.Get("1"));
+        Assert.Null(service.Retrieve("1"));
         var meta = new BoardMetadata("1", "Board");
         service.Store(meta);
-        Assert.Equal(meta, service.Get("1"));
+        Assert.Equal(meta, service.Retrieve("1"));
     }
 
     /// <summary>
@@ -26,6 +26,6 @@ public class InMemoryCacheServiceTests
         service.Store(new BoardMetadata("1", "Old"));
         service.Store(new BoardMetadata("1", "New"));
 
-        Assert.Equal("New", service.Get("1")?.Name);
-    }
+        Assert.Equal("New", service.Retrieve("1")?.Name);
+}
 }

--- a/fenrick.miro.tests/tests/LogsControllerTests.cs
+++ b/fenrick.miro.tests/tests/LogsControllerTests.cs
@@ -30,9 +30,9 @@ public class LogsControllerTests
     private sealed class StubSink(Action<IEnumerable<ClientLogEntry>> cb)
         : ILogSink
     {
-        private readonly Action<IEnumerable<ClientLogEntry>> _cb = cb;
+        private readonly Action<IEnumerable<ClientLogEntry>> callback = cb;
 
         public void Store(IEnumerable<ClientLogEntry> entries) =>
-            this._cb(entries);
+            this.callback(entries);
     }
 }

--- a/fenrick.miro.tests/tests/SerilogSinkTests.cs
+++ b/fenrick.miro.tests/tests/SerilogSinkTests.cs
@@ -53,8 +53,8 @@ public class SerilogSinkTests
 
     private sealed class DelegatingSink(Action<LogEvent> write) : ILogEventSink
     {
-        private readonly Action<LogEvent> _write = write;
+        private readonly Action<LogEvent> writeAction = write;
 
-        public void Emit(LogEvent logEvent) => this._write(logEvent);
+        public void Emit(LogEvent logEvent) => this.writeAction(logEvent);
     }
 }

--- a/fenrick.miro.tests/tests/WebhookControllerTests.cs
+++ b/fenrick.miro.tests/tests/WebhookControllerTests.cs
@@ -14,8 +14,8 @@ public class WebhookControllerTests
     public void HandleEnqueuesEvent()
     {
         WebhookEvent? received = null;
-        var queue = new StubQueue(evt => received = evt);
-        var controller = new WebhookController(queue);
+        var sink = new StubSink(evt => received = evt);
+        var controller = new WebhookController(sink);
         var evt = new WebhookEvent("created", "b1");
 
         var result = controller.Handle(evt);
@@ -24,10 +24,10 @@ public class WebhookControllerTests
         Assert.Equal("b1", received?.BoardId);
     }
 
-    private sealed class StubQueue(Action<WebhookEvent> enqueue) : IEventQueue
+    private sealed class StubSink(Action<WebhookEvent> enqueue) : IEventSink
     {
-        private readonly Action<WebhookEvent> _enqueue = enqueue;
+        private readonly Action<WebhookEvent> enqueueAction = enqueue;
 
-        public void Enqueue(WebhookEvent evt) => this._enqueue(evt);
+        public void Enqueue(WebhookEvent evt) => this.enqueueAction(evt);
     }
 }


### PR DESCRIPTION
## Summary
- remove underscore prefix on server fields
- rename `IEventQueue` to `IEventSink`
- rename cache service `Get` method to `Retrieve`
- update controllers and tests for new names

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687ce3bc2930832b83f9c156ec5dc753