### PR TITLE
feat(cards): add card creation endpoint

### DIFF
--- a/src/miro_backend/api/routers/cards.py
+++ b/src/miro_backend/api/routers/cards.py
@@ -1,0 +1,30 @@
+"""Card endpoints migrated from the C# ``CardsController``."""
+
+from __future__ import annotations
+
+import miro_backend.main as main
+from fastapi import APIRouter, Depends, status
+from typing import cast
+
+from ...queue import ChangeQueue
+from ...schemas.card_create import CardCreate
+
+router = APIRouter(prefix="/api/cards", tags=["cards"])
+
+
+def get_change_queue() -> ChangeQueue:
+    """Provide the application's change queue."""
+
+    return cast(ChangeQueue, main.change_queue)
+
+
+@router.post("", status_code=status.HTTP_202_ACCEPTED)  # type: ignore[misc]
+async def create_cards(
+    cards: list[CardCreate],
+    queue: ChangeQueue = Depends(get_change_queue),
+) -> dict[str, int]:
+    """Queue tasks that create the supplied ``cards``."""
+
+    for card in cards:
+        await queue.enqueue(card.to_task())
+    return {"accepted": len(cards)}

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -13,13 +13,16 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
-from .api.routers.auth import router as auth_router
 from .queue import ChangeQueue
 from .services.miro_client import MiroClient
 
 
-change_queue = ChangeQueue()
+change_queue: ChangeQueue = ChangeQueue()
 """Global queue used by the background worker."""
+
+# Routers are imported after the queue to avoid circular dependencies.
+from .api.routers.auth import router as auth_router  # noqa: E402
+from .api.routers.cards import router as cards_router  # noqa: E402
 
 
 @asynccontextmanager
@@ -52,6 +55,7 @@ if static_dir.exists():
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.include_router(auth_router)
+app.include_router(cards_router)
 
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]

--- a/src/miro_backend/schemas/card_create.py
+++ b/src/miro_backend/schemas/card_create.py
@@ -1,0 +1,28 @@
+"""Schema for card creation requests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from ..queue import CreateNode, ChangeTask
+
+
+class CardCreate(BaseModel):
+    """Data describing a card to be created on the board."""
+
+    id: str | None = None
+    title: str
+    description: str | None = None
+    tags: list[str] | None = None
+    style: dict[str, Any] | None = None
+    fields: list[dict[str, Any]] | None = None
+    taskStatus: str | None = None
+
+    def to_task(self) -> ChangeTask:
+        """Convert this definition into a :class:`ChangeTask`."""
+
+        payload = self.model_dump(exclude_none=True)
+        node_id = payload.pop("id", "")
+        return CreateNode(node_id=node_id, data=payload)

--- a/tests/test_cards_controller.py
+++ b/tests/test_cards_controller.py
@@ -1,8 +1,49 @@
-"""Placeholder for ported tests from CardsControllerTests.cs."""
+"""Tests for the cards API router."""
 
-import pytest
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from miro_backend.queue import ChangeTask, CreateNode
 
 
-@pytest.mark.skip("Test not yet ported from C#")  # type: ignore[misc]
-def test_placeholder() -> None:
-    assert True
+class StubQueue:
+    """Queue stub that records enqueued tasks."""
+
+    def __init__(self) -> None:
+        self.tasks: list[ChangeTask] = []
+
+    async def enqueue(self, task: ChangeTask) -> None:
+        self.tasks.append(task)
+
+    async def worker(self, client: object) -> None:  # pragma: no cover - stub
+        """No-op worker used during testing."""
+
+        return
+
+
+def test_post_cards_enqueues_tasks(tmp_path: Path) -> None:
+    """POSTing cards should enqueue matching change tasks."""
+
+    static_dir = Path(__file__).resolve().parent.parent / "web" / "client" / "dist"
+    static_dir.mkdir(parents=True, exist_ok=True)
+
+    app_module = importlib.import_module("miro_backend.main")
+    queue = StubQueue()
+    app_module.change_queue = queue  # type: ignore[attr-defined]
+
+    with TestClient(app_module.app) as client:
+        response = client.post(
+            "/api/cards",
+            json=[{"id": "c1", "title": "t"}],
+        )
+        assert response.status_code == 202
+
+    assert len(queue.tasks) == 1
+    task = queue.tasks[0]
+    assert isinstance(task, CreateNode)
+    assert task.node_id == "c1"
+    assert task.data["title"] == "t"


### PR DESCRIPTION
## Summary
- route POST /api/cards to enqueue card creation tasks
- define CardCreate schema mapping payloads to ChangeQueue tasks
- cover queueing logic with tests

## Testing
- `poetry run pre-commit run --files src/miro_backend/api/routers/cards.py src/miro_backend/schemas/card_create.py src/miro_backend/main.py tests/test_cards_controller.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3ad9c4c4832bb487b0ffc665b0d0