### PR TITLE
docs: add missing core utilities

### DIFF
--- a/docs/BOARD_MODULES.md
+++ b/docs/BOARD_MODULES.md
@@ -16,6 +16,7 @@ fenrick.miro.client/src/board/
 
 - board-builder.ts
 - board.ts
+- board-cache.ts
 - card-processor.ts
 - connector-utils.ts
 - element-utils.ts
@@ -27,6 +28,7 @@ fenrick.miro.client/src/board/
 - item-types.ts
 - meta-constants.ts
 - node-search.ts
+- types.ts
 - resize-tools.ts
 - search-tools.ts
 - spacing-layout.ts
@@ -41,6 +43,7 @@ fenrick.miro.client/src/board/
 | ------------------ | ------------------------------------------------------------ |
 | board.ts           | Board API helpers and simple abstractions used across tools. |
 | board-builder.ts   | Creates and updates widgets on the board.                    |
+| board-cache.ts     | Caches selection and widget queries to reduce network calls. |
 | card-processor.ts  | Imports card data and arranges them in a grid.               |
 | connector-utils.ts | Connector creation and update helpers.                       |
 | element-utils.ts   | Shared widget helper functions.                              |
@@ -52,6 +55,7 @@ fenrick.miro.client/src/board/
 | item-types.ts      | Type guards for different widget kinds.                      |
 | meta-constants.ts  | Metadata key definitions used across modules.                |
 | node-search.ts     | Board search functions for nodes and groups.                 |
+| types.ts           | Helper interfaces describing board and query APIs. |
 | resize-tools.ts    | Resize selected widgets to match references.                 |
 | search-tools.ts    | Text search helpers for selection and boards.                |
 | spacing-layout.ts  | Pure spacing calculations for growth or movement.            |

--- a/docs/CORE_MODULES.md
+++ b/docs/CORE_MODULES.md
@@ -32,12 +32,17 @@ fenrick.miro.client/src/core/
   utils/
     aspect-ratio.ts
     base64.ts
+    card-client.ts
     cards.ts
     color-utils.ts
     excel-loader.ts
+    exceljs-loader.ts
     file-utils.ts
     graph-auth.ts
     graph-client.ts
+    shape-client.ts
+    string-utils.ts
+    tag-client.ts
     unit-utils.ts
     workbook-writer.ts
 ```
@@ -64,12 +69,16 @@ fenrick.miro.client/src/core/
 | layout/nested-layout.ts      | Arrange nodes in a nested hierarchy.                |
 | utils/aspect-ratio.ts        | Maintain consistent aspect ratios when scaling.     |
 | utils/base64.ts              | Encode data in Base64 without regex backtracking.   |
-| utils/cards.ts               | Format card content for widgets.                    |
-| utils/color-utils.ts         | Map semantic color names to Miro tokens.            |
-| utils/exceljs-loader.ts      | Dynamically load ExcelJS from the CDN.              |
-| utils/excel-loader.ts        | Parse Excel files into row objects.                 |
-| utils/file-utils.ts          | Read and write local files for import/export.       |
-| utils/graph-auth.ts          | Handle OAuth login for the graph service.           |
-| utils/graph-client.ts        | Fetch graph data from the backend API.              |
-| utils/unit-utils.ts          | Unit conversion helpers for board measurements.     |
-| utils/workbook-writer.ts     | Output workbook rows to an Excel file.              |
+| utils/cards.ts               | Format card content for widgets. |
+| utils/card-client.ts        | HTTP client for the cards API. |
+| utils/color-utils.ts         | Map semantic color names to Miro tokens. |
+| utils/exceljs-loader.ts      | Dynamically load ExcelJS from the CDN. |
+| utils/excel-loader.ts        | Parse Excel files into row objects. |
+| utils/file-utils.ts          | Read and write local files for import/export. |
+| utils/graph-auth.ts          | Handle OAuth login for the graph service. |
+| utils/graph-client.ts        | Fetch graph data from the backend API. |
+| utils/shape-client.ts        | HTTP client for the shapes API. |
+| utils/string-utils.ts        | Safe conversions to string values. |
+| utils/tag-client.ts          | HTTP client for the tags API. |
+| utils/unit-utils.ts          | Unit conversion helpers for board measurements. |
+| utils/workbook-writer.ts     | Output workbook rows to an Excel file. |


### PR DESCRIPTION
## Summary
- document all util modules in CORE_MODULES

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet format fenrick.miro.slnx --verbosity minimal` *(no output)*
- `dotnet build fenrick.miro.slnx -warnaserror`
- `dotnet test fenrick.miro.slnx -v minimal` *(failures: ITemplateStore not registered)*
- `npm --prefix fenrick.miro.client install`
- `npm --prefix fenrick.miro.client run typecheck`
- `npm --prefix fenrick.miro.client run lint`
- `npm --prefix fenrick.miro.client run stylelint`
- `npm --prefix fenrick.miro.client run prettier`
- `npm --prefix fenrick.miro.client run test`


------
https://chatgpt.com/codex/tasks/task_e_688b66ff7578832bab1d10a519f9b1b4