### PR TITLE
Update dependabot to target develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,24 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "npm"
+    directory: "/fenrick.miro.client"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+
   - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
@@ -19,8 +36,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "develop"
 
   - package-ecosystem: "docker"
     directory: "/fenrick.miro.server"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/fenrick.miro.server"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
## Summary
- configure dependabot to create PRs for `develop`
- dependencies and project tests executed

## Testing
- `npm install --prefix fenrick.miro.client`
- `npm --prefix fenrick.miro.client run typecheck`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_688314cd5f94832b8b30012174641f1f