### PR TITLE
Fix server async methods and update tests

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -10,7 +10,7 @@ env:
   DOTNET_VERSION: "9.0.x"
 
 jobs:
-  dotnet-format:
+  server-build:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/server-format.yml
+++ b/.github/workflows/server-format.yml
@@ -10,7 +10,7 @@ env:
   DOTNET_VERSION: "9.0.x"
 
 jobs:
-  dotnet-format:
+  server-format:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -11,7 +11,7 @@ env:
   DOTNET_VERSION: "9.0.x"
 
 jobs:
-  dotnet-tests:
+  server-tests:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/fenrick.miro.server/src/Services/ExcelLoader.cs
+++ b/fenrick.miro.server/src/Services/ExcelLoader.cs
@@ -169,8 +169,8 @@ public class ExcelLoader(ILogger<ExcelLoader>? log = null) : IDisposable
             throw ex;
         }
 
-        return StreamSheetAsync(name);
-        async IAsyncEnumerable<Dictionary<string, string>> StreamSheetAsync(string name)
+        return StreamSheetAsync();
+        async IAsyncEnumerable<Dictionary<string, string>> StreamSheetAsync()
         {
             var headers = ws.Row(1).Cells().Select(c => c.GetString()).ToList();
             foreach (IXLRow? row in ws.RowsUsed().Skip(1))
@@ -223,8 +223,8 @@ public class ExcelLoader(ILogger<ExcelLoader>? log = null) : IDisposable
             throw ex;
         }
 
-        return StreamNamedTableAsync(name);
-        async IAsyncEnumerable<Dictionary<string, string>> StreamNamedTableAsync(string name)
+        return StreamNamedTableAsync();
+        async IAsyncEnumerable<Dictionary<string, string>> StreamNamedTableAsync()
         {
             var headers = range.FirstRow().Cells().Select(c => c.GetString()).ToList();
             foreach (IXLRangeRow? row in range.Rows().Skip(1))

--- a/fenrick.miro.tests/tests/EfUserStoreTests.cs
+++ b/fenrick.miro.tests/tests/EfUserStoreTests.cs
@@ -95,15 +95,15 @@ public class EfUserStoreTests
         DbContextOptions<MiroDbContext> options = new DbContextOptionsBuilder<MiroDbContext>()
             .UseInMemoryDatabase($"test_async")
             .Options;
-        await using MiroDbContext context = new MiroDbContext(options);
+        using var context = new MiroDbContext(options);
         var store = new EfUserStore(context);
         var info = new UserInfo($"u1", $"Bob", $"t1");
 
-        await store.StoreAsync(info);
-        UserInfo fetched = await store.RetrieveAsync($"u1");
+        await store.StoreAsync(info).ConfigureAwait(false);
+        UserInfo fetched = await store.RetrieveAsync($"u1").ConfigureAwait(false);
         Assert.Equal($"t1", fetched?.Token);
 
-        await store.DeleteAsync($"u1");
-        Assert.Null(await store.RetrieveAsync($"u1"));
+        await store.DeleteAsync($"u1").ConfigureAwait(false);
+        Assert.Null(await store.RetrieveAsync($"u1").ConfigureAwait(false));
     }
 }

--- a/fenrick.miro.tests/tests/EfUserStoreTests.cs
+++ b/fenrick.miro.tests/tests/EfUserStoreTests.cs
@@ -95,15 +95,15 @@ public class EfUserStoreTests
         DbContextOptions<MiroDbContext> options = new DbContextOptionsBuilder<MiroDbContext>()
             .UseInMemoryDatabase($"test_async")
             .Options;
-        await using var context = new MiroDbContext(options).ConfigureAwait(false);
+        await using MiroDbContext context = new MiroDbContext(options);
         var store = new EfUserStore(context);
         var info = new UserInfo($"u1", $"Bob", $"t1");
 
-        await store.StoreAsync(info).ConfigureAwait(false);
-        UserInfo fetched = await store.RetrieveAsync($"u1").ConfigureAwait(false);
+        await store.StoreAsync(info);
+        UserInfo fetched = await store.RetrieveAsync($"u1");
         Assert.Equal($"t1", fetched?.Token);
 
