### PR TITLE
chore(server): add healthcheck and db provider

### DIFF
--- a/fenrick.miro.apphost/src/Program.cs
+++ b/fenrick.miro.apphost/src/Program.cs
@@ -28,6 +28,7 @@ IResourceBuilder<IResourceWithConnectionString> db =
 IResourceBuilder<ProjectResource> serverApi = builder.AddProject<fenrick_miro_server>($"server")
                        .WithReference(db)
                        .WaitFor(db)
+                       .WithEnvironment($"DatabaseProvider", chosen)
                        .WithExternalHttpEndpoints();
 
 // 5. Front-end waits for the API

--- a/fenrick.miro.server/Dockerfile
+++ b/fenrick.miro.server/Dockerfile
@@ -25,4 +25,5 @@ RUN dotnet publish "./fenrick.miro.server.csproj" -c "$BUILD_CONFIGURATION" -o /
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD curl -f http://localhost:8080/health/livez || exit 1
 ENTRYPOINT ["dotnet", "Fenrick.Miro.Server.dll"]

--- a/fenrick.miro.server/appsettings.Development.json
+++ b/fenrick.miro.server/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "DatabaseProvider": "sqlite"
 }

--- a/fenrick.miro.server/appsettings.json
+++ b/fenrick.miro.server/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "DatabaseProvider": "sqlite"
 }


### PR DESCRIPTION
## Summary
- add container healthcheck hitting `/health/livez`
- allow selecting database provider via config/env variables

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet format fenrick.miro.slnx --verify-no-changes --no-restore --include fenrick.miro.server/src/Services/TagService.cs fenrick.miro.server/src/Services/SerilogSink.cs` *(failed: MA0165 warnings)*
- `dotnet build fenrick.miro.slnx -warnaserror` *(failed: xUnit1030 analyzer errors)*
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal` *(failed: 3 failing tests)*
- `dotnet test fenrick.miro.slnx` *(failed: 3 failing tests)*
- `dotnet build fenrick.miro.server/fenrick.miro.server.csproj -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68983cd28d30832ba49a2e78c9ce6e23