### PR TITLE
feat: add shape management endpoints

### DIFF
--- a/src/miro_backend/api/routers/shapes.py
+++ b/src/miro_backend/api/routers/shapes.py
@@ -1,0 +1,112 @@
+"""Endpoints for managing shapes on boards."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+
+from ...queue import (
+    ChangeQueue,
+    CreateShape,
+    UpdateShape,
+    DeleteShape,
+    get_change_queue,
+)
+from ...schemas.shape import Shape, ShapeCreate, ShapeUpdate
+from ...services.shape_store import ShapeStore, get_shape_store
+
+router = APIRouter(prefix="/api/boards/{board_id}/shapes", tags=["shapes"])
+
+
+def _verify_board(board_id: str, user_id: str | None, store: ShapeStore) -> None:
+    owner = store.board_owner(board_id)
+    if owner is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Board not found"
+        )
+    if user_id != owner:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not board owner"
+        )
+
+
+@router.get("/{shape_id}", response_model=Shape)  # type: ignore[misc]
+def get_shape(
+    board_id: str,
+    shape_id: str,
+    user_id: str | None = Header(default=None, alias="X-User-Id"),
+    store: ShapeStore = Depends(get_shape_store),
+) -> Shape:
+    """Return the specified shape if the requester owns the board."""
+
+    _verify_board(board_id, user_id, store)
+    shape = store.get(board_id, shape_id)
+    if shape is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Shape not found"
+        )
+    return shape
+
+
+@router.post("/", response_model=Shape, status_code=status.HTTP_201_CREATED)  # type: ignore[misc]
+async def create_shape(
+    board_id: str,
+    payload: ShapeCreate,
+    user_id: str | None = Header(default=None, alias="X-User-Id"),
+    store: ShapeStore = Depends(get_shape_store),
+    queue: ChangeQueue = Depends(get_change_queue),
+) -> Shape:
+    """Create a new shape and queue the change."""
+
+    _verify_board(board_id, user_id, store)
+    shape = Shape(id=str(uuid4()), **payload.model_dump())
+    store.create(board_id, shape)
+    await queue.enqueue(
+        CreateShape(board_id=board_id, shape_id=shape.id, data=payload.model_dump())
+    )
+    return shape
+
+
+@router.put("/{shape_id}", response_model=Shape)  # type: ignore[misc]
+async def update_shape(
+    board_id: str,
+    shape_id: str,
+    payload: ShapeUpdate,
+    user_id: str | None = Header(default=None, alias="X-User-Id"),
+    store: ShapeStore = Depends(get_shape_store),
+    queue: ChangeQueue = Depends(get_change_queue),
+) -> Shape:
+    """Update an existing shape and queue the change."""
+
+    _verify_board(board_id, user_id, store)
+    if store.get(board_id, shape_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Shape not found"
+        )
+    shape = Shape(id=shape_id, **payload.model_dump())
+    store.update(board_id, shape)
+    await queue.enqueue(
+        UpdateShape(board_id=board_id, shape_id=shape_id, data=payload.model_dump())
+    )
+    return shape
+
+
+@router.delete("/{shape_id}", status_code=status.HTTP_204_NO_CONTENT)  # type: ignore[misc]
+async def delete_shape(
+    board_id: str,
+    shape_id: str,
+    user_id: str | None = Header(default=None, alias="X-User-Id"),
+    store: ShapeStore = Depends(get_shape_store),
+    queue: ChangeQueue = Depends(get_change_queue),
+) -> Response:
+    """Delete a shape and queue the removal."""
+
+    _verify_board(board_id, user_id, store)
+    if store.get(board_id, shape_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Shape not found"
+        )
+    store.delete(board_id, shape_id)
+    await queue.enqueue(DeleteShape(board_id=board_id, shape_id=shape_id))
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -14,11 +14,12 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from .api.routers.auth import router as auth_router
-from .queue import ChangeQueue
+from .api.routers.shapes import router as shapes_router
+from .queue import get_change_queue
 from .services.miro_client import MiroClient
 
 
-change_queue = ChangeQueue()
+change_queue = get_change_queue()
 """Global queue used by the background worker."""
 
 
@@ -52,6 +53,7 @@ if static_dir.exists():
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.include_router(auth_router)
+app.include_router(shapes_router)
 
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]

--- a/src/miro_backend/queue/__init__.py
+++ b/src/miro_backend/queue/__init__.py
@@ -1,11 +1,31 @@
 """Queue utilities for processing board changes."""
 
 from .change_queue import ChangeQueue
-from .tasks import ChangeTask, CreateNode, UpdateCard
+from .tasks import (
+    ChangeTask,
+    CreateNode,
+    UpdateCard,
+    CreateShape,
+    UpdateShape,
+    DeleteShape,
+)
+
+_queue = ChangeQueue()
+
+
+def get_change_queue() -> ChangeQueue:
+    """Provide the global change queue instance."""
+
+    return _queue
+
 
 __all__ = [
     "ChangeQueue",
     "ChangeTask",
     "CreateNode",
     "UpdateCard",
+    "CreateShape",
+    "UpdateShape",
+    "DeleteShape",
+    "get_change_queue",
 ]

--- a/src/miro_backend/queue/tasks.py
+++ b/src/miro_backend/queue/tasks.py
@@ -40,3 +40,35 @@ class UpdateCard(ChangeTask):
 
     async def apply(self, client: Any) -> None:
         await client.update_card(self.card_id, self.payload)
+
+
+class CreateShape(ChangeTask):
+    """Create a new shape on a board."""
+
+    board_id: str
+    shape_id: str
+    data: dict[str, Any]
+
+    async def apply(self, client: Any) -> None:
+        await client.create_shape(self.board_id, self.shape_id, self.data)
+
+
+class UpdateShape(ChangeTask):
+    """Update an existing shape."""
+
+    board_id: str
+    shape_id: str
+    data: dict[str, Any]
+
+    async def apply(self, client: Any) -> None:
+        await client.update_shape(self.board_id, self.shape_id, self.data)
+
+
+class DeleteShape(ChangeTask):
+    """Delete a shape from a board."""
+
+    board_id: str
+    shape_id: str
+
+    async def apply(self, client: Any) -> None:
+        await client.delete_shape(self.board_id, self.shape_id)

--- a/src/miro_backend/schemas/shape.py
+++ b/src/miro_backend/schemas/shape.py
@@ -1,0 +1,25 @@
+"""Pydantic models representing shapes."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ShapeBase(BaseModel):
+    """Common attributes shared by all shape representations."""
+
+    content: str
+
+
+class ShapeCreate(ShapeBase):
+    """Payload required to create a new shape."""
+
+
+class ShapeUpdate(ShapeBase):
+    """Payload used to update an existing shape."""
+
+
+class Shape(ShapeBase):
+    """A shape stored on a board."""
+
+    id: str