-        await store.DeleteAsync($"u1").ConfigureAwait(false);
-        Assert.Null(await store.RetrieveAsync($"u1").ConfigureAwait(false));
+        await store.DeleteAsync($"u1");
+        Assert.Null(await store.RetrieveAsync($"u1"));
     }
 }

--- a/fenrick.miro.tests/tests/InMemoryShapeCacheTests.cs
+++ b/fenrick.miro.tests/tests/InMemoryShapeCacheTests.cs
@@ -12,9 +12,9 @@ public class InMemoryShapeCacheTests
     {
         var cache = new InMemoryShapeCache();
         var entry = new ShapeCacheEntry(
-$"b",
-$"i",
-            new ShapeData($"r", 0, 0, 1, 1, Rotation: Text: null, Style: null, null));
+            "b",
+            "i",
+            new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null));
         cache.Store(entry);
         cache.Remove($"b", $"i");
         Assert.Null(cache.Retrieve($"b", $"i"));
@@ -25,9 +25,9 @@ $"i",
     {
         var cache = new InMemoryShapeCache();
         var entry = new ShapeCacheEntry(
-$"b1",
-$"i1",
-            new ShapeData($"rect", 0, 0, 1, 1, Rotation: Text: null, Style: null, null));
+            "b1",
+            "i1",
+            new ShapeData("rect", 0, 0, 1, 1, Rotation: null, Text: null, Style: null));
         cache.Store(entry);
 
         ShapeCacheEntry? result = cache.Retrieve($"b1", $"i1");

--- a/fenrick.miro.tests/tests/MiroRestClientTests.cs
+++ b/fenrick.miro.tests/tests/MiroRestClientTests.cs
@@ -24,7 +24,7 @@ public class MiroRestClientTests
         var httpClient =
             new HttpClient(handler) { BaseAddress = new Uri($"http://x") };
         var store = new InMemoryUserStore();
-        await store.StoreAsync(new UserInfo($"u1", $"Bob", $"tok")).ConfigureAwait(false);
+        await store.StoreAsync(new UserInfo($"u1", $"Bob", $"tok"));
         var ctx = new DefaultHttpContext();
         ctx.Request.Headers[$"X-User-Id"] = $"u1";
         var client = new MiroRestClient(
@@ -32,7 +32,7 @@ public class MiroRestClientTests
             store,
             new HttpContextAccessor { HttpContext = ctx });
 
-        await client.SendAsync(new MiroRequest($"GET", $"/", Body: null), ctx.RequestAborted).ConfigureAwait(false);
+        await client.SendAsync(new MiroRequest($"GET", $"/", Body: null), ctx.RequestAborted);
 
         Assert.Equal($"Bearer", handler.Request?.Headers.Authorization?.Scheme);
         Assert.Equal($"tok", handler.Request?.Headers.Authorization?.Parameter);
@@ -52,7 +52,7 @@ public class MiroRestClientTests
             return Task.FromResult(
                 new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent($"{}"),
+                    Content = new StringContent("{}"),
                 });
         }
     }

--- a/fenrick.miro.tests/tests/NewFeatures/ExcelLoaderTests.cs
+++ b/fenrick.miro.tests/tests/NewFeatures/ExcelLoaderTests.cs
@@ -31,7 +31,7 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
         IReadOnlyList<Dictionary<string, string>> rows = loader.LoadSheet($"Sheet1");
 
         Assert.Single(rows);
@@ -52,7 +52,7 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
 
         Assert.Contains($"Table1", loader.ListNamedTables());
     }
@@ -72,7 +72,7 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
         IReadOnlyList<Dictionary<string, string>> rows = loader.LoadNamedTable($"Table1");
 
         Assert.Single(rows);
@@ -99,7 +99,7 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
 
         Assert.Throws<ArgumentException>(() => loader.LoadNamedTable($"Missing"));
     }
