### PR TITLE
feat(api): add oauth login and callback endpoints

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from .api.routers.auth import router as auth_router
+from .api.routers.oauth import router as oauth_router
 from .queue import ChangeQueue
 from .services.miro_client import MiroClient
 
@@ -52,6 +53,7 @@ if static_dir.exists():
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.include_router(auth_router)
+app.include_router(oauth_router)
 
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]

--- a/src/miro_backend/services/__init__.py
+++ b/src/miro_backend/services/__init__.py
@@ -1,6 +1,6 @@
 """Service layer utilities."""
 
-from .miro_client import MiroClient
+from .miro_client import MiroClient, get_miro_client
 from .repository import Repository
 
-__all__ = ["MiroClient", "Repository"]
+__all__ = ["MiroClient", "Repository", "get_miro_client"]

--- a/src/miro_backend/services/miro_client.py
+++ b/src/miro_backend/services/miro_client.py
@@ -21,3 +21,18 @@ class MiroClient:
         self, card_id: str, payload: dict[str, Any]
     ) -> None:  # pragma: no cover - stub
         """Update a card on the board."""
+
+    async def exchange_code(
+        self, code: str, redirect_uri: str
+    ) -> dict[str, Any]:  # pragma: no cover - stub
+        """Exchange an OAuth code for tokens."""
+        raise NotImplementedError
+
+
+_client = MiroClient()
+
+
+def get_miro_client() -> MiroClient:
+    """Provide the global Miro client instance."""
+
+    return _client

--- a/tests/test_o_auth_controller.py
+++ b/tests/test_o_auth_controller.py
@@ -1,8 +1,91 @@
-"""Placeholder for ported tests from OAuthControllerTests.cs."""
+"""Tests for the OAuth router."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from urllib.parse import parse_qs, urlparse
 
 import pytest
+from fastapi.testclient import TestClient
+
+from miro_backend.api.routers import oauth
+from miro_backend.main import app
+from miro_backend.services.miro_client import MiroClient
+from miro_backend.services.user_store import InMemoryUserStore, get_user_store
 
 
-@pytest.mark.skip("Test not yet ported from C#")  # type: ignore[misc]
-def test_placeholder() -> None:
-    assert True
+class StubClient(MiroClient):  # type: ignore[misc]
+    """Fake client capturing exchange calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, int | str]:
+        self.calls.append((code, redirect_uri))
+        return {"access_token": "tok", "refresh_token": "ref", "expires_in": 3600}
+
+
+@pytest.fixture  # type: ignore[misc]
+def client_store() -> Iterator[tuple[TestClient, InMemoryUserStore, StubClient]]:
+    store = InMemoryUserStore()
+    stub = StubClient()
+    cfg = oauth.OAuthConfig(
+        auth_base="http://auth",
+        client_id="id",
+        client_secret="secret",
+        redirect_uri="http://redir",
+    )
+    app.dependency_overrides[get_user_store] = lambda: store
+    app.dependency_overrides[oauth.get_miro_client] = lambda: stub
+    app.dependency_overrides[oauth.get_oauth_config] = lambda: cfg
+    client = TestClient(app)
+    yield client, store, stub
+    app.dependency_overrides.clear()
+
+
+def test_login_redirects_to_miro(
+    client_store: tuple[TestClient, InMemoryUserStore, StubClient]
+) -> None:
+    client, _, _ = client_store
+    res = client.get("/oauth/login", params={"userId": "u1"}, allow_redirects=False)
+    assert res.status_code == 307
+    loc = res.headers["location"]
+    parsed = urlparse(loc)
+    assert parsed.scheme + "://" + parsed.netloc == "http://auth"
+    assert parsed.path == "/oauth/authorize"
+    q = parse_qs(parsed.query)
+    assert q["client_id"] == ["id"]
+    assert q["redirect_uri"] == ["http://redir"]
+    assert q["response_type"] == ["code"]
+    assert q["scope"] == ["boards:read boards:write"]
+    assert q["state"][0].endswith(":u1")
+
+
+def test_callback_exchanges_code_and_stores_tokens(
+    client_store: tuple[TestClient, InMemoryUserStore, StubClient]
+) -> None:
+    client, store, stub = client_store
+    res = client.get(
+        "/oauth/callback",
+        params={"code": "c", "state": "x:u1"},
+        allow_redirects=False,
+    )
+    assert res.status_code == 307
+    assert res.headers["location"] == "/app.html"
+    info = store.retrieve("u1")
+    assert info is not None
+    assert info.access_token == "tok"
+    assert info.refresh_token == "ref"
+    assert stub.calls == [("c", "http://redir")]
+
+
+def test_callback_rejects_invalid_state(
+    client_store: tuple[TestClient, InMemoryUserStore, StubClient]
+) -> None:
+    client, store, stub = client_store
+    res = client.get(
+        "/oauth/callback", params={"code": "c", "state": "bad"}, allow_redirects=False
+    )
+    assert res.status_code == 400
+    assert store.retrieve("u1") is None
+    assert stub.calls == []


### PR DESCRIPTION
## Summary
- add OAuth login and callback API routes
- exchange authorization codes using MiroClient and persist tokens
- cover OAuth flows with new unit tests

## Testing
- `PYTHONPATH=src poetry run pre-commit run --files src/miro_backend/services/miro_client.py src/miro_backend/services/__init__.py src/miro_backend/api/routers/oauth.py src/miro_backend/main.py tests/test_o_auth_controller.py`
- `PYTHONPATH=src poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3adaf0b8832b8080b01b6a0503a1