### PR TITLE
docs: add Python architecture guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ fenrick.miro.[module]/
 └── tests/    – unit and integration tests
 ```
 
-Backend code is **C# (nullable enabled)**. Frontend code is **TypeScript + React**.
+Backend code is primarily **C# (nullable enabled)** with a small **FastAPI** service in **Python 3.11**. Frontend code is **TypeScript + React**.
 
 ## Object-Oriented Design Principles — **Mandatory**
 
@@ -84,6 +84,12 @@ All rules are configured in `.editorconfig`; the build runs with `-warnaserror`.
 
 * Prettier
 
+### Python
+
+* **Ruff** – lint and fix PEP 8 issues
+* **Black** – code formatter (line length 88)
+* **Mypy** – static type checking
+
 ## Development Commands
 
 ### Backend
@@ -104,6 +110,14 @@ npm --prefix web/client run lint
 npm --prefix web/client run stylelint
 npm --prefix web/client run prettier
 npm --prefix web/client run test
+```
+
+### Python
+
+``` bash
+poetry install
+poetry run pre-commit run --files [changed files]
+poetry run pytest
 ```
 
 ## Git Hooks
@@ -135,13 +149,14 @@ Types include `feat`, `fix`, `docs`, `test`, `refactor`, `chore`.
 * `docs/DEPLOYMENT.md` – build & CI/CD
 
 * `CONTRIBUTING.md` – PR workflow, onboarding
+* `docs/python-architecture.md` – FastAPI modules and data flow
 
 ## Summary
 
 | Area      | Requirement                                  |
 | --------- | -------------------------------------------- |
 | Structure | `src/` and `tests/` folders                  |