--- a/src/miro_backend/services/miro_client.py
+++ b/src/miro_backend/services/miro_client.py
@@ -21,3 +21,18 @@ class MiroClient:
         self, card_id: str, payload: dict[str, Any]
     ) -> None:  # pragma: no cover - stub
         """Update a card on the board."""
+
+    async def create_shape(
+        self, board_id: str, shape_id: str, data: dict[str, Any]
+    ) -> None:  # pragma: no cover - stub
+        """Create a shape on ``board_id``."""
+
+    async def update_shape(
+        self, board_id: str, shape_id: str, data: dict[str, Any]
+    ) -> None:  # pragma: no cover - stub
+        """Update ``shape_id`` on ``board_id``."""
+
+    async def delete_shape(
+        self, board_id: str, shape_id: str
+    ) -> None:  # pragma: no cover - stub
+        """Delete ``shape_id`` from ``board_id``."""

--- a/src/miro_backend/services/shape_store.py
+++ b/src/miro_backend/services/shape_store.py
@@ -1,0 +1,82 @@
+"""Storage abstractions for shapes and board ownership."""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Protocol
+
+from ..schemas.shape import Shape
+
+
+class ShapeStore(Protocol):
+    """Persist and retrieve shapes for boards."""
+
+    def add_board(self, board_id: str, owner_id: str) -> None:
+        """Register a board owned by ``owner_id``."""
+
+    def board_owner(self, board_id: str) -> str | None:
+        """Return the owner for ``board_id`` if known."""
+
+    def list(self, board_id: str) -> list[Shape]:
+        """Return all shapes for ``board_id``."""
+
+    def get(self, board_id: str, shape_id: str) -> Shape | None:
+        """Retrieve a single shape by ``shape_id``."""
+
+    def create(self, board_id: str, shape: Shape) -> None:
+        """Persist ``shape`` under ``board_id``."""
+
+    def update(self, board_id: str, shape: Shape) -> None:
+        """Replace an existing shape with ``shape``."""
+
+    def delete(self, board_id: str, shape_id: str) -> None:
+        """Remove the shape identified by ``shape_id``."""
+
+
+class InMemoryShapeStore(ShapeStore):
+    """Thread-safe in-memory implementation of :class:`ShapeStore`."""
+
+    def __init__(self) -> None:
+        self._owners: dict[str, str] = {}
+        self._boards: dict[str, dict[str, Shape]] = {}
+        self._lock = Lock()
+
+    def add_board(self, board_id: str, owner_id: str) -> None:
+        with self._lock:
+            self._owners[board_id] = owner_id
+            self._boards.setdefault(board_id, {})
+
+    def board_owner(self, board_id: str) -> str | None:
+        with self._lock:
+            return self._owners.get(board_id)
+
+    def list(self, board_id: str) -> list[Shape]:
+        with self._lock:
+            return list(self._boards.get(board_id, {}).values())
+
+    def get(self, board_id: str, shape_id: str) -> Shape | None:
+        with self._lock:
+            return self._boards.get(board_id, {}).get(shape_id)
+
+    def create(self, board_id: str, shape: Shape) -> None:
+        with self._lock:
+            self._boards.setdefault(board_id, {})[shape.id] = shape
+
+    def update(self, board_id: str, shape: Shape) -> None:
+        with self._lock:
+            if board_id in self._boards and shape.id in self._boards[board_id]:
+                self._boards[board_id][shape.id] = shape
+
+    def delete(self, board_id: str, shape_id: str) -> None:
+        with self._lock:
+            if board_id in self._boards:
+                self._boards[board_id].pop(shape_id, None)
+
+
+_store = InMemoryShapeStore()
+
+
+def get_shape_store() -> ShapeStore:
+    """Provide the global shape store instance."""
+
+    return _store

