### PR TITLE
feat(tags): add API endpoint to list board tags

### DIFF
--- a/src/miro_backend/api/routers/tags.py
+++ b/src/miro_backend/api/routers/tags.py
@@ -1,0 +1,28 @@
+"""HTTP routes for tag operations."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ...db.session import get_session
+from ...schemas.tag import Tag as TagSchema
+from ...services.tag_repository import TagRepository
+
+router = APIRouter(prefix="/api/boards", tags=["tags"])
+
+
+@router.get("/{board_id}/tags", response_model=list[TagSchema])  # type: ignore[misc]
+def list_tags(
+    board_id: int, session: Session = Depends(get_session)
+) -> list[TagSchema]:
+    """Return all tags for ``board_id`` sorted by name."""
+
+    repo = TagRepository(session)
+    try:
+        tags = repo.list_for_board(board_id)
+    except LookupError as exc:  # pragma: no cover - exercised via tests
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Board not found"
+        ) from exc
+    return [TagSchema.model_validate(tag) for tag in tags]

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from .api.routers.auth import router as auth_router
+from .api.routers.tags import router as tags_router
 from .queue import ChangeQueue
 from .services.miro_client import MiroClient
 
@@ -52,6 +53,7 @@ if static_dir.exists():
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 app.include_router(auth_router)
+app.include_router(tags_router)
 
 
 @app.get("/", response_class=HTMLResponse)  # type: ignore[misc]

--- a/src/miro_backend/models/__init__.py
+++ b/src/miro_backend/models/__init__.py
@@ -1,5 +1,7 @@
 """ORM models used by the service."""
 
+from .board import Board
 from .cache import CacheEntry
+from .tag import Tag
 
-__all__ = ["CacheEntry"]
+__all__ = ["Board", "CacheEntry", "Tag"]

--- a/src/miro_backend/models/board.py
+++ b/src/miro_backend/models/board.py
@@ -1,0 +1,26 @@
+"""Database model for boards."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..db.session import Base
+
+if TYPE_CHECKING:
+    from .tag import Tag
+
+
+class Board(Base):
+    """Represents a board in the local database."""
+
+    __tablename__ = "boards"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, unique=True, index=True)
+
+    tags: Mapped[list["Tag"]] = relationship(
+        "Tag", back_populates="board", cascade="all, delete-orphan"
+    )

--- a/src/miro_backend/models/tag.py
+++ b/src/miro_backend/models/tag.py
@@ -1,0 +1,27 @@
+"""Database model for tags."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..db.session import Base
+
+if TYPE_CHECKING:
+    from .board import Board
+
+
+class Tag(Base):
+    """Represents a tag attached to a board."""
+
+    __tablename__ = "tags"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    board_id: Mapped[int] = mapped_column(
+        ForeignKey("boards.id", ondelete="CASCADE"), index=True
+    )
+    name: Mapped[str] = mapped_column(String, index=True)
+
+    board: Mapped["Board"] = relationship("Board", back_populates="tags")

--- a/src/miro_backend/schemas/tag.py
+++ b/src/miro_backend/schemas/tag.py
@@ -1,0 +1,13 @@
+"""Pydantic model for tag data."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Tag(BaseModel):
+    """Serialised representation of a :class:`~miro_backend.models.tag.Tag`."""
+
+    id: int
+    board_id: int
+    name: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/src/miro_backend/services/tag_repository.py
+++ b/src/miro_backend/services/tag_repository.py
@@ -1,0 +1,32 @@
+"""Repository for tag entities."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from ..models import Board, Tag
+from .repository import Repository
+
+
+class TagRepository(Repository[Tag]):
+    """Data access layer for :class:`Tag` objects."""
+
+    def __init__(self, session: Session) -> None:
+        super().__init__(session, Tag)
+
+    def list_for_board(self, board_id: int) -> Sequence[Tag]:
+        """Return tags for ``board_id`` sorted by name.
+
+        Raises:
+            LookupError: If the board does not exist.
+        """
+        if self.session.get(Board, board_id) is None:
+            raise LookupError("Board not found")
+        return (
+            self.session.query(Tag)
+            .filter(Tag.board_id == board_id)
+            .order_by(Tag.name.asc())
+            .all()
+        )


### PR DESCRIPTION
## Summary
- add GET `/api/boards/{board_id}/tags` endpoint
- introduce Tag ORM model, schema, repository and tests
- include tags router in app startup

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/models/board.py src/miro_backend/models/tag.py src/miro_backend/models/__init__.py src/miro_backend/schemas/tag.py src/miro_backend/services/tag_repository.py src/miro_backend/api/routers/tags.py src/miro_backend/main.py tests/test_tags_controller.py`
- `poetry run pytest -k "not change_queue_persistence and not shape_queue_processor"`


------
https://chatgpt.com/codex/tasks/task_e_689f3addb09c832ba2587f07b8c226eb