### PR TITLE
chore: add stylelint standard config

### DIFF
--- a/fenrick.miro.client/.stylelintrc.json
+++ b/fenrick.miro.client/.stylelintrc.json
@@ -1,0 +1,1 @@
+{ "extends": ["stylelint-config-standard"] }


### PR DESCRIPTION
## Summary
- add stylelint configuration extending stylelint-config-standard

## Testing
- `npm install`
- `npm run typecheck --silent`
- `npm run test --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_689838de4c70832bb7ae6baf0fd675bd