### PR TITLE
chore(client): add stylelint config

### DIFF
--- a/fenrick.miro.client/stylelint.config.js
+++ b/fenrick.miro.client/stylelint.config.js
@@ -1,0 +1,6 @@
+/** @type {import('stylelint').Config} */
+export default {
+  extends: ['stylelint-config-standard'],
+  ignoreFiles: ['dist/**', 'node_modules/**'],
+  rules: {},
+};


### PR DESCRIPTION
## Summary
- add Stylelint config based on stylelint-config-standard

## Testing
- `npm run prettier`
- `npm run lint`
- `npm run stylelint`
- `npm run typecheck`
- `npm run test` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68983d1665bc832ba74d1e98298ae412