### PR TITLE
Add named table support to Excel loader

### DIFF
--- a/fenrick.miro.tests/tests/NewFeatures/ExcelLoaderTests.cs
+++ b/fenrick.miro.tests/tests/NewFeatures/ExcelLoaderTests.cs
@@ -2,6 +2,7 @@
 
 namespace Fenrick.Miro.Tests.NewFeatures;
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using ClosedXML.Excel;
@@ -30,5 +31,86 @@ public class ExcelLoaderTests
         Assert.Single(rows);
         Assert.Equal("Alice", rows[0]["Name"]);
         Assert.Equal("30", rows[0]["Age"]);
+    }
+
+    [Fact]
+    public async Task ListNamedTablesReturnsNamesAsync()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1");
+        ws.Cell(1, 1).Value = "A";
+        ws.Cell(2, 1).Value = 1;
+        wb.NamedRanges.Add("Table1", ws.Range("A1:A2"));
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        ms.Position = 0;
+
+        var loader = new ExcelLoader();
+        await loader.LoadAsync(ms);
+
+        Assert.Contains("Table1", loader.ListNamedTables());
+    }
+
+    [Fact]
+    public async Task LoadNamedTableReturnsRowsAsync()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1");
+        ws.Cell(1, 1).Value = "Name";
+        ws.Cell(1, 2).Value = "Value";
+        ws.Cell(2, 1).Value = "A";
+        ws.Cell(2, 2).Value = 1;
+        wb.NamedRanges.Add("Table1", ws.Range("A1:B2"));
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        ms.Position = 0;
+
+        var loader = new ExcelLoader();
+        await loader.LoadAsync(ms);
+        var rows = loader.LoadNamedTable("Table1");
+
+        Assert.Single(rows);
+        Assert.Equal("A", rows[0]["Name"]);
+    }
+
+    [Fact]
+    public void MethodsThrowWhenWorkbookNotLoaded()
+    {
+        var loader = new ExcelLoader();
+
+        Assert.Empty(loader.ListNamedTables());
+        Assert.Throws<InvalidOperationException>(() => loader.LoadNamedTable("T1"));
+    }
+
+    [Fact]
+    public async Task LoadNamedTableThrowsWhenUnknownAsync()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Sheet1");
+        ws.Cell(1, 1).Value = "A";
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        ms.Position = 0;
+
+        var loader = new ExcelLoader();
+        await loader.LoadAsync(ms);
+
+        Assert.Throws<ArgumentException>(() => loader.LoadNamedTable("Missing"));
+    }
+
+    [Fact]
+    public async Task LoadNamedTableThrowsForMissingSheetAsync()
+    {
+        using var wb = new XLWorkbook();
+        wb.Worksheets.Add("Temp");
+        wb.DefinedNames.Add("Bad", "Missing!A1:B1");
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        ms.Position = 0;
+
+        var loader = new ExcelLoader();
+        await loader.LoadAsync(ms);
+
+        Assert.Throws<ArgumentException>(() => loader.LoadNamedTable("Bad"));
     }
 }


### PR DESCRIPTION
## Summary
- extend server-side ExcelLoader with named table helpers
- expand ExcelLoader unit tests

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal -p:ShouldRunBuildScript=false` *(fails: OpenApiConfigurationTests.SwaggerJsonEndpointReturnsDocumentAsync, DbContextRegistrationTests.CanResolveTemplateStore, DbContextRegistrationTests.CanResolveDbContext)*

------
https://chatgpt.com/codex/tasks/task_e_6884aae93330832b8e237da6c77b25e8