### PR TITLE
fix(client): remove duplicate React plugin import

### DIFF
--- a/fenrick.miro.client/vite.config.ts
+++ b/fenrick.miro.client/vite.config.ts
@@ -1,5 +1,4 @@
 import react from '@vitejs/plugin-react';
-import plugin from '@vitejs/plugin-react';
 import dns from 'dns';
 import fs from 'fs';
 
@@ -37,7 +36,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
     },
-    plugins: [react(), plugin()],
+    plugins: [react()],
     server: {
       port: parseInt(env.VITE_PORT),
       proxy: {


### PR DESCRIPTION
## Summary
- remove duplicate React plugin import from Vite config

## Testing
- `npm --prefix fenrick.miro.client install`
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_689838cdc77c832bbdc7a41b782d160a