### PR TITLE
Add integration test for HttpLogSink

### DIFF
--- a/fenrick.miro.client/tests/http-log-sink.test.ts
+++ b/fenrick.miro.client/tests/http-log-sink.test.ts
@@ -1,0 +1,75 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import path from 'node:path';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import { HttpLogSink } from '../src/log-sink';
+
+declare let process: NodeJS.Process;
+
+let server: ReturnType<typeof spawn>;
+let url: string;
+const originalEnv = process.env.NODE_ENV;
+
+beforeAll(async () => {
+  server = spawn(
+    'dotnet',
+    [
+      'run',
+      '--project',
+      path.join('fenrick.miro.server'),
+      '--no-launch-profile',
+    ],
+    {
+      cwd: path.resolve(__dirname, '..', '..'),
+      env: {
+        ...process.env,
+        ASPNETCORE_URLS: 'http://127.0.0.1:0',
+        ASPNETCORE_ENVIRONMENT: 'Development',
+      },
+    },
+  );
+  const addr = await new Promise<string>((resolve, reject) => {
+    const onData = (data: Buffer) => {
+      const match = /Now listening on: (http:\/\/[^\s]+)/.exec(data.toString());
+      if (match) {
+        server.stdout.off('data', onData);
+        resolve(match[1]);
+      }
+    };
+    server.stdout.on('data', onData);
+    server.once('error', reject);
+    server.once('exit', code =>
+      reject(new Error(`server exited with code ${code}`)),
+    );
+  });
+  url = `${addr}/api/logs`;
+});
+
+afterAll(async () => {
+  process.env.NODE_ENV = originalEnv;
+  server.kill();
+  await once(server, 'exit');
+});
+
+test('HttpLogSink posts log entries to backend', async () => {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level: 'info',
+    message: 'pong',
+  };
+  let status = 0;
+  const originalFetch = global.fetch;
+  global.fetch = async (...args) => {
+    const res = await originalFetch(...args);
+    status = res.status;
+    return res;
+  };
+
+  process.env.NODE_ENV = 'development';
+  const sink = new HttpLogSink(url);
+  await sink.store([entry]);
+
+  expect(status).toBe(202);
+
+  global.fetch = originalFetch;
+});

--- a/fenrick.miro.server/src/Program.cs
+++ b/fenrick.miro.server/src/Program.cs
@@ -1,4 +1,8 @@
+using Fenrick.Miro.Server.Services;
+using Serilog;
+
 var builder = WebApplication.CreateBuilder(args);
+builder.Host.UseSerilog((_, cfg) => cfg.WriteTo.Console());
 
 builder.AddServiceDefaults();
 
@@ -7,6 +11,7 @@ builder.AddServiceDefaults();
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddSingleton<ILogSink, SerilogSink>();
 
 var app = builder.Build();
 
@@ -21,7 +26,10 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- register Serilog sink and only enable HTTPS redirection outside development
- start the .NET backend from tests and verify `HttpLogSink` posts log entries

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687d55940334832ba520528d8812844d