### PR TITLE
docs: clarify Aspire setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ dependency installs run from that directory.
 - [Tab Overview](docs/TABS.md) describes the sidebar tabs and their purpose.
 - [Deployment & Build Guide](docs/DEPLOYMENT.md) explains how to build and host
   the bundle.
+- [Aspire Quick Start](docs/ASPIRE.md) shows how to run the .NET AppHost
+  locally or in Docker.
 - [Server Modules](docs/SERVER_MODULES.md) details the planned .NET API layout.
 - [Components Catalogue](docs/COMPONENTS.md) documents reusable React
   components.

--- a/docs/ASPIRE.md
+++ b/docs/ASPIRE.md
@@ -1,0 +1,55 @@
+# .NET Aspire Quick Start
+
+---
+
+## 0 Purpose
+
+Introduce the built-in AppHost, how to extend it with external services and how to run the Aspire dashboard.
+
+## 1 AppHost overview
+
+`fenrick.miro.apphost` starts the server via `DistributedApplication.CreateBuilder`. Add services like Redis or PostgreSQL using the host builder APIs.
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+var cache = builder.AddRedisContainer("redis");
+var db = builder.AddNpgsqlContainer("postgres");
+
+builder.AddProject<fenrick_miro_server>("fenrick-miro-server")
+    .WithReference(cache)
+    .WithReference(db)
+    .WithSwaggerUI();
+
+builder.Build().Run();
+```
+
+## 2 Dashboard
+
+The Aspire dashboard listens on port `18888`. Set the `DOTNET_DASHBOARD_PORT` environment variable to change it. The example below runs the dashboard on port `3000`:
+
+```bash
+DOTNET_DASHBOARD_PORT=3000 dotnet run --project fenrick.miro.apphost
+```
+
+Point a browser to `http://localhost:3000` to inspect service logs and metrics.
+
+## 3 Docker image
+
+Build the application host with the Dockerfile located in the server project:
+
+```bash
+docker build -t miro-apphost -f fenrick.miro.server/Dockerfile .
+```
+
+Run the container, configuring connections to Redis and PostgreSQL as needed:
+
+```bash
+docker run --rm \
+  -e REDIS_CONNECTION_STRING="localhost:6379" \
+  -e POSTGRES_CONNECTION_STRING="Host=localhost;Username=miro" \
+  -p 8080:8080 -p 18888:18888 miro-apphost
+```
+
+---
+
+_End of file._


### PR DESCRIPTION
## Summary
- clarify Docker build instructions for the AppHost
- explain how to pass Redis and PostgreSQL connection strings

## Testing
- `npm install` *(fails: package.json missing)*
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687e39047cdc832b972ed26583b0c1d3