### PR TITLE
Enable Swagger per project

### DIFF
--- a/fenrick.miro.apphost/AppHost.cs
+++ b/fenrick.miro.apphost/AppHost.cs
@@ -2,6 +2,7 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<fenrick_miro_server>("fenrick-miro-server");
+builder.AddProject<fenrick_miro_server>("fenrick-miro-server")
+    .WithSwaggerUI();
 
 builder.Build().Run();

--- a/fenrick.miro.apphost/SwaggerUIExtensions.cs
+++ b/fenrick.miro.apphost/SwaggerUIExtensions.cs
@@ -1,0 +1,20 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Provides a placeholder implementation of the <c>WithSwaggerUI</c> extension used in distributed applications.
+/// </summary>
+public static class SwaggerUIExtensions
+{
+    /// <summary>
+    /// Adds Swagger UI hosting for the specified project. In this simplified sample the method
+    /// returns the original builder without additional configuration.
+    /// </summary>
+    /// <param name="builder">The project resource builder.</param>
+    /// <returns>The original project builder.</returns>
+    public static IResourceBuilder<ProjectResource> WithSwaggerUI(this IResourceBuilder<ProjectResource> builder)
+    {
+        // In a full implementation this would host Swagger UI for the project's OpenAPI endpoint.
+        return builder;
+    }
+}

--- a/fenrick.miro.server/fenrick.miro.server.csproj
+++ b/fenrick.miro.server/fenrick.miro.server.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1"/>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1"/>
   </ItemGroup>
 

--- a/fenrick.miro.server/src/Program.cs
+++ b/fenrick.miro.server/src/Program.cs
@@ -1,3 +1,4 @@
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
@@ -5,8 +6,8 @@ builder.AddServiceDefaults();
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
@@ -18,7 +19,8 @@ app.MapStaticAssets();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();
@@ -30,3 +32,10 @@ app.MapControllers();
 app.MapFallbackToFile("/index.html");
 
 app.Run();
+
+/// <summary>
+/// Exposes the entry point for integration tests.
+/// </summary>
+public partial class Program
+{
+}

--- a/fenrick.miro.tests/fenrick.miro.tests.csproj
+++ b/fenrick.miro.tests/fenrick.miro.tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
     <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.2.24157.4" />
     <!-- Ensure patched runtime libraries for tests -->
     <PackageReference Include="System.Text.Json" Version="9.0.7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/fenrick.miro.tests/tests/OpenApiConfigurationTests.cs
+++ b/fenrick.miro.tests/tests/OpenApiConfigurationTests.cs
@@ -1,0 +1,26 @@
+namespace Fenrick.Miro.Tests;
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+public class OpenApiConfigurationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient client;
+
+    public OpenApiConfigurationTests(WebApplicationFactory<Program> factory)
+    {
+        this.client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task SwaggerJsonEndpointReturnsDocumentAsync()
+    {
+        var response = await this.client.GetAsync("/swagger/v1/swagger.json");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"openapi\"", body);
+        Assert.Contains("\"title\": \"fenrick.miro.server\"", body);
+    }
+}


### PR DESCRIPTION
## Summary
- revert service defaults changes
- configure Swagger directly in server project
- expose placeholder WithSwaggerUI extension in app host
- verify Swagger document accessibility via integration test

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent` (with warnings)
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore` (with warnings)
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687d5670ebb4832bbf3530d3b134e6d5