@@ -115,7 +115,7 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
 
         Assert.Throws<ArgumentException>(() => loader.LoadNamedTable($"Bad"));
     }
@@ -131,7 +131,7 @@ public class ExcelLoaderTests
 
         var logger = new CaptureLogger<ExcelLoader>();
         var loader = new ExcelLoader(logger);
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
 
         Assert.Contains(logger.Entries, l => l.Level == LogLevel.Debug && l.Message.Contains($"Loading workbook", StringComparison.Ordinal));
         Assert.Contains(logger.Entries, l => l.Message.Contains($"Workbook loaded", StringComparison.Ordinal));
@@ -159,9 +159,9 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
         var results = new List<Dictionary<string, string>>();
-        await foreach (Dictionary<string, string> r in loader.StreamSheetAsync($"Sheet1").ConfigureAwait(false))
+        await foreach (Dictionary<string, string> r in loader.StreamSheet($"Sheet1").ConfigureAwait(false).ConfigureAwait(false))
         {
             results.Add(r);
         }
@@ -183,9 +183,9 @@ public class ExcelLoaderTests
         ms.Position = 0;
 
         var loader = new ExcelLoader();
-        await loader.LoadAsync(ms).ConfigureAwait(false);
+        await loader.LoadAsync(ms);
         var results = new List<Dictionary<string, string>>();
-        await foreach (Dictionary<string, string> r in loader.StreamNamedTableAsync($"Table1").ConfigureAwait(false))
+        await foreach (Dictionary<string, string> r in loader.StreamNamedTable($"Table1").ConfigureAwait(false).ConfigureAwait(false))
         {
             results.Add(r);
         }
@@ -200,17 +200,17 @@ public class ExcelLoaderTests
         var loader = new ExcelLoader();
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
-            await foreach (Dictionary<string, string> _ in loader.StreamSheetAsync($"A").ConfigureAwait(false))
+            await foreach (Dictionary<string, string> _ in loader.StreamSheet($"A").ConfigureAwait(false).ConfigureAwait(false))
             {
             }
-        }).ConfigureAwait(false);
+        });
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
-            await foreach (Dictionary<string, string> _ in loader.StreamNamedTableAsync($"A").ConfigureAwait(false))
+            await foreach (Dictionary<string, string> _ in loader.StreamNamedTable($"A").ConfigureAwait(false).ConfigureAwait(false))
             {
             }
-        }).ConfigureAwait(false);
+        });
     }
 }
 

--- a/fenrick.miro.tests/tests/NewFeatures/LayoutEngineTests.cs
+++ b/fenrick.miro.tests/tests/NewFeatures/LayoutEngineTests.cs
@@ -11,12 +11,11 @@ public class LayoutEngineTests
     [Fact]
     public void LayoutPositionsNodesVertically()
     {
-        var engine = new LayoutEngine();
         var data = new GraphData(
-            [new GraphNode($"n1", $"A", $"t"), new GraphNode($"n2", $"B", $"t")],
+            [new GraphNode("n1", "A", "t"), new GraphNode("n2", "B", "t")],
             []);
 
-        LayoutResult result = engine.Layout(data);
+        LayoutResult result = LayoutEngine.Layout(data);
 
         Assert.Equal(0, result.Nodes[$"n1"].X);
         Assert.Equal(0, result.Nodes[$"n1"].Y);

--- a/fenrick.miro.tests/tests/ShapeQueueProcessorTests.cs
+++ b/fenrick.miro.tests/tests/ShapeQueueProcessorTests.cs
@@ -19,13 +19,13 @@ public class ShapeQueueProcessorTests
         var client = new StubClient();
         var proc = new ShapeQueueProcessor(client);
         proc.EnqueueCreate(
-        [
-            new ShapeData($"r", 0, 0, 1, 1, Rotation: Text: null, Style: null, null),
-        ]);
+            [
+                new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null),
+            ]);
         Task<List<MiroResponse>> t1 = proc.ProcessAsync();
         Task<List<MiroResponse>> t2 = proc.ProcessAsync();
 
