### PR TITLE
feat(batch): add batch processing endpoint

### DIFF
--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -1,0 +1,22 @@
+"""Batch operations endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+
+from ...queue.change_queue import ChangeQueue
+from ...queue.provider import get_change_queue
+from ...schemas.batch import BatchRequest, BatchResponse
+from ...services.batch_service import enqueue_operations
+
+router = APIRouter(prefix="/api", tags=["batch"])
+
+
+@router.post("/batch", status_code=status.HTTP_202_ACCEPTED, response_model=BatchResponse)  # type: ignore[misc]
+async def post_batch(
+    request: BatchRequest, queue: ChangeQueue = Depends(get_change_queue)
+) -> BatchResponse:
+    """Validate ``request`` and enqueue its operations."""
+
+    count = await enqueue_operations(request.operations, queue)
+    return BatchResponse(enqueued=count)

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -14,11 +14,12 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from .api.routers.auth import router as auth_router
-from .queue import ChangeQueue
+from .api.routers.batch import router as batch_router
+from .queue.provider import get_change_queue
 from .services.miro_client import MiroClient
 
 
-change_queue = ChangeQueue()
+change_queue = get_change_queue()
 """Global queue used by the background worker."""
 
 
@@ -52,6 +53,7 @@ if static_dir.exists():
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.include_router(auth_router)
+app.include_router(batch_router)
 
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]

--- a/src/miro_backend/queue/__init__.py
+++ b/src/miro_backend/queue/__init__.py
@@ -1,6 +1,7 @@
 """Queue utilities for processing board changes."""
 
 from .change_queue import ChangeQueue
+from .provider import get_change_queue
 from .tasks import ChangeTask, CreateNode, UpdateCard
 
 __all__ = [
@@ -8,4 +9,5 @@ __all__ = [
     "ChangeTask",
     "CreateNode",
     "UpdateCard",
+    "get_change_queue",
 ]

--- a/src/miro_backend/queue/provider.py
+++ b/src/miro_backend/queue/provider.py
@@ -1,0 +1,12 @@
+"""Dependency helpers for the global :class:`ChangeQueue`."""
+
+from __future__ import annotations
+
+from .change_queue import ChangeQueue
+
+_change_queue = ChangeQueue()
+
+
+def get_change_queue() -> ChangeQueue:
+    """Return the shared :class:`ChangeQueue` instance."""
+    return _change_queue

--- a/src/miro_backend/schemas/batch.py
+++ b/src/miro_backend/schemas/batch.py
@@ -1,0 +1,44 @@
+"""Pydantic models for batch change operations."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class CreateNodeOperation(BaseModel):
+    """Request to create a new node on the board."""
+
+    type: Literal["create_node"] = Field(
+        description="Discriminator for the operation type"
+    )
+    node_id: str
+    data: dict[str, Any]
+
+
+class UpdateCardOperation(BaseModel):
+    """Request to update an existing card."""
+
+    type: Literal["update_card"] = Field(
+        description="Discriminator for the operation type"
+    )
+    card_id: str
+    payload: dict[str, Any]
+
+
+Operation = Annotated[
+    CreateNodeOperation | UpdateCardOperation, Field(discriminator="type")
+]
+
+
+class BatchRequest(BaseModel):
+    """Incoming batch of operations to process."""
+
+    operations: list[Operation]
+
+
+class BatchResponse(BaseModel):
+    """Summary of enqueued operations."""
+
+    enqueued: int

--- a/src/miro_backend/services/__init__.py
+++ b/src/miro_backend/services/__init__.py
@@ -1,6 +1,7 @@
 """Service layer utilities."""
 
+from .batch_service import enqueue_operations
 from .miro_client import MiroClient
 from .repository import Repository
 
-__all__ = ["MiroClient", "Repository"]
+__all__ = ["enqueue_operations", "MiroClient", "Repository"]

