### PR TITLE
fix(server): handle tag service errors

### DIFF
--- a/fenrick.miro.server/src/Services/ITagService.cs
+++ b/fenrick.miro.server/src/Services/ITagService.cs
@@ -15,6 +15,7 @@ public interface ITagService
     /// <param name="boardId">Target board identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>List of tags.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the Miro API returns malformed JSON.</exception>
     public Task<IReadOnlyList<TagInfo>> GetTagsAsync(string boardId,
         CancellationToken ct = default);
 }

--- a/fenrick.miro.tests/tests/TagServiceTests.cs
+++ b/fenrick.miro.tests/tests/TagServiceTests.cs
@@ -1,0 +1,41 @@
+namespace Fenrick.Miro.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Server.Domain;
+using Server.Services;
+
+public class TagServiceTests
+{
+    [Fact]
+    public async Task GetTagsAsyncReturnsEmptyListOnNonSuccessAsync()
+    {
+        var client = new StubClient(new MiroResponse(500, string.Empty));
+        var svc = new TagService(client);
+
+        IReadOnlyList<TagInfo> tags =
+            await svc.GetTagsAsync("b1").ConfigureAwait(false);
+
+        Assert.Empty(tags);
+    }
+
+    [Fact]
+    public async Task GetTagsAsyncThrowsOnMalformedJsonAsync()
+    {
+        var client = new StubClient(new MiroResponse(200, "not json"));
+        var svc = new TagService(client);
+
+        await Assert
+            .ThrowsAsync<InvalidOperationException>(() => svc.GetTagsAsync("b1"))
+            .ConfigureAwait(false);
+    }
+
+    private sealed class StubClient(MiroResponse response) : IMiroClient
+    {
+        public Task<MiroResponse> SendAsync(MiroRequest request, CancellationToken ct = default) => Task.FromResult(response);
+    }
+}
+


### PR DESCRIPTION
## Summary
- guard TagService against non-success responses and malformed JSON
- document TagService exceptions
- add TagService unit tests for error scenarios

## Testing
- `dotnet restore`
- `dotnet format fenrick.miro.slnx --verify-no-changes` *(fails: WHITESPACE: Fix whitespace formatting. Insert '\s')*
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal` *(fails: No service for type 'Fenrick.Miro.Server.Services.ITemplateStore' has been registered, Response status code does not indicate success: 404 (Not Found).)*
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal --filter "TagServiceTests"`


------
https://chatgpt.com/codex/tasks/task_e_6892b7e43650832b8134dcd3e55f929b