-| Language  | C# (.NET Aspire) + React (TypeScript)        |
+| Language  | C# (.NET Aspire) + React (TypeScript) + Python (FastAPI) |
 | Design    | SOLID, composition over inheritance          |
 | Testing   | TDD, ≥ 90 % coverage                         |
 | Analysis  | Roslyn analyzers, ESLint, Stylelint          |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,12 @@ for the general workflow.
 See the
 [Miro developer documentation](https://developers.miro.com/docs/overview) for a
 step-by-step tutorial on building diagramming apps. When contributing code,
-please follow the formatting rules in [docs/CODE_STYLE.md](docs/CODE_STYLE.md).
-Aim for at least **90 % line and branch test coverage** in both Node and .NET
-code and keep cyclomatic complexity below eight as described in
+please follow the formatting rules in [docs/CODE_STYLE.md](docs/CODE_STYLE.md)
+and the Python conventions outlined in
+[docs/python-architecture.md](docs/python-architecture.md). Use `poetry run
+pre-commit run --files …` and `poetry run pytest` for Python changes. Aim for at
+least **90 % line and branch test coverage** in Node, .NET and Python code and
+keep cyclomatic complexity below eight as described in
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Commit messages

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ each element can carry metadata that controls its appearance and placement.
 - Node.js 20.x
 - .NET 9 SDK
 - `dotnet workload install aspire`
+- Python 3.11 with [Poetry](https://python-poetry.org/)
 
 ### Environment
 
@@ -381,6 +382,7 @@ dependency installs run from that directory.
 - [Aspire Quick Start](docs/ASPIRE.md) shows how to run the .NET AppHost
   locally or in Docker.
 - [Server Modules](docs/SERVER_MODULES.md) details the planned .NET API layout.
+- [Python Service Architecture](docs/python-architecture.md) covers FastAPI modules, caching and Miro API integration.
 - [Miro API Costs](docs/MIRO_API_COSTS.md) explains why we cache shapes and avoid expensive board calls.
 - [ShapesController](docs/SERVER_MODULES.md#3-controllers) handles create, update and delete of Miro widgets via the backend cache.
 - [Components Catalogue](docs/COMPONENTS.md) documents reusable React

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,7 @@ security-significant or process change.
 | Design tokens, colour, spacing, typography      | **FOUNDATION.md** |
 | CI/CD, hosting, rollback, environment settings  | **DEPLOYMENT.md** |
 | Sidebar tab flows, validation, keyboard support | **TABS.md**       |
+| Python service architecture                      | **python-architecture.md** |
 
 ---
 

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -44,6 +44,10 @@ This project enforces consistent formatting with
 
 For additional architectural guidelines see [ARCHITECTURE.md](ARCHITECTURE.md).
 
+## Python
+
+Backend scripts and services follow [PEP 8](https://peps.python.org/pep-0008/) and are formatted with [Black](https://black.readthedocs.io/en/stable/) using an 88 character line length. Lint with [Ruff](https://docs.astral.sh/ruff/) and type-check with [Mypy](https://mypy.readthedocs.io/). Document public APIs with concise docstrings and keep type hints on all function signatures. Run `poetry run pre-commit run --files <files>` before committing.
+
 ## Storybook
 
 Run the Storybook dev server during component development to preview UI changes.

--- a/docs/python-architecture.md
+++ b/docs/python-architecture.md
@@ -1,0 +1,70 @@
+# Python Architecture
+
+## Module Overview
+
+```text
++------------------+       +-----------+       +----------------+
+| FastAPI Routers  +------>+ Services  +------>+ Repositories   |
++------------------+       +-----------+       +----------------+
+                                                     |
+                                                     v
+                                             +---------------+
+                                             | SQLite Cache  |
+                                             +---------------+
+                                                     |
+                                                     v
+                                             +---------------+
+                                             |   Miro API    |
+                                             +---------------+
+
+                +---------------------+
+                |   Queue Worker      |
+                | (background tasks)  |
+                +---------------------+
+```
+
+## Request Flow
+
+1. Node client issues HTTP request.
+2. FastAPI router validates input and delegates to a service.
+3. Service coordinates domain logic and queries the repository.
+4. Repository reads from the SQLite cache; on a miss it fetches from the Miro API and updates the cache.
+5. Service returns DTOs to the router, which serialises the response back to the client.
+
+## Background Queue
+
+- Routers or services enqueue long-running jobs (e.g. board sync or webhook processing).
+- A dedicated worker consumes the queue, reusing the same services and repositories as the web layer.
+- Failures are retried with exponential backoff and logged with full context.
+
+## Static Assets and CORS
+
+- `StaticFiles` serves bundled client assets. Paths are versioned to enable aggressive caching.
+- CORS is restricted to the official Node client origin and only exposes the required headers.
+
+## Error Handling & Logging
+
+- Use exception handlers to map domain and validation errors into clear HTTP responses.
+- Structured logging captures correlation IDs and request context. Logging output ships to the central aggregator and feeds metri
+cs/alerts.
+- A global fallback handler reports unhandled exceptions and returns a 500 response without leaking internals.
+
+## Security
+
+- Enforce HTTPS and HSTS at the edge.
+- Secrets (API keys, database credentials) are injected via environment variables or secret managers; they are never committed to source control.
+- Input is validated and sanitised to avoid injection attacks.
+- Access to the Miro API uses short-lived OAuth tokens that are rotated and stored outside the codebase.
+
+## Migration Strategy
+
+- Initial Python endpoints may proxy requests to existing C# services when feature parity is incomplete.
+- Each migration phase replaces a legacy C# feature with a Python implementation and gradually deprecates the proxy.
+
+## Coding Standards
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/) with automatic formatting (e.g. `black`).
+- Provide concise docstrings and type hints for all public APIs.
+- Maintain small, single-responsibility modules and refactor shared logic into common libraries.
+- Run `pre-commit` hooks for formatting and linting (`black`, `ruff`) and enforce tests (`pytest`) in continuous integration.
+


### PR DESCRIPTION
## Summary
- document FastAPI modules, caching, and Miro API flow
- outline background queue, static asset/CORS strategy, error handling, security, and migration plan
- note coding standards (PEP 8, docstrings, type hints, pre-commit hooks)
- reference Python guide in README, AGENTS, CONTRIBUTING, and CODE_STYLE

## Testing
- `pre-commit run --files README.md AGENTS.md CONTRIBUTING.md docs/CODE_STYLE.md`


------
https://chatgpt.com/codex/tasks/task_e_689f0ff40870832bb4de75e4ab4a7c34