### PR TITLE
chore(ci): enable coverage reporting

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -21,5 +21,10 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Restore
         run: dotnet restore fenrick.miro.slnx
-      - name: Test
-        run: dotnet test fenrick.miro.slnx
+      - name: Test with coverage
+        run: dotnet test fenrick.miro.slnx -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:ExcludeByAttribute=GeneratedCode
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-coverage
+          path: '**/coverage.cobertura.xml'

--- a/fenrick.miro.client/vitest.config.ts
+++ b/fenrick.miro.client/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    coverage: { provider: 'istanbul', reporter: ['text', 'lcov'] },
+    coverage: {
+      provider: 'istanbul',
+      reporter: ['text', 'lcov'],
+      lines: 70,
+      functions: 70,
+      branches: 60,
+    },
   },
 });


### PR DESCRIPTION
## Summary
- collect coverlet coverage in server test workflow and upload an artifact
- enforce minimum coverage thresholds for client vitest tests

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet build fenrick.miro.slnx -warnaserror` *(fails: The name 'Status' does not exist in the current context)*
- `dotnet test fenrick.miro.slnx` *(fails: The name 'Status' does not exist in the current context)*
- `npm --prefix fenrick.miro.client install`
- `npm --prefix fenrick.miro.client run typecheck`
- `npm run lint`
- `npm run stylelint`
- `npm run prettier`
- `npm test` *(hangs; coverage summary not produced)*

------
https://chatgpt.com/codex/tasks/task_e_68983c9d7d1c832ba265de39a6de167c