### PR TITLE
feat: bridge user identity between client and server

### DIFF
--- a/fenrick.miro.client/src/core/utils/api-fetch.ts
+++ b/fenrick.miro.client/src/core/utils/api-fetch.ts
@@ -1,0 +1,16 @@
+/**
+ * Augment fetch calls with the current user's identifier.
+ *
+ * @param input - Request URL or object.
+ * @param init - Fetch options.
+ * @returns Response from the server.
+ */
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const user = await miro.board.getUserInfo();
+  const headers = new Headers(init.headers || {});
+  headers.set('X-User-Id', String(user.id));
+  return fetch(input, { ...init, headers });
+}

--- a/fenrick.miro.client/src/core/utils/card-client.ts
+++ b/fenrick.miro.client/src/core/utils/card-client.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from './api-fetch';
 import type { CardData } from './cards';
 
 /** HTTP client for the cards API. */
@@ -17,7 +18,7 @@ export class CardClient {
     if (typeof fetch !== 'function') {
       return;
     }
-    await fetch(this.url, {
+    await apiFetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(cards),

--- a/fenrick.miro.client/src/core/utils/shape-client.ts
+++ b/fenrick.miro.client/src/core/utils/shape-client.ts
@@ -1,4 +1,6 @@
 /** Data describing a Miro shape widget. */
+import { apiFetch } from './api-fetch';
+
 export interface ShapeData {
   shape: string;
   x: number;
@@ -38,7 +40,7 @@ export class ShapeClient {
     if (typeof fetch !== 'function') {
       return;
     }
-    await fetch(this.url, {
+    await apiFetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(shapes),
@@ -50,7 +52,7 @@ export class ShapeClient {
     if (typeof fetch !== 'function') {
       return;
     }
-    await fetch(`${this.url}/${id}`, {
+    await apiFetch(`${this.url}/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(shape),
@@ -62,7 +64,7 @@ export class ShapeClient {
     if (typeof fetch !== 'function') {
       return;
     }
-    await fetch(`${this.url}/${id}`, { method: 'DELETE' });
+    await apiFetch(`${this.url}/${id}`, { method: 'DELETE' });
   }
 
   /** Retrieve a shape widget by identifier. */
@@ -72,7 +74,7 @@ export class ShapeClient {
     if (typeof fetch !== 'function') {
       return undefined;
     }
-    const res = await fetch(`${this.url}/${id}`);
+    const res = await apiFetch(`${this.url}/${id}`);
     if (!res.ok) {
       return undefined;
     }

--- a/fenrick.miro.client/src/core/utils/tag-client.ts
+++ b/fenrick.miro.client/src/core/utils/tag-client.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from './api-fetch';
+
 export interface TagInfo {
   id: string;
   title: string;
@@ -20,7 +22,7 @@ export class TagClient {
     if (typeof fetch !== 'function') {
       return [];
     }
-    const res = await fetch(this.url);
+    const res = await apiFetch(this.url);
     if (!res.ok) {
       return [];
     }

--- a/fenrick.miro.client/src/index.ts
+++ b/fenrick.miro.client/src/index.ts
@@ -1,9 +1,19 @@
 import { DiagramApp } from './app/diagram-app';
+import { apiFetch } from './core/utils/api-fetch';
 import { log } from './logger';
+import { registerWithCurrentUser } from './user-auth';
 
-log.info('Starting application');
-DiagramApp.getInstance()
-  .init()
-  .catch(err => log.error(err));
+async function start(): Promise<void> {
+  log.info('Starting application');
+  await registerWithCurrentUser();
+  const status = await apiFetch('/api/auth/status');
+  if (status.status === 404) {
+    const user = await miro.board.getUserInfo();
+    await miro.board.ui.openPanel({ url: `/oauth/login?userId=${user.id}` });
+  }
+  await DiagramApp.getInstance().init();
+}
+
+start().catch(err => log.error(err));
 
 export {};

--- a/fenrick.miro.client/src/log-sink.ts
+++ b/fenrick.miro.client/src/log-sink.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from './core/utils/api-fetch';
+
 export interface ClientLogEntry {
   timestamp: string;
   level: string;
@@ -26,7 +28,7 @@ export class HttpLogSink implements LogSink {
       return;
     }
     try {
-      const response = await fetch(this.url, {
+      const response = await apiFetch(this.url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(entries),

--- a/fenrick.miro.client/src/user-auth.ts
+++ b/fenrick.miro.client/src/user-auth.ts
@@ -3,8 +3,10 @@
  *
  * @property id - Unique identifier returned by Miro.
  * @property name - Display name of the user.
- * @property token - OAuth token scoped for REST API calls.
+ * @property token - ID token proving user identity.
  */
+import { apiFetch } from './core/utils/api-fetch';
+
 export interface AuthDetails {
   id: string;
   name: string;
@@ -25,7 +27,7 @@ export class AuthClient {
       return;
     }
 
-    const res = await fetch(this.url, {
+    const res = await apiFetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(details),
@@ -61,11 +63,11 @@ export class AuthClient {
 }
 
 /**
- * Obtain the current Miro token and forward it to the server.
+ * Obtain the current Miro ID token and forward it to the server.
  *
  * @throws Error when the Miro SDK is unavailable.
  */
-export async function registerCurrentUser(
+export async function registerWithCurrentUser(
   client = new AuthClient(),
 ): Promise<void> {
   if (typeof miro === 'undefined' || !miro.board) {

--- a/fenrick.miro.client/tests/api-fetch.test.ts
+++ b/fenrick.miro.client/tests/api-fetch.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+import { apiFetch } from '../src/core/utils/api-fetch';
+
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true } as Response));
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 42 }) },
+});
+
+test('apiFetch attaches user header', async () => {
+  await apiFetch('/api/test');
+  const call = (fetch as unknown as vi.Mock).mock.calls[0];
+  const headers = call[1].headers as Headers;
+  expect(headers.get('X-User-Id')).toBe('42');
+});

--- a/fenrick.miro.client/tests/card-client.test.ts
+++ b/fenrick.miro.client/tests/card-client.test.ts
@@ -3,6 +3,9 @@ import { CardClient } from '../src/core/utils/card-client';
 import type { CardData } from '../src/core/utils/cards';
 
 vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
 
 beforeEach(() => (fetch as unknown as vi.Mock).mockReset());
 

--- a/fenrick.miro.client/tests/card-processor.tags.test.ts
+++ b/fenrick.miro.client/tests/card-processor.tags.test.ts
@@ -4,6 +4,9 @@ import { CardProcessor } from '../src/board/card-processor';
 import { TagClient } from '../src/core/utils/tag-client';
 
 vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
 
 beforeEach(() => (fetch as unknown as vi.Mock).mockReset());
 

--- a/fenrick.miro.client/tests/http-log-sink.test.ts
+++ b/fenrick.miro.client/tests/http-log-sink.test.ts
@@ -5,6 +5,10 @@ import { HttpLogSink } from '../src/log-sink';
 let server: ReturnType<typeof createServer>;
 let url: string;
 
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
+
 beforeAll(async () => {
   server = createServer((_, res) => {
     res.statusCode = 202;

--- a/fenrick.miro.client/tests/logger.test.ts
+++ b/fenrick.miro.client/tests/logger.test.ts
@@ -11,6 +11,10 @@ afterEach(() => {
   delete (global as { fetch?: unknown }).fetch;
 });
 
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
+
 test('defaults to info level', async () => {
   delete process.env.LOG_LEVEL;
   const { log } = await import('../src/logger');

--- a/fenrick.miro.client/tests/mock-board.ts
+++ b/fenrick.miro.client/tests/mock-board.ts
@@ -17,6 +17,7 @@ export function mockBoard(
   const board = {
     getSelection: vi.fn().mockResolvedValue([]),
     info: { id },
+    getUserInfo: vi.fn().mockResolvedValue({ id: 'u1', name: 'Test' }),
     ...overrides,
   } as unknown as BoardLike;
   (globalThis as { miro?: { board?: BoardLike } }).miro = { board };

--- a/fenrick.miro.client/tests/shape-client.test.ts
+++ b/fenrick.miro.client/tests/shape-client.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { ShapeClient, type ShapeData } from '../src/core/utils/shape-client';
 
 vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
 
 beforeEach(() => (fetch as unknown as vi.Mock).mockReset());
 

--- a/fenrick.miro.client/tests/tag-client.test.ts
+++ b/fenrick.miro.client/tests/tag-client.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { TagClient } from '../src/core/utils/tag-client';
 
 vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
 
 beforeEach(() => (fetch as unknown as vi.Mock).mockReset());
 

--- a/fenrick.miro.client/tests/user-auth.integration.test.ts
+++ b/fenrick.miro.client/tests/user-auth.integration.test.ts
@@ -1,7 +1,7 @@
 import http, { type Server } from 'node:http';
 import { AddressInfo } from 'node:net';
 import { afterAll, beforeAll, expect, test, vi } from 'vitest';
-import { AuthClient, registerCurrentUser } from '../src/user-auth';
+import { AuthClient, registerWithCurrentUser } from '../src/user-auth';
 
 let server: Server;
 let url: string;
@@ -39,7 +39,7 @@ test('registerCurrentUser sends token to server', async () => {
     status = r.status;
     return r;
   };
-  await registerCurrentUser(client);
+  await registerWithCurrentUser(client);
   expect(status).toBe(202);
   global.fetch = originalFetch;
 });

--- a/fenrick.miro.client/tests/user-auth.test.ts
+++ b/fenrick.miro.client/tests/user-auth.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
-import { AuthClient, registerCurrentUser } from '../src/user-auth';
+import { AuthClient, registerWithCurrentUser } from '../src/user-auth';
 
 test('registerCurrentUser posts auth details', async () => {
   const client = new AuthClient('/api/users');
@@ -12,7 +12,7 @@ test('registerCurrentUser posts auth details', async () => {
   (global as unknown as { fetch: unknown }).fetch = fetchMock;
   (global as unknown as { miro: unknown }).miro = { board: boardMock };
 
-  await registerCurrentUser(client);
+  await registerWithCurrentUser(client);
 
   expect(fetchMock).toHaveBeenCalledWith(
     '/api/users',
@@ -34,7 +34,7 @@ test('registerCurrentUser retries on failure', async () => {
     },
   };
   const client = new AuthClient('/api/users');
-  const promise = registerCurrentUser(client);
+  const promise = registerWithCurrentUser(client);
   await vi.runAllTimersAsync();
   await promise;
   expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/fenrick.miro.client/vitest.config.ts
+++ b/fenrick.miro.client/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    globals: true,
     environment: 'jsdom',
     coverage: {
       provider: 'istanbul',

--- a/fenrick.miro.server/src/Api/AuthController.cs
+++ b/fenrick.miro.server/src/Api/AuthController.cs
@@ -1,0 +1,31 @@
+namespace Fenrick.Miro.Server.Api;
+
+using Microsoft.AspNetCore.Mvc;
+
+using Services;
+
+/// <summary>
+///     Exposes authentication status for the calling user.
+/// </summary>
+[ApiController]
+[Route($"api/auth")]
+public class AuthController(IUserStore store) : ControllerBase
+{
+    private readonly IUserStore userStore = store;
+
+    /// <summary>
+    ///     Returns 200 when tokens exist for the provided <c>X-User-Id</c> header;
+    ///     otherwise 404.
+    /// </summary>
+    /// <param name="userId">Identifier of the calling user.</param>
+    [HttpGet($"status")]
+    public IActionResult GetStatus([FromHeader(Name = $"X-User-Id")] string? userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return this.BadRequest();
+        }
+
+        return this.userStore.Retrieve(userId) is null ? this.NotFound() : this.Ok();
+    }
+}

--- a/fenrick.miro.tests/tests/AuthControllerTests.cs
+++ b/fenrick.miro.tests/tests/AuthControllerTests.cs
@@ -1,0 +1,72 @@
+namespace Fenrick.Miro.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+
+using Server.Api;
+using Server.Domain;
+using Server.Services;
+
+using Xunit;
+
+public class AuthControllerTests
+{
+    [Fact]
+    public void GetStatusReturnsOkWhenUserPresent()
+    {
+        var store = new StubStore();
+        store.Store(new UserInfo($"u1", $"n", $"a", $"r", DateTimeOffset.UtcNow));
+        var controller = new AuthController(store);
+
+        IActionResult result = controller.GetStatus($"u1");
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public void GetStatusReturnsNotFoundForMissingUser()
+    {
+        var controller = new AuthController(new StubStore());
+        IActionResult result = controller.GetStatus($"u2");
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void GetStatusReturnsBadRequestWithoutHeader()
+    {
+        var controller = new AuthController(new StubStore());
+        IActionResult result = controller.GetStatus(userId: null);
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    private sealed class StubStore : IUserStore
+    {
+        private readonly Dictionary<string, UserInfo> users = [];
+
+        public UserInfo? Retrieve(string userId) =>
+            this.users.TryGetValue(userId, out UserInfo? u) ? u : null;
+
+        public Task<UserInfo?> RetrieveAsync(string userId, CancellationToken ct = default) =>
+            Task.FromResult(this.Retrieve(userId));
+
+        public void Delete(string userId) => this.users.Remove(userId);
+
+        public Task DeleteAsync(string userId, CancellationToken ct = default)
+        {
+            this.Delete(userId);
+            return Task.CompletedTask;
+        }
+
+        public void Store(UserInfo info) => this.users[info.Id] = info;
+
+        public Task StoreAsync(UserInfo info, CancellationToken ct = default)
+        {
+            this.Store(info);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- send id token and user id on client startup and prompt login when tokens missing
- attach X-User-Id to every API call with a new apiFetch helper
- add /api/auth/status endpoint to verify token presence

## Testing
- `npm --prefix fenrick.miro.client run typecheck`
- `npm --prefix fenrick.miro.client run lint`
- `npm --prefix fenrick.miro.client run stylelint`
- `npm --prefix fenrick.miro.client run prettier`
- `npm --prefix fenrick.miro.client run test` *(fails: jest is not defined, PointerEvent missing)*
- `dotnet restore`
- `dotnet format`
- `dotnet test fenrick.miro.tests/fenrick.miro.tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6898726a5b9c832ba574fa3b7d440813