### PR TITLE
feat(cache): add board cache endpoint

### DIFF
--- a/src/miro_backend/api/routers/cache.py
+++ b/src/miro_backend/api/routers/cache.py
@@ -1,0 +1,33 @@
+"""Cache lookup endpoints for board metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ...db.session import get_session
+from ...models import CacheEntry
+from ...services.repository import Repository
+
+router = APIRouter(prefix="/api/cache", tags=["cache"])
+
+
+@router.get("/{board_id}", status_code=status.HTTP_200_OK)  # type: ignore[misc]
+def get_board_cache(
+    board_id: str, session: Session = Depends(get_session)
+) -> dict[str, Any]:
+    """Return cached board state for ``board_id``."""
+
+    if board_id.strip() == "":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Board not found"
+        )
+    repo: Repository[CacheEntry] = Repository(session, CacheEntry)
+    state = repo.get_board_state(board_id)
+    if state is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Board not found"
+        )
+    return state

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from .api.routers.auth import router as auth_router
+from .api.routers.cache import router as cache_router
 from .queue import ChangeQueue
 from .services.miro_client import MiroClient
 
@@ -52,6 +53,7 @@ if static_dir.exists():
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.include_router(auth_router)
+app.include_router(cache_router)
 
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]

--- a/src/miro_backend/services/repository.py
+++ b/src/miro_backend/services/repository.py
@@ -8,9 +8,11 @@ business logic.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from sqlalchemy.orm import Session
+
+from ..models import CacheEntry
 
 ModelT = TypeVar("ModelT")
 
@@ -45,6 +47,12 @@ class Repository(Generic[ModelT]):
         """Return all entities of the repository type."""
 
         return self.session.query(self.model).all()
+
+    def get_board_state(self, board_id: str) -> dict[str, Any] | None:
+        """Return cached board state for ``board_id`` if present."""
+
+        entry = self.session.query(CacheEntry).filter_by(key=board_id).one_or_none()
+        return entry.value if entry else None
 
     # ------------------------------------------------------------------
     # Delete operations

--- a/tests/test_cache_controller.py
+++ b/tests/test_cache_controller.py
@@ -1,8 +1,52 @@
-"""Placeholder for ported tests from CacheControllerTests.cs."""
+"""Tests for the cache router."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
 
 import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from miro_backend.db.session import Base, SessionLocal, engine, get_session
+from miro_backend.main import app
+from miro_backend.models import CacheEntry
 
 
-@pytest.mark.skip("Test not yet ported from C#")  # type: ignore[misc]
-def test_placeholder() -> None:
-    assert True
+# mypy struggles with pytest decorators
+@pytest.fixture  # type: ignore[misc]
+def client_session() -> Iterator[tuple[TestClient, Session]]:
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+
+    def override_get_session() -> Iterator[Session]:
+        try:
+            yield session
+        finally:
+            pass
+
+    app.dependency_overrides[get_session] = override_get_session
+    client = TestClient(app)
+    yield client, session
+    session.close()
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_get_cache_returns_board_state(
+    client_session: tuple[TestClient, Session]
+) -> None:
+    client, session = client_session
+    session.add(CacheEntry(key="b1", value={"id": "b1", "name": "Board"}))
+    session.commit()
+    response = client.get("/api/cache/b1")
+    assert response.status_code == 200
+    assert response.json() == {"id": "b1", "name": "Board"}
+
+
+def test_get_cache_returns_404_when_missing(
+    client_session: tuple[TestClient, Session]
+) -> None:
+    client, _ = client_session
+    response = client.get("/api/cache/missing")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add board cache retrieval to repository
- expose `/api/cache/{board_id}` to fetch cached board state
- test cache controller for hit and miss cases

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/repository.py src/miro_backend/api/routers/cache.py src/miro_backend/main.py tests/test_cache_controller.py` (fails: async def functions are not natively supported in two tests)
- `poetry run pytest` (fails: async def functions are not natively supported in two tests)


------
https://chatgpt.com/codex/tasks/task_e_689f3ad81784832b9767c592dafed50c