### PR TITLE
Fix data validation annotations and refactor Excel tab types

### DIFF
--- a/fenrick.miro.client/src/ui/pages/ExcelTab.tsx
+++ b/fenrick.miro.client/src/ui/pages/ExcelTab.tsx
@@ -18,6 +18,9 @@ import {
 } from '../components';
 import { PageHelp } from '../components/PageHelp';
 import { RowInspector } from '../components/RowInspector';
+
+// prettier-ignore
+type LoaderStateDispatch = React.Dispatch<React.SetStateAction<ExcelLoader | GraphExcelLoader>>;
 import { TabPanel } from '../components/TabPanel';
 import { useExcelData } from '../hooks/excel-data-context';
 import { showError } from '../hooks/notifications';
@@ -35,9 +38,7 @@ import type { TabTuple } from './tab-definitions';
  */
 async function handleRemote(
   remote: string,
-  setLoader: React.Dispatch<
-    React.SetStateAction<ExcelLoader | GraphExcelLoader>
-  >,
+  setLoader: LoaderStateDispatch,
   setFile: React.Dispatch<React.SetStateAction<File | null>>,
   setSource: React.Dispatch<React.SetStateAction<string>>,
   setRows: React.Dispatch<React.SetStateAction<ExcelRow[]>>,
@@ -99,9 +100,7 @@ function useExcelDataSync(
 }
 
 function useDropHandler(
-  setLoader: React.Dispatch<
-    React.SetStateAction<ExcelLoader | GraphExcelLoader>
-  >,
+  setLoader: LoaderStateDispatch,
   setFile: React.Dispatch<React.SetStateAction<File | null>>,
   setSource: React.Dispatch<React.SetStateAction<string>>,
   setRows: React.Dispatch<React.SetStateAction<ExcelRow[]>>,
@@ -114,9 +113,7 @@ function useDropHandler(
 
 async function handleDrop(
   files: File[],
-  setLoader: React.Dispatch<
-    React.SetStateAction<ExcelLoader | GraphExcelLoader>
-  >,
+  setLoader: LoaderStateDispatch,
   setFile: React.Dispatch<React.SetStateAction<File | null>>,
   setSource: React.Dispatch<React.SetStateAction<string>>,
   setRows: React.Dispatch<React.SetStateAction<ExcelRow[]>>,

--- a/fenrick.miro.server/src/Domain/ClientLogEntry.cs
+++ b/fenrick.miro.server/src/Domain/ClientLogEntry.cs
@@ -1,5 +1,7 @@
 namespace Fenrick.Miro.Server.Domain;
 
+using System.ComponentModel.DataAnnotations;
+
 /// <summary>
 ///     Log entry forwarded from the client application.
 /// </summary>
@@ -8,7 +10,7 @@ namespace Fenrick.Miro.Server.Domain;
 /// <param name="Message">Message text.</param>
 /// <param name="Context">Optional structured context data.</param>
 public record ClientLogEntry(
-    DateTime Timestamp,
-    string Level,
-    string Message,
+    [property: Required] DateTime Timestamp,
+    [property: Required] string Level,
+    [property: Required] string Message,
     Dictionary<string, string>? Context);

--- a/fenrick.miro.server/src/Domain/ShapeData.cs
+++ b/fenrick.miro.server/src/Domain/ShapeData.cs
@@ -7,10 +7,10 @@ using System.ComponentModel.DataAnnotations;
 /// </summary>
 public record ShapeData(
     [property: Required] string Shape,
-    double X,
-    double Y,
-    double Width,
-    double Height,
+    [property: Required] double X,
+    [property: Required] double Y,
+    [property: Required] double Width,
+    [property: Required] double Height,
     double? Rotation,
     string? Text,
     Dictionary<string, object>? Style);

--- a/fenrick.miro.tests/tests/ClientLogEntryTests.cs
+++ b/fenrick.miro.tests/tests/ClientLogEntryTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 public class ClientLogEntryTests
 {
     [Fact]
-    public void ValidationAlwaysSucceeds()
+    public void ValidationFailsWhenLevelMissing()
     {
         var entry = new ClientLogEntry(DateTime.UtcNow, null!, "msg", null);
         var ctx = new ValidationContext(entry);
@@ -17,8 +17,8 @@ public class ClientLogEntryTests
 
         var valid = Validator.TryValidateObject(entry, ctx, results, true);
 
-        Assert.True(valid);
-        Assert.Empty(results);
+        Assert.False(valid);
+        Assert.NotEmpty(results);
     }
 
     [Fact]

--- a/fenrick.miro.tests/tests/ShapeQueueProcessorTests.cs
+++ b/fenrick.miro.tests/tests/ShapeQueueProcessorTests.cs
@@ -6,6 +6,8 @@ using Fenrick.Miro.Server.Domain;
 using Fenrick.Miro.Server.Services;
 using Xunit;
 
+namespace Fenrick.Miro.Tests;
+
 public class ShapeQueueProcessorTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- escape JSX generics in `ExcelTab` by introducing a dispatch type alias
- mark `ClientLogEntry` and `ShapeData` properties as required
- put `ShapeQueueProcessorTests` in the test namespace
- update `ClientLogEntryTests` for new validation rules

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6880e60d31c8832bb0c36a91736189e9