### PR TITLE
Fix regex security issues

### DIFF
--- a/fenrick.miro.client/package-lock.json
+++ b/fenrick.miro.client/package-lock.json
@@ -15,7 +15,8 @@
         "elkjs": "^0.10.0",
         "exceljs": "^4.4.0",
         "pino": "^8.21.0",
-        "react-dropzone": "^14.3.8"
+        "react-dropzone": "^14.3.8",
+        "safe-regex": "^2.1.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -18863,6 +18864,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -19147,6 +19157,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {

--- a/fenrick.miro.client/package.json
+++ b/fenrick.miro.client/package.json
@@ -40,7 +40,8 @@
     "elkjs": "^0.10.0",
     "exceljs": "^4.4.0",
     "pino": "^8.21.0",
-    "react-dropzone": "^14.3.8"
+    "react-dropzone": "^14.3.8",
+    "safe-regex": "^2.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/fenrick.miro.client/src/board/search-tools.ts
+++ b/fenrick.miro.client/src/board/search-tools.ts
@@ -5,6 +5,7 @@ import {
   Syncable,
 } from './board';
 import { boardCache } from './board-cache';
+import safeRegex from 'safe-regex';
 
 /** Search configuration. */
 export interface SearchOptions {
@@ -52,7 +53,13 @@ function escapeRegExp(str: string): string {
 
 function buildRegex(opts: SearchOptions): RegExp {
   const src = opts.regex ? opts.query : escapeRegExp(opts.query);
+  if (src.length > 200) {
+    throw new SyntaxError('Pattern too long');
+  }
   const pattern = opts.wholeWord ? `\\b${src}\\b` : src;
+  if (!safeRegex(pattern)) {
+    throw new SyntaxError('Unsafe regular expression');
+  }
   const flags = opts.caseSensitive ? 'g' : 'gi';
   return new RegExp(pattern, flags);
 }

--- a/fenrick.miro.client/tests/search-tools.test.ts
+++ b/fenrick.miro.client/tests/search-tools.test.ts
@@ -276,6 +276,24 @@ describe('search-tools', () => {
     ).rejects.toThrow(SyntaxError);
   });
 
+  test('searchBoardContent rejects unsafe regex patterns', async () => {
+    const { board } = makeBoard();
+    await expect(
+      searchBoardContent({ query: '(a+)+$', regex: true }, board),
+    ).rejects.toThrow('Unsafe regular expression');
+  });
+
+  test('replaceBoardContent rejects excessively long patterns', async () => {
+    const { board } = makeBoard();
+    const pattern = 'a'.repeat(201);
+    await expect(
+      replaceBoardContent(
+        { query: pattern, replacement: 'x', regex: true },
+        board,
+      ),
+    ).rejects.toThrow('Pattern too long');
+  });
+
   test('getTextFields extracts common text properties', () => {
     const item = {
       title: 't',


### PR DESCRIPTION
## Summary
- validate regex queries with safe-regex
- reject excessively long patterns
- test new validation logic
- add safe-regex dependency

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6880e79ce464832bbf16428aeb5b095a