### PR TITLE
feat(queue): persist change tasks in sqlite

### DIFF
--- a/docs/python-architecture.md
+++ b/docs/python-architecture.md
@@ -41,6 +41,8 @@
 - Routers or services enqueue long-running jobs (e.g. board sync or webhook processing).
 - A dedicated worker consumes the queue, reusing the same services and repositories as the web layer.
 - Failures are retried with exponential backoff and logged with full context.
+- Pending tasks are persisted to SQLite so they survive process restarts.
+- On startup the queue reloads any stored tasks before accepting new work.
 
 ## Static Assets and CORS
 

--- a/src/miro_backend/queue/persistence.py
+++ b/src/miro_backend/queue/persistence.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from typing import Type
+
+from .tasks import (
+    ChangeTask,
+    CreateNode,
+    UpdateCard,
+    CreateShape,
+    UpdateShape,
+    DeleteShape,
+)
+
+_TASK_TYPES: dict[str, Type[ChangeTask]] = {
+    "CreateNode": CreateNode,
+    "UpdateCard": UpdateCard,
+    "CreateShape": CreateShape,
+    "UpdateShape": UpdateShape,
+    "DeleteShape": DeleteShape,
+}
+
+
+class QueuePersistence:
+    """Store pending change tasks in a SQLite database."""
+
+    def __init__(self, path: str | Path = "queue.db") -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    type TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    async def save(self, task: ChangeTask) -> None:
+        """Persist ``task`` to the database."""
+
+        await asyncio.to_thread(self._insert, task)
+
+    def _insert(self, task: ChangeTask) -> None:
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                "INSERT INTO tasks (type, payload) VALUES (?, ?)",
+                (task.__class__.__name__, task.model_dump_json()),
+            )
+            conn.commit()
+
+    async def delete(self, task: ChangeTask) -> None:
+        """Remove ``task`` from the database."""
+
+        await asyncio.to_thread(self._delete_one, task)
+
+    def _delete_one(self, task: ChangeTask) -> None:
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                "DELETE FROM tasks WHERE id IN (SELECT id FROM tasks WHERE type = ? AND payload = ? LIMIT 1)",
+                (task.__class__.__name__, task.model_dump_json()),
+            )
+            conn.commit()
+
+    def load(self) -> list[ChangeTask]:
+        """Return all persisted tasks in FIFO order."""
+
+        with sqlite3.connect(self._path) as conn:
+            cursor = conn.execute("SELECT type, payload FROM tasks ORDER BY id")
+            rows = cursor.fetchall()
+
+        tasks: list[ChangeTask] = []
+        for type_name, payload in rows:
+            cls = _TASK_TYPES.get(type_name)
+            if cls is None:
+                continue
+            tasks.append(cls.model_validate_json(payload))
+        return tasks

--- a/src/miro_backend/queue/provider.py
+++ b/src/miro_backend/queue/provider.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from .change_queue import ChangeQueue
+from .persistence import QueuePersistence
 
-_change_queue = ChangeQueue()
+_change_queue = ChangeQueue(persistence=QueuePersistence())
 
 
 def get_change_queue() -> ChangeQueue:


### PR DESCRIPTION
## Summary
- add `QueuePersistence` storing tasks in SQLite
- load and remove tasks atomically in `ChangeQueue`
- document queue restart behavior

## Testing
- `poetry run pre-commit run --files src/miro_backend/queue/persistence.py src/miro_backend/queue/change_queue.py src/miro_backend/queue/provider.py tests/test_change_queue_persistence.py docs/python-architecture.md`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f42bfacf4832bbc38c1ce79480da9