--- a/tests/test_shapes_controller.py
+++ b/tests/test_shapes_controller.py
@@ -1,8 +1,106 @@
-"""Placeholder for ported tests from ShapesControllerTests.cs."""
+"""Tests for the shapes router."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
 
 import pytest
+from fastapi.testclient import TestClient
+
+from miro_backend.main import app
+from miro_backend.queue import (
+    ChangeQueue,
+    CreateShape,
+    UpdateShape,
+    DeleteShape,
+    get_change_queue,
+)
+from miro_backend.schemas.shape import Shape
+from miro_backend.services.shape_store import (
+    InMemoryShapeStore,
+    get_shape_store,
+)
 
 
-@pytest.mark.skip("Test not yet ported from C#")  # type: ignore[misc]
-def test_placeholder() -> None:
-    assert True
+@pytest.fixture  # type: ignore[misc]
+def client_store_queue() -> (
+    Iterator[tuple[TestClient, InMemoryShapeStore, ChangeQueue]]
+):
+    store = InMemoryShapeStore()
+    queue = ChangeQueue()
+    app.dependency_overrides[get_shape_store] = lambda: store
+    app.dependency_overrides[get_change_queue] = lambda: queue
+    client = TestClient(app)
+    yield client, store, queue
+    app.dependency_overrides.clear()
+
+
+def test_create_shape_enqueues_task_and_returns_shape(
+    client_store_queue: tuple[TestClient, InMemoryShapeStore, ChangeQueue]
+) -> None:
+    client, store, queue = client_store_queue
+    store.add_board("b1", "u1")
+    response = client.post(
+        "/api/boards/b1/shapes/",
+        headers={"X-User-Id": "u1"},
+        json={"content": "c"},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert store.get("b1", body["id"]) is not None
+    task = asyncio.run(queue.dequeue())
+    assert isinstance(task, CreateShape)
+    assert task.board_id == "b1"
+    assert task.data == {"content": "c"}
+
+
+def test_update_shape_enqueues_task(
+    client_store_queue: tuple[TestClient, InMemoryShapeStore, ChangeQueue]
+) -> None:
+    client, store, queue = client_store_queue
+    store.add_board("b1", "u1")
+    store.create("b1", Shape(id="s1", content="old"))
+    response = client.put(
+        "/api/boards/b1/shapes/s1",
+        headers={"X-User-Id": "u1"},
+        json={"content": "new"},
+    )
+    assert response.status_code == 200
+    assert store.get("b1", "s1").content == "new"
+    task = asyncio.run(queue.dequeue())
+    assert isinstance(task, UpdateShape)
+    assert task.shape_id == "s1"
+
+
+def test_delete_shape_enqueues_task(
+    client_store_queue: tuple[TestClient, InMemoryShapeStore, ChangeQueue]
+) -> None:
+    client, store, queue = client_store_queue
+    store.add_board("b1", "u1")
+    store.create("b1", Shape(id="s1", content="c"))
+    response = client.delete("/api/boards/b1/shapes/s1", headers={"X-User-Id": "u1"})
+    assert response.status_code == 204
+    assert store.get("b1", "s1") is None
+    task = asyncio.run(queue.dequeue())
+    assert isinstance(task, DeleteShape)
+    assert task.board_id == "b1"
+
+
+def test_get_shape_enforces_board_ownership(
+    client_store_queue: tuple[TestClient, InMemoryShapeStore, ChangeQueue]
+) -> None:
+    client, store, _ = client_store_queue
+    store.add_board("b1", "u1")
+    store.create("b1", Shape(id="s1", content="c"))
+    response = client.get("/api/boards/b1/shapes/s1", headers={"X-User-Id": "u2"})
+    assert response.status_code == 403
+
+
+def test_get_shape_returns_not_found_for_missing_item(
+    client_store_queue: tuple[TestClient, InMemoryShapeStore, ChangeQueue]
+) -> None:
+    client, store, _ = client_store_queue
+    store.add_board("b1", "u1")
+    response = client.get("/api/boards/b1/shapes/unknown", headers={"X-User-Id": "u1"})
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- handle CRUD for board shapes with new FastAPI router
- validate shape payloads and queue board updates
- cover shape routes with tests

## Testing
- `poetry run pre-commit run --files src/miro_backend/schemas/shape.py src/miro_backend/services/shape_store.py src/miro_backend/queue/tasks.py src/miro_backend/queue/__init__.py src/miro_backend/services/miro_client.py src/miro_backend/api/routers/shapes.py src/miro_backend/main.py tests/test_shapes_controller.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3add21c4832bb4d3f88ed060f0b9