### PR TITLE
docs(server): document ASP.NET Core entry point

### DIFF
--- a/fenrick.miro.server/src/Program.cs
+++ b/fenrick.miro.server/src/Program.cs
@@ -68,7 +68,13 @@ app.UseAuthorization();
 
 await app.RunAsync().ConfigureAwait(false);
 
-// Expose Program for WebApplicationFactory<T>
+/// <summary>
+/// Entry point for the ASP.NET Core application.
+/// </summary>
+/// <remarks>
+/// The class is non-static and partial to enable test projects to reference it via
+/// Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory.
+/// </remarks>
 public partial class Program
 {
     protected Program()


### PR DESCRIPTION
## Summary
- document ASP.NET Core entry point and testing visibility

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet format fenrick.miro.slnx --include fenrick.miro.server/src/Program.cs`
- `dotnet test fenrick.miro.slnx` *(fails: TagService.cs(55,23) CS0103, TagService.cs(55,51) CS0103, TagService.cs(61,41) CS0103, SerilogSink.cs(26,34) CS0103)*

------
https://chatgpt.com/codex/tasks/task_e_6892ca0c7268832ba20d8c32c89cfb69