### PR TITLE
chore: align paths with new layout

### DIFF
--- a/.github/workflows/client-eslint.yml
+++ b/.github/workflows/client-eslint.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: ESLint
         run: npm run lint
-        working-directory: fenrick.miro.client
+        working-directory: web/client

--- a/.github/workflows/client-prettier.yml
+++ b/.github/workflows/client-prettier.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Prettier
         run: npm run prettier:check
-        working-directory: fenrick.miro.client
+        working-directory: web/client

--- a/.github/workflows/client-stylelint.yml
+++ b/.github/workflows/client-stylelint.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Stylelint
         run: npm run stylelint
-        working-directory: fenrick.miro.client
+        working-directory: web/client

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -17,19 +17,19 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Node tests
         run: npm run test
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Upload coverage
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: fenrick.miro.client/coverage/*
+          path: web/client/coverage/*
           include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/client-typecheck.yml
+++ b/.github/workflows/client-typecheck.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Typecheck
         run: npm run typecheck
-        working-directory: fenrick.miro.client
+        working-directory: web/client

--- a/.github/workflows/repo-commitlint.yml
+++ b/.github/workflows/repo-commitlint.yml
@@ -20,11 +20,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run:
           npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.event.pull_request.head.sha }}
-        working-directory: fenrick.miro.client
+        working-directory: web/client

--- a/.github/workflows/repo-release.yml
+++ b/.github/workflows/repo-release.yml
@@ -20,24 +20,24 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - name: Cache Storybook
         uses: actions/cache@v4
         with:
-          path: fenrick.miro.client/node_modules/.cache/storybook
-          key: ${{ runner.os }}-storybook-${{ hashFiles('fenrick.miro.client/package-lock.json') }}
+          path: web/client/node_modules/.cache/storybook
+          key: ${{ runner.os }}-storybook-${{ hashFiles('web/client/package-lock.json') }}
           restore-keys: ${{ runner.os }}-storybook-
       - name: Build Storybook
         run: npm run build-storybook
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Verify Storybook
         run: test -d storybook-static
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Upload artefact
         uses: actions/upload-artifact@v4
         with:
           name: build
-          path: fenrick.miro.client/dist
+          path: web/client/dist
 
   release:
     needs: build
@@ -50,21 +50,21 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - run: npm ci --prefer-offline --no-audit
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Download artefact
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: fenrick.miro.client/dist
+          path: web/client/dist
       - name: Semantic release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Check release tag
         id: release_tag
         run: |

--- a/.github/workflows/repo-sonar.yml
+++ b/.github/workflows/repo-sonar.yml
@@ -27,12 +27,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: fenrick.miro.client/package-lock.json
+          cache-dependency-path: web/client/package-lock.json
       - run: corepack enable && npm ci
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Run node unit tests
         run: npm run test
-        working-directory: fenrick.miro.client
+        working-directory: web/client
       - name: Begin sonar-scanner
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
             /k:"fenrick_MiroDiagraming" /o:"fenrick" `
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" `
             /d:sonar.host.url="https://sonarcloud.io" `
-            /d:sonar.javascript.lcov.reportPaths="${{ github.workspace }}/fenrick.miro.client/coverage/lcov.info"
+            /d:sonar.javascript.lcov.reportPaths="${{ github.workspace }}/web/client/coverage/lcov.info"
       - name: End sonar-scanner
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/server-format.yml
+++ b/.github/workflows/server-format.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Format check
-        run: dotnet format --verify-no-changes fenrick.miro.slnx
+        run: dotnet format --verify-no-changes legacy/dotnet/fenrick.miro.slnx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ All rules are configured in `.editorconfig`; the build runs with `-warnaserror`.
 ### Backend
 
 ``` bash
-dotnet format fenrick.miro.slnx
+dotnet format legacy/dotnet/fenrick.miro.slnx
 ```
 
 ### Frontend

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Copy `web/client/.env.example` to `web/client/.env` and adjust the values as nee
 Run both the server and client together:
 
 ```bash
-dotnet run --project fenrick.miro.apphost
+dotnet run --project legacy/dotnet/fenrick.miro.apphost
 ```
 
 Run them separately:
 
 ```bash
 (cd web/client && npm run dev)
-dotnet run --project fenrick.miro.server
+dotnet run --project legacy/dotnet/fenrick.miro.server
 ```
 
 ## Uploading JSON Content
@@ -284,7 +284,7 @@ Then validate the codebase with:
 ```bash
 npm --prefix web/client run typecheck --silent
 npm --prefix web/client run test --silent
-npx dotnet-format --verify-no-changes fenrick.miro.server/fenrick.miro.server.csproj
+npx dotnet-format --verify-no-changes legacy/dotnet/fenrick.miro.server/fenrick.miro.server.csproj
 npm --prefix web/client run lint --silent
 npm --prefix web/client run stylelint --silent
 npm --prefix web/client run prettier --silent
@@ -353,11 +353,8 @@ dependency installs run from that directory.
 
 ```
 .
-├── fenrick.miro.server/
-│   └── src
-│       ├── Api
-│       ├── Domain
-│       └── Services
+├── docs/
+├── src/miro_backend/
 ├── web/client/
 │   ├── src
 │   │   ├── app
@@ -367,10 +364,9 @@ dependency installs run from that directory.
 │   │   └── assets
 │   ├── index.html // entry point specified as App URL
 │   └── app.html   // panel view loaded by the SDK
-├── fenrick.miro.api/
-├── fenrick.miro.services/
-├── public         // icons and i18n JSON
-└── scripts        // build helpers
+├── tests/
+├── legacy/dotnet/
+└── templates/
 ```
 
 ## 📚 Additional Design Docs

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,12 +80,12 @@ Orchestration (web/client/src/core) (web/client/src/core)
 
 ```
 
-fenrick.miro.server/ src/{Api,Domain,Services} web/client/
-src/{app,board,core,ui,assets} fenrick.miro.api/ src/ (future public API)
-fenrick.miro.services/ src/ (shared cross-cutting services)
-fenrick.miro.tests/ .NET unit tests web/client/tests/ Node/React
-tests docs/ \*.md (this file, components, foundation …) scripts/ build helpers
-public/ icons, i18n JSON templates/ default widget templates
+docs/                 project documentation
+src/miro_backend/     FastAPI service
+web/client/           React front-end
+tests/                Python unit tests
+legacy/dotnet/        archived .NET implementation
+templates/            default widget templates
 
 ```
 

--- a/docs/ASPIRE.md
+++ b/docs/ASPIRE.md
@@ -8,7 +8,7 @@ Introduce the built-in AppHost, how to extend it with external services and how 
 
 ## 1 AppHost overview
 
-`fenrick.miro.apphost` starts the server via `DistributedApplication.CreateBuilder`. Add services like Redis or PostgreSQL using the host builder APIs.
+`legacy/dotnet/fenrick.miro.apphost` starts the server via `DistributedApplication.CreateBuilder`. Add services like Redis or PostgreSQL using the host builder APIs.
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -30,7 +30,7 @@ The server persists data in **PostgreSQL** using the `Microsoft.EntityFrameworkC
 The Aspire dashboard listens on port `18888`. Set the `DOTNET_DASHBOARD_PORT` environment variable to change it. The example below runs the dashboard on port `3000`:
 
 ```bash
-DOTNET_DASHBOARD_PORT=3000 dotnet run --project fenrick.miro.apphost
+DOTNET_DASHBOARD_PORT=3000 dotnet run --project legacy/dotnet/fenrick.miro.apphost
 ```
 
 Point a browser to `http://localhost:3000` to inspect service logs and metrics.
@@ -40,7 +40,7 @@ Point a browser to `http://localhost:3000` to inspect service logs and metrics.
 Build the application host with the Dockerfile located in the server project:
 
 ```bash
-docker build -t miro-apphost -f fenrick.miro.server/Dockerfile .
+docker build -t miro-apphost -f legacy/dotnet/fenrick.miro.server/Dockerfile .
 ```
 
 Run the container, configuring connections to Redis and PostgreSQL as needed:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -203,7 +203,7 @@ automatically.
 Some teams host the React bundle alongside an ASP.NET Core API. The backend
 publishes to a `publish/` directory and serves static files from the `wwwroot`
 folder. When `dotnet publish` runs the front‑end build output is copied from
-`web/client/dist` into `fenrick.miro.server/wwwroot` so front-end assets
+`web/client/dist` into `legacy/dotnet/fenrick.miro.server/wwwroot` so front-end assets
 and API endpoints share the same origin.
 
 ### 12.1 Environment variables
@@ -228,7 +228,7 @@ dotnet publish -c Release -o publish --nologo
 Run the app locally with:
 
 ```bash
-dotnet run --project fenrick.miro.apphost/fenrick.miro.apphost.csproj
+dotnet run --project legacy/dotnet/fenrick.miro.apphost/fenrick.miro.apphost.csproj
 ```
 
 The front-end build creates `web/client/dist`. During `dotnet publish`

--- a/docs/SERVER_MODULES.md
+++ b/docs/SERVER_MODULES.md
@@ -12,7 +12,7 @@ project structure and main controllers.
 ## 1 Proposed Repository Layout
 
 ```
-fenrick.miro.server/
+legacy/dotnet/fenrick.miro.server/
   src/                .NET 9 API project
     Api/              controllers and middleware
     Domain/           entities and data models
@@ -24,17 +24,17 @@ web/client/
     board/            board adapter utilities
     core/             domain logic used by the client
     ui/               React components
-fenrick.miro.tests/   unit tests for .NET code
+legacy/dotnet/fenrick.miro.tests/   unit tests for .NET code
 web/client/tests/       Node tests
 ```
 
-All server modules live under `fenrick.miro.server/src/` with matching tests
-under `fenrick.miro.tests/`. The Node code resides in
+All server modules live under `legacy/dotnet/fenrick.miro.server/src/` with matching tests
+under `legacy/dotnet/fenrick.miro.tests/`. The Node code resides in
 `web/client/src/` to emphasise the front‑end role.
 
 ## 2 IDE Configuration
 
- `fenrick.miro.server/fenrick.miro.server.csproj` – .NET 9 Web API project.
+ `legacy/dotnet/fenrick.miro.server/fenrick.miro.server.csproj` – .NET 9 Web API project.
  `package.json` in `web/client/` – Node workspace for the React client.
 
 Each tool can open only its relevant folder, but the repository still builds end
@@ -59,13 +59,13 @@ The API exposes five controller types:
    without calling `board.get`. TODO: expose a lookup endpoint once the cache
    supports persistence.
 
-Each controller resides under `fenrick.miro.server/src/Api/` and is covered by
+Each controller resides under `legacy/dotnet/fenrick.miro.server/src/Api/` and is covered by
 dedicated unit tests.
 
 ## 4 Shared Contracts
 
 Models used by both the server and client live in
-`fenrick.miro.server/src/Domain/`. These include board metadata, webhook
+`legacy/dotnet/fenrick.miro.server/src/Domain/`. These include board metadata, webhook
 payloads and diagram definitions. The React code imports the TypeScript
 declarations generated from the C# records, ensuring a single source of truth
 for all data shapes.


### PR DESCRIPTION
## Summary
- update docs to reflect new repository structure
- point workflows to web/client and legacy/dotnet directories
- refresh AGENTS instructions and README paths

## Testing
- `SKIP=pytest poetry run pre-commit run --files .github/workflows/client-eslint.yml .github/workflows/client-prettier.yml .github/workflows/client-stylelint.yml .github/workflows/client-tests.yml .github/workflows/client-typecheck.yml .github/workflows/repo-commitlint.yml .github/workflows/repo-release.yml .github/workflows/repo-sonar.yml .github/workflows/server-format.yml AGENTS.md README.md docs/ARCHITECTURE.md docs/ASPIRE.md docs/DEPLOYMENT.md docs/SERVER_MODULES.md`
- `poetry run pytest` *(fails: PendingDeprecation warning & unraisable exception)*
- `npm install --prefix web/client`
- `npm --prefix web/client run typecheck`
- `npm --prefix web/client run lint`
- `npm --prefix web/client run stylelint`
- `npm --prefix web/client run prettier`
- `npm --prefix web/client run test` *(fails: jest is not defined in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f18e10e5c832b9d3a4d0b77e337db