--- a/src/miro_backend/services/batch_service.py
+++ b/src/miro_backend/services/batch_service.py
@@ -1,0 +1,37 @@
+"""Service for enqueuing board change operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ..queue import ChangeQueue, ChangeTask, CreateNode, UpdateCard
+from ..schemas.batch import (
+    CreateNodeOperation,
+    Operation,
+    UpdateCardOperation,
+)
+
+
+async def enqueue_operations(
+    operations: Sequence[Operation], queue: ChangeQueue
+) -> int:
+    """Convert ``operations`` into tasks and enqueue them.
+
+    Args:
+        operations: Validated operations to enqueue.
+        queue: Target :class:`ChangeQueue`.
+
+    Returns:
+        Number of enqueued operations.
+    """
+
+    for op in operations:
+        task: ChangeTask
+        if isinstance(op, CreateNodeOperation):
+            task = CreateNode(node_id=op.node_id, data=op.data)
+        elif isinstance(op, UpdateCardOperation):
+            task = UpdateCard(card_id=op.card_id, payload=op.payload)
+        else:  # pragma: no cover - safeguarded by Pydantic validation
+            continue
+        await queue.enqueue(task)
+    return len(operations)

--- a/tests/test_batch_controller.py
+++ b/tests/test_batch_controller.py
@@ -1,8 +1,57 @@
-"""Placeholder for ported tests from BatchControllerTests.cs."""
+"""Tests for the batch operations endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
 
 import pytest
+from fastapi.testclient import TestClient
+
+from miro_backend.main import app
+from miro_backend.queue.provider import get_change_queue
+from miro_backend.queue.tasks import CreateNode, UpdateCard
 
 
-@pytest.mark.skip("Test not yet ported from C#")  # type: ignore[misc]
-def test_placeholder() -> None:
-    assert True
+class DummyQueue:
+    """Simple queue capturing enqueued tasks."""
+
+    def __init__(self) -> None:
+        self.tasks: list[object] = []
+
+    async def enqueue(self, task: object) -> None:
+        self.tasks.append(task)
+
+
+# mypy struggles with pytest fixtures
+@pytest.fixture  # type: ignore[misc]
+def client_queue() -> Iterator[tuple[TestClient, DummyQueue]]:
+    queue = DummyQueue()
+    app.dependency_overrides[get_change_queue] = lambda: queue
+    client = TestClient(app)
+    yield client, queue
+    app.dependency_overrides.clear()
+
+
+def test_post_batch_enqueues_tasks(client_queue: tuple[TestClient, DummyQueue]) -> None:
+    client, queue = client_queue
+    body = {
+        "operations": [
+            {"type": "create_node", "node_id": "n1", "data": {"x": 1}},
+            {"type": "update_card", "card_id": "c1", "payload": {"y": 2}},
+        ]
+    }
+    response = client.post("/api/batch", json=body)
+    assert response.status_code == 202
+    assert response.json() == {"enqueued": 2}
+    assert len(queue.tasks) == 2
+    assert isinstance(queue.tasks[0], CreateNode)
+    assert isinstance(queue.tasks[1], UpdateCard)
+
+
+def test_post_batch_validates_payload(
+    client_queue: tuple[TestClient, DummyQueue]
+) -> None:
+    client, _ = client_queue
+    body = {"operations": [{"type": "create_node", "node_id": "n1"}]}
+    response = client.post("/api/batch", json=body)
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add `/api/batch` endpoint to queue board mutations
- define batch request/response schemas and enqueue service
- cover success and validation paths with unit tests

## Testing
- `poetry run pre-commit run --files src/miro_backend/api/routers/batch.py src/miro_backend/schemas/batch.py src/miro_backend/services/batch_service.py src/miro_backend/queue/provider.py src/miro_backend/main.py src/miro_backend/queue/__init__.py src/miro_backend/services/__init__.py tests/test_batch_controller.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f39a95d44832b8f4d6745dc5c10c5