### PR TITLE
feat(cache): add ttl and size cap to shape cache

### DIFF
--- a/fenrick.miro.client/tests/excel-sync-service.unit.test.ts
+++ b/fenrick.miro.client/tests/excel-sync-service.unit.test.ts
@@ -18,6 +18,7 @@ vi.mock('../src/board/templates', () => ({
 vi.mock('../src/board/element-utils', () => ({ applyElementToItem: vi.fn() }));
 
 describe('ExcelSyncService', () => {
+  beforeEach(() => vi.clearAllMocks());
   test('registerMapping and getWidgetId round-trip', () => {
     const svc = new ExcelSyncService();
     svc.registerMapping('r1', 'w1');
@@ -89,6 +90,8 @@ describe('ExcelSyncService', () => {
     const result = await svc.findWidget('r1', 'foo');
     expect(result).toEqual({ id: 'w1' });
     expect(api.getShape).toHaveBeenCalledWith('w1');
+    expect(searchShapes).not.toHaveBeenCalled();
+    expect(searchGroups).not.toHaveBeenCalled();
   });
 
   test('findWidget searches shapes then groups', async () => {

--- a/fenrick.miro.server/src/Services/InMemoryShapeCache.cs
+++ b/fenrick.miro.server/src/Services/InMemoryShapeCache.cs
@@ -1,6 +1,8 @@
 namespace Fenrick.Miro.Server.Services;
 
+using System;
 using System.Collections.Concurrent;
+using System.Linq;
 
 using Domain;
 
@@ -12,29 +14,77 @@ using Domain;
 /// </remarks>
 public class InMemoryShapeCache : IShapeCache
 {
-    private readonly
-        ConcurrentDictionary<(string Board, string Item), ShapeCacheEntry>
-        cache = new();
+    private readonly ConcurrentDictionary<(string Board, string Item), CacheItem> cache = new();
+    private readonly TimeSpan ttl;
+    private readonly int maxSize;
+
+    private record CacheItem(ShapeCacheEntry Entry, DateTimeOffset Timestamp);
+
+    /// <summary>
+    ///     Create a cache with the specified retention settings.
+    /// </summary>
+    /// <param name="ttl">Maximum lifetime for entries.</param>
+    /// <param name="maxSize">Maximum number of entries to retain.</param>
+    public InMemoryShapeCache(TimeSpan? ttl = null, int maxSize = 1024)
+    {
+        this.ttl = ttl ?? TimeSpan.FromMinutes(5);
+        this.maxSize = maxSize;
+    }
 
     /// <inheritdoc />
     public void Remove(string boardId, string itemId) =>
         this.cache.TryRemove((boardId, itemId), out _);
 
     /// <inheritdoc />
-    public ShapeCacheEntry? Retrieve(string boardId, string itemId) =>
-        this.cache.TryGetValue((boardId, itemId), out ShapeCacheEntry? entry)
-            ? entry
-            : null;
+    public ShapeCacheEntry? Retrieve(string boardId, string itemId)
+    {
+        this.Purge();
+        if (this.cache.TryGetValue((boardId, itemId), out CacheItem item))
+        {
+            if (DateTimeOffset.UtcNow - item.Timestamp <= this.ttl)
+            {
+                return item.Entry;
+            }
+
+            this.cache.TryRemove((boardId, itemId), out _);
+        }
+
+        return null;
+    }
 
     /// <inheritdoc />
     public ShapeData? RetrieveData(string boardId, string itemId) =>
         this.Retrieve(boardId, itemId)?.Data;
 
     /// <inheritdoc />
-    public void Store(ShapeCacheEntry entry) =>
-        this.cache[(entry.BoardId, entry.ItemId)] = entry;
+    public void Store(ShapeCacheEntry entry)
+    {
+        this.cache[(entry.BoardId, entry.ItemId)] =
+            new CacheItem(entry, DateTimeOffset.UtcNow);
+        this.Purge();
+    }
 
     /// <inheritdoc />
     public void Store(string boardId, string itemId, ShapeData data) =>
         this.Store(new ShapeCacheEntry(boardId, itemId, data));
+
+    private void Purge()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        foreach ((var key, CacheItem value) in this.cache)
+        {
+            if (now - value.Timestamp > this.ttl)
+            {
+                this.cache.TryRemove(key, out _);
+            }
+        }
+
+        while (this.cache.Count > this.maxSize)
+        {
+            (var key, _) = this.cache
+                .OrderBy(kv => kv.Value.Timestamp)
+                .First();
+            this.cache.TryRemove(key, out _);
+        }
+    }
 }

--- a/fenrick.miro.tests/tests/InMemoryShapeCacheTests.cs
+++ b/fenrick.miro.tests/tests/InMemoryShapeCacheTests.cs
@@ -1,5 +1,7 @@
 namespace Fenrick.Miro.Tests;
 
+using System;
+using System.Threading.Tasks;
 using Server.Domain;
 using Server.Services;
 
@@ -46,5 +48,28 @@ Style: null));
         ShapeData? result = cache.RetrieveData($"b2", $"i2");
 
         Assert.Equal(data, result);
+    }
+
+    [Fact]
+    public async Task ExpiredEntriesArePurged()
+    {
+        var cache = new InMemoryShapeCache(TimeSpan.FromMilliseconds(10), 10);
+        var data = new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null);
+        cache.Store("b3", "i3", data);
+        await Task.Delay(20);
+        Assert.Null(cache.Retrieve("b3", "i3"));
+    }
+
+    [Fact]
+    public void SizeLimitEvictsOldestEntry()
+    {
+        var cache = new InMemoryShapeCache(TimeSpan.FromMinutes(1), 2);
+        var data = new ShapeData("r", 0, 0, 1, 1, Rotation: null, Text: null, Style: null);
+        cache.Store("b4", "i1", data);
+        cache.Store("b4", "i2", data);
+        cache.Store("b4", "i3", data);
+        Assert.Null(cache.Retrieve("b4", "i1"));
+        Assert.NotNull(cache.Retrieve("b4", "i2"));
+        Assert.NotNull(cache.Retrieve("b4", "i3"));
     }
 }


### PR DESCRIPTION
## Summary
- add time-to-live and entry cap to in-memory shape cache
- cover cache eviction logic with new unit tests
- ensure ExcelSyncService reads go through cached getShape before board scans

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet format fenrick.miro.slnx` *(failed: Unable to fix IDE0060 / IDE1006)*
- `dotnet build fenrick.miro.slnx -warnaserror`
- `dotnet test fenrick.miro.slnx` *(failed: No service for type 'Fenrick.Miro.Server.Services.ITemplateStore' has been registered)*
- `npm --prefix fenrick.miro.client install`
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run test --silent` *(failed: Bus error)*
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68987b7a8018832b9ca7774a747f26d6