### PR TITLE
fix(server): map client log levels

### DIFF
--- a/fenrick.miro.server/src/Services/SerilogSink.cs
+++ b/fenrick.miro.server/src/Services/SerilogSink.cs
@@ -2,6 +2,8 @@ namespace Fenrick.Miro.Server.Services;
 
 using Domain;
 
+using Serilog.Events;
+
 using ILogger = Serilog.ILogger;
 
 /// <summary>
@@ -16,10 +18,24 @@ public class SerilogSink(ILogger logger) : ILogSink
     {
         foreach (ClientLogEntry e in entries)
         {
-            this.loggerInstance.ForContext($"Source", $"Client")
-                .ForContext($"Level", e.Level)
-                .ForContext($"Context", e.Context, destructureObjects: true)
-                .Information($"{{Message}}", e.Message);
+            LogEventLevel level = MapLevel(e.Level);
+
+            this.loggerInstance.ForContext("Source", "Client")
+                .ForContext("Level", e.Level)
+                .ForContext("Context", e.Context, destructureObjects: true)
+                .Write(level, "{Message}", e.Message);
         }
     }
+
+    private static LogEventLevel MapLevel(string level) =>
+        level.ToLowerInvariant() switch
+        {
+            "trace" => LogEventLevel.Verbose,
+            "debug" => LogEventLevel.Debug,
+            "info" => LogEventLevel.Information,
+            "warn" => LogEventLevel.Warning,
+            "error" => LogEventLevel.Error,
+            "fatal" => LogEventLevel.Fatal,
+            _ => LogEventLevel.Information,
+        };
 }

--- a/fenrick.miro.tests/tests/SerilogSinkTests.cs
+++ b/fenrick.miro.tests/tests/SerilogSinkTests.cs
@@ -22,20 +22,21 @@ public class SerilogSinkTests
     public void StoreAddsContextProperties()
     {
         var events = new List<LogEvent>();
-        Logger logger = new LoggerConfiguration().WriteTo
-            .Sink(new DelegatingSink(events.Add)).CreateLogger();
+        Logger logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(new DelegatingSink(events.Add)).CreateLogger();
         var sink = new SerilogSink(logger);
 
         var entry = new ClientLogEntry(
             DateTime.UnixEpoch,
-            $"warn",
-            $"hello",
-Context: null);
+            "warn",
+            "hello",
+            Context: null);
         sink.Store([entry]);
 
         LogEvent log = events[0];
-        Assert.Equal($"Client", log.Properties[$"Source"].ToString().Trim('"'));
-        Assert.Equal($"warn", log.Properties[$"Level"].ToString().Trim('"'));
+        Assert.Equal("Client", log.Properties["Source"].ToString().Trim('"'));
+        Assert.Equal("warn", log.Properties["Level"].ToString().Trim('"'));
     }
 
     [Fact]
@@ -48,14 +49,38 @@ Context: null);
 
         var entry = new ClientLogEntry(
             DateTime.UnixEpoch,
-            $"info",
-            $"hello",
-Context: null);
+            "info",
+            "hello",
+            Context: null);
         sink.Store([entry]);
 
         Assert.Single(events);
-        var message = events[0].Properties[$"Message"].ToString().Trim('"');
-        Assert.Equal($"hello", message);
+        var message = events[0].Properties["Message"].ToString().Trim('"');
+        Assert.Equal("hello", message);
+    }
+
+    [Theory]
+    [InlineData("info", LogEventLevel.Information)]
+    [InlineData("warn", LogEventLevel.Warning)]
+    [InlineData("error", LogEventLevel.Error)]
+    [InlineData("fatal", LogEventLevel.Fatal)]
+    public void StoreUsesCorrectLogLevel(string level, LogEventLevel expected)
+    {
+        var events = new List<LogEvent>();
+        Logger logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(new DelegatingSink(events.Add)).CreateLogger();
+        var sink = new SerilogSink(logger);
+
+        var entry = new ClientLogEntry(
+            DateTime.UnixEpoch,
+            level,
+            "hello",
+            Context: null);
+        sink.Store([entry]);
+
+        LogEvent log = Assert.Single(events);
+        Assert.Equal(expected, log.Level);
     }
 
     private sealed class DelegatingSink(Action<LogEvent> write) : ILogEventSink


### PR DESCRIPTION
## Summary
- translate client log levels to Serilog levels and write using mapped level
- test that client levels info/warn/error/fatal map to expected Serilog levels

## Testing
- `dotnet restore`
- `dotnet format --include fenrick.miro.server/src/Services/SerilogSink.cs fenrick.miro.tests/tests/SerilogSinkTests.cs --verbosity diagnostic`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal` *(fails: CanResolveDbContext, CanResolveTemplateStore, SwaggerJsonEndpointReturnsDocumentAsync)*

------
https://chatgpt.com/codex/tasks/task_e_6892bcdf8808832b93fbc24792ba5682