### PR TITLE
test(server): add log and API contract integration tests

### DIFF
--- a/fenrick.miro.tests/tests/ContractSmokeTests.cs
+++ b/fenrick.miro.tests/tests/ContractSmokeTests.cs
@@ -1,0 +1,92 @@
+
+#nullable enable
+
+namespace Fenrick.Miro.Tests;
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Server.Domain;
+using Server.Services;
+
+public class ContractSmokeTests(WebApplicationFactory<Program> factory)
+    : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient client =
+        factory.WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting($"ApplyMigrations", $"false");
+                builder.UseSetting($"ConnectionStrings:sqlite", $"Data Source=:memory:");
+                builder.ConfigureServices(services =>
+                {
+                    services.AddSingleton<ICacheService, StubCacheService>();
+                    services.AddSingleton<IUserStore, StubUserStore>();
+                    services.AddSingleton<IMiroClient, StubMiroClient>();
+                });
+            })
+            .CreateClient();
+
+    [Fact]
+    public async Task EndpointsReturnSuccessAsync()
+    {
+        HttpResponseMessage cacheResponse =
+            await this.client.GetAsync($"/api/cache/board");
+        cacheResponse.EnsureSuccessStatusCode();
+
+        UserInfo user = new($"id", $"name", $"token");
+        HttpResponseMessage userResponse =
+            await this.client.PostAsJsonAsync($"/api/users", user);
+        Assert.Equal(HttpStatusCode.Accepted, userResponse.StatusCode);
+
+        MiroRequest[] batch = [new($"GET", $"/ping", Body: null)];
+        HttpResponseMessage batchResponse =
+            await this.client.PostAsJsonAsync($"/api/batch", batch);
+        batchResponse.EnsureSuccessStatusCode();
+        List<MiroResponse>? body =
+            await batchResponse.Content.ReadFromJsonAsync<List<MiroResponse>>();
+        Assert.NotNull(body);
+        Assert.Single(body!);
+    }
+
+    private sealed class StubCacheService : ICacheService
+    {
+        public BoardMetadata? Retrieve(string boardId) => new(boardId, $"name");
+
+        public void Store(BoardMetadata metadata)
+        {
+        }
+    }
+
+    private sealed class StubUserStore : IUserStore
+    {
+        public UserInfo? Retrieve(string userId) => null;
+
+        public Task<UserInfo?> RetrieveAsync(string userId, CancellationToken ct = default) =>
+            Task.FromResult<UserInfo?>(null);
+
+        public void Delete(string userId)
+        {
+        }
+
+        public Task DeleteAsync(string userId, CancellationToken ct = default) => Task.CompletedTask;
+
+        public void Store(UserInfo info)
+        {
+        }
+
+        public Task StoreAsync(UserInfo info, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class StubMiroClient : IMiroClient
+    {
+        public Task<MiroResponse> SendAsync(MiroRequest request, CancellationToken ct = default) =>
+            Task.FromResult(new MiroResponse((int)HttpStatusCode.OK, $"ok"));
+    }
+}
+

--- a/fenrick.miro.tests/tests/LogsEndpointTests.cs
+++ b/fenrick.miro.tests/tests/LogsEndpointTests.cs
@@ -1,0 +1,56 @@
+
+#nullable enable
+
+namespace Fenrick.Miro.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Server.Domain;
+using Server.Services;
+
+public class LogsEndpointTests(WebApplicationFactory<Program> factory)
+    : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> configuredFactory =
+        factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting($"ApplyMigrations", $"false");
+            builder.UseSetting($"ConnectionStrings:sqlite", $"Data Source=:memory:");
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<RecordingSink>();
+                services.AddSingleton<ILogSink>(sp => sp.GetRequiredService<RecordingSink>());
+            });
+        });
+
+    [Fact]
+    public async Task CaptureEndpointPersistsEntriesAsync()
+    {
+        RecordingSink sink = this.configuredFactory.Services.GetRequiredService<RecordingSink>();
+        HttpClient client = this.configuredFactory.CreateClient();
+        ClientLogEntry[] payload =
+        [
+            new(DateTime.UtcNow, $"info", $"message", Context: null),
+        ];
+
+        HttpResponseMessage response =
+            await client.PostAsJsonAsync($"/api/logs", payload);
+        Assert.Equal(System.Net.HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Single(sink.Entries);
+    }
+
+    private sealed class RecordingSink : ILogSink
+    {
+        public List<ClientLogEntry> Entries { get; } = [];
+
+        public void Store(IEnumerable<ClientLogEntry> entries) =>
+            this.Entries.AddRange(entries);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add integration test ensuring `/api/logs` stores entries
- add contract smoke test hitting cache, user and batch endpoints

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet format fenrick.miro.tests/fenrick.miro.tests.csproj --include tests/LogsEndpointTests.cs tests/ContractSmokeTests.cs --verify-no-changes --verbosity normal`
- `dotnet build fenrick.miro.slnx -warnaserror` *(fails: MA0165, xUnit1030, CS0103)*
- `dotnet test fenrick.miro.slnx` *(fails: HttpRequestException, InternalServerError)*

------
https://chatgpt.com/codex/tasks/task_e_68983cee3894832bb8b9021bfec4d149