### PR TITLE
test: add OAuth callback and login redirect tests

### DIFF
--- a/fenrick.miro.client/tests/index-login-redirect.test.ts
+++ b/fenrick.miro.client/tests/index-login-redirect.test.ts
@@ -1,0 +1,27 @@
+import { vi, test, expect } from 'vitest';
+
+vi.mock('../src/user-auth', () => ({
+  registerWithCurrentUser: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/core/utils/api-fetch', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ status: 404 } as Response),
+}));
+vi.mock('../src/app/diagram-app', () => ({
+  DiagramApp: {
+    getInstance: vi.fn(() => ({ init: vi.fn().mockResolvedValue(undefined) })),
+  },
+}));
+
+test('opens login panel when not authorised', async () => {
+  const openPanel = vi.fn();
+  vi.stubGlobal('miro', {
+    board: {
+      getUserInfo: vi.fn().mockResolvedValue({ id: 7 }),
+      ui: { openPanel },
+    },
+  });
+
+  await import('../src/index');
+
+  expect(openPanel).toHaveBeenCalledWith({ url: '/oauth/login?userId=7' });
+});

--- a/fenrick.miro.tests/tests/OAuthControllerTests.cs
+++ b/fenrick.miro.tests/tests/OAuthControllerTests.cs
@@ -1,0 +1,67 @@
+namespace Fenrick.Miro.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+
+using Server.Api;
+using Server.Domain;
+using Server.Services;
+
+using Xunit;
+
+public class OAuthControllerTests
+{
+    [Fact]
+    public async Task CallbackExchangesCodeAndStoresTokensAsync()
+    {
+        IConfiguration cfg = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+(StringComparer.Ordinal)
+        {
+            [$"Miro:AuthBase"] = $"http://auth",
+            [$"Miro:ClientId"] = $"id",
+            [$"Miro:ClientSecret"] = $"secret",
+            [$"Miro:RedirectUri"] = $"http://redir",
+        }).Build();
+        var handler = new StubHandler();
+        var factory = new StubFactory(handler);
+        var store = new InMemoryUserStore();
+        var controller = new OAuthController(cfg, store, factory);
+
+        IActionResult res = await controller.Callback($"code", $"x:u1", CancellationToken.None).ConfigureAwait(false);
+
+        UserInfo? info = await store.RetrieveAsync($"u1").ConfigureAwait(false);
+        Assert.Equal($"tok", info?.AccessToken);
+        Assert.Equal($"ref", info?.RefreshToken);
+        RedirectResult redirect = Assert.IsType<RedirectResult>(res);
+        Assert.Equal($"/app.html", redirect.Url);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            const string json = """{""token_type"":""bearer"",""access_token"":""tok"",""refresh_token"":""ref"",""expires_in"":3600}""";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json),
+            });
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory, IDisposable
+    {
+        private readonly HttpClient client = new(handler) { BaseAddress = new Uri($"http://auth") };
+
+        public HttpClient CreateClient(string name) => this.client;
+
+        public void Dispose() => this.client.Dispose();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add OAuth callback integration test
- add client test for unauthorised login redirect

## Testing
- `dotnet restore fenrick.miro.slnx`
- `dotnet format fenrick.miro.slnx` *(fails: NamingStyleCodeFixProvider doesn't support Fix All in Solution)*
- `dotnet build fenrick.miro.slnx -warnaserror` *(fails: CS0103 'itemId' does not exist)*
- `dotnet test fenrick.miro.slnx` *(fails: CS0103 'itemId' does not exist)*
- `npm install` *(fails: package.json missing)*
- `npm --prefix fenrick.miro.client install`
- `npm --prefix fenrick.miro.client run typecheck --silent`
- `npm --prefix fenrick.miro.client run lint --silent`
- `npm --prefix fenrick.miro.client run stylelint --silent`
- `npm --prefix fenrick.miro.client run prettier --silent`
- `npm --prefix fenrick.miro.client run test --silent` *(fails: PointerEvent is not defined, jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689880768538832b894110b5d1c74e6e