-        await Task.WhenAll(t1, t2).ConfigureAwait(false);
+        await Task.WhenAll(t1, t2);
 
         Assert.Equal(1, client.Count);
     }
@@ -38,12 +38,12 @@ public class ShapeQueueProcessorTests
         var shapes = new List<ShapeData>();
         for (var i = 0; i < 25; i++)
         {
-            shapes.Add(new ShapeData($"r", 0, 0, 1, 1, Rotation: Text: null, Style: null, null));
+            shapes.Add(new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null));
         }
 
         proc.EnqueueCreate(shapes);
 
-        List<MiroResponse> responses = await proc.ProcessAsync().ConfigureAwait(false);
+        List<MiroResponse> responses = await proc.ProcessAsync();
 
         Assert.Equal(25, client.Count);
         Assert.Equal(25, responses.Count);
@@ -54,7 +54,7 @@ public class ShapeQueueProcessorTests
     {
         var client = new StubClient();
         var proc = new ShapeQueueProcessor(client);
-        proc.EnqueueCreate([new ShapeData($"r", 0, 0, 1, 1, Rotation: Text: null, Style: null, null)]);
+        proc.EnqueueCreate([new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null)]);
 
         proc.Dispose();
 

--- a/fenrick.miro.tests/tests/ShapesControllerTests.cs
+++ b/fenrick.miro.tests/tests/ShapesControllerTests.cs
@@ -23,7 +23,7 @@ public class ShapesControllerTests
     public async Task CreateAsyncHandlesBulk()
     {
         ShapeData[] shapes = Enumerable.Range(0, 25)
-            .Select(i => new ShapeData($"r", i, 0, 1, 1, Rotation: Text: null, Style: null, null))
+            .Select(i => new ShapeData("r", i, 0, 1, 1, Rotation: null, Text: null, Style: null))
             .ToArray();
         var controller = new ShapesController(
             new StubClient(),
@@ -47,7 +47,7 @@ public class ShapesControllerTests
     {
         ShapeData[] shapes = new[]
                      {
-                         new ShapeData($"rect", 0, 0, 1, 1, Rotation: Text: null, Style: null, null),
+                         new ShapeData("rect", 0, 0, 1, 1, Rotation: null, Text: null, Style: null),
                      };
         var controller = new ShapesController(
             new StubClient(),
@@ -120,7 +120,7 @@ Style: null,
     public async Task GetAsyncReturnsCachedEntry()
     {
         var cache = new RecordingCache();
-        cache.Store(new ShapeCacheEntry($"b1", $"i2", new ShapeData($"r", 0, 0, 1, 1, Rotation: Text: null, Style: null, null)));
+        cache.Store(new ShapeCacheEntry("b1", "i2", new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null)));
         var controller = new ShapesController(new StubClient(), cache)
         {
             ControllerContext = new ControllerContext

--- a/fenrick.miro.tests/tests/UsersControllerTests.cs
+++ b/fenrick.miro.tests/tests/UsersControllerTests.cs
@@ -4,6 +4,8 @@ namespace Fenrick.Miro.Tests;
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Fenrick.Miro.Server.Api;
 using Fenrick.Miro.Server.Domain;
@@ -36,10 +38,22 @@ public class UsersControllerTests
 
         public UserInfo? Retrieve(string userId) => null;
 
+        public Task<UserInfo?> RetrieveAsync(string userId, CancellationToken ct = default) =>
+            Task.FromResult<UserInfo?>(null);
+
         public void Store(UserInfo info) => this.callback(info);
+
+        public Task StoreAsync(UserInfo info, CancellationToken ct = default)
+        {
+            this.callback(info);
+            return Task.CompletedTask;
+        }
 
         public void Delete(string userId)
         {
         }
+
+        public Task DeleteAsync(string userId, CancellationToken ct = default) =>
+            Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- adjust ExcelLoader streaming methods
- correct test utilities for EF user store
- update tests using ExcelLoader API
- fix layout engine test to use static method
- repair invalid test code and add async store stubs

## Testing
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `dotnet format`
- `dotnet restore`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68861f579054832b8a1d2c0bad3bf9bc