### PR TITLE
refactor: centralize change queue and document new endpoints

### DIFF
--- a/docs/migration-tracker.md
+++ b/docs/migration-tracker.md
@@ -5,12 +5,12 @@ This document lists legacy C# controllers and their endpoints to track migration
 | Controller | Endpoints | Status |
 |-----------|-----------|--------|
 | AuthController | `GET /api/auth/status` | ✅ Migrated |
-| BatchController | `POST /api/batch` | ⏳ Pending |
-| CacheController | `GET /api/cache/{boardId}` | ⏳ Pending |
-| CardsController | `POST /api/cards` | ⏳ Pending |
-| LogsController | `POST /api/logs` | ⏳ Pending |
-| OAuthController | `GET /oauth/login`, `GET /oauth/callback` | ⏳ Pending |
-| ShapesController | `POST /api/boards/{boardId}/shapes`, `DELETE /api/boards/{boardId}/shapes/{itemId}`, `PUT /api/boards/{boardId}/shapes/{itemId}`, `GET /api/boards/{boardId}/shapes/{itemId}` | ⏳ Pending |
-| TagsController | `GET /api/boards/{boardId}/tags` | ⏳ Pending |
-| UsersController | `POST /api/users` | ⏳ Pending |
-| WebhookController | `POST /api/webhook` | ⏳ Pending |
+| BatchController | `POST /api/batch` | ✅ Migrated |
+| CacheController | `GET /api/cache/{boardId}` | ✅ Migrated |
+| CardsController | `POST /api/cards` | ✅ Migrated |
+| LogsController | `POST /api/logs` | ✅ Migrated |
+| OAuthController | `GET /oauth/login`, `GET /oauth/callback` | ✅ Migrated |
+| ShapesController | `POST /api/boards/{boardId}/shapes`, `DELETE /api/boards/{boardId}/shapes/{itemId}`, `PUT /api/boards/{boardId}/shapes/{itemId}`, `GET /api/boards/{boardId}/shapes/{itemId}` | ✅ Migrated |
+| TagsController | `GET /api/boards/{boardId}/tags` | ✅ Migrated |
+| UsersController | `POST /api/users` | ✅ Migrated |
+| WebhookController | `POST /api/webhook` | ✅ Migrated |

--- a/docs/python-architecture.md
+++ b/docs/python-architecture.md
@@ -31,6 +31,22 @@
 4. Repository reads from the SQLite cache; on a miss it fetches from the Miro API and updates the cache.
 5. Service returns DTOs to the router, which serialises the response back to the client.
 
+## API Endpoints
+
+- `GET /api/auth/status` – verify that OAuth tokens exist for the supplied `X-User-Id`.
+- `POST /api/batch` – enqueue a batch of board operations for asynchronous processing.
+- `GET /api/cache/{boardId}` – return the cached state for a board.
+- `POST /api/cards` – queue creation of multiple cards.
+- `POST /api/logs` – ingest client log entries for diagnostics.
+- `GET /oauth/login` / `GET /oauth/callback` – complete the OAuth handshake and persist tokens.
+- `GET /api/boards/{boardId}/shapes/{itemId}` – retrieve a shape owned by the caller.
+- `POST /api/boards/{boardId}/shapes` – create a new shape on a board.
+- `PUT /api/boards/{boardId}/shapes/{itemId}` – update an existing shape.
+- `DELETE /api/boards/{boardId}/shapes/{itemId}` – delete a shape.
+- `GET /api/boards/{boardId}/tags` – list all tags for a board.
+- `POST /api/users` – persist user tokens and metadata.
+- `POST /api/webhook` – accept webhook events from Miro for background processing.
+
 ## User Store
 
 - An in-memory, thread-safe store keeps OAuth tokens keyed by user ID. It acts as a

--- a/src/miro_backend/api/routers/cards.py
+++ b/src/miro_backend/api/routers/cards.py
@@ -2,20 +2,12 @@
 
 from __future__ import annotations
 
-import miro_backend.main as main
 from fastapi import APIRouter, Depends, status
-from typing import cast
 
-from ...queue import ChangeQueue
+from ...queue import ChangeQueue, get_change_queue
 from ...schemas.card_create import CardCreate
 
 router = APIRouter(prefix="/api/cards", tags=["cards"])
-
-
-def get_change_queue() -> ChangeQueue:
-    """Provide the application's change queue."""
-
-    return cast(ChangeQueue, main.change_queue)
 
 
 @router.post("", status_code=status.HTTP_202_ACCEPTED)  # type: ignore[misc]

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -1,7 +1,3 @@
-"""Application entry point."""
-
-from __future__ import annotations
-
 import asyncio
 import contextlib
 from contextlib import asynccontextmanager
@@ -13,33 +9,22 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
-from .api.routers.auth import router as auth_router
-from .api.routers.webhook import router as webhook_router
-from .api.routers.users import router as users_router
-from .api.routers.tags import router as tags_router
-from .api.routers.shapes import router as shapes_router
 from .queue import get_change_queue
 from .services.miro_client import MiroClient
 
-
 change_queue = get_change_queue()
-from .api.routers.oauth import router as oauth_router
-from .api.routers.logs import router as logs_router
-from .api.routers.cache import router as cache_router
-from .queue import ChangeQueue
-from .api.routers.batch import router as batch_router
-from .queue.provider import get_change_queue
-from .services.miro_client import MiroClient
-
-
-change_queue: ChangeQueue = ChangeQueue()
-change_queue = get_change_queue()
-
-"""Global queue used by the background worker."""
 
 # Routers are imported after the queue to avoid circular dependencies.
 from .api.routers.auth import router as auth_router  # noqa: E402
+from .api.routers.batch import router as batch_router  # noqa: E402
+from .api.routers.cache import router as cache_router  # noqa: E402
 from .api.routers.cards import router as cards_router  # noqa: E402
+from .api.routers.logs import router as logs_router  # noqa: E402
+from .api.routers.oauth import router as oauth_router  # noqa: E402
+from .api.routers.shapes import router as shapes_router  # noqa: E402
+from .api.routers.tags import router as tags_router  # noqa: E402
+from .api.routers.users import router as users_router  # noqa: E402
+from .api.routers.webhook import router as webhook_router  # noqa: E402
 
 
 @asynccontextmanager

--- a/src/miro_backend/queue/__init__.py
+++ b/src/miro_backend/queue/__init__.py
@@ -1,6 +1,7 @@
 """Queue utilities for processing board changes."""
 
 from .change_queue import ChangeQueue
+from .provider import get_change_queue
 from .tasks import (
     ChangeTask,
     CreateNode,
@@ -9,17 +10,6 @@ from .tasks import (
     UpdateShape,
     DeleteShape,
 )
-
-_queue = ChangeQueue()
-
-
-def get_change_queue() -> ChangeQueue:
-    """Provide the global change queue instance."""
-
-    return _queue
-
-from .provider import get_change_queue
-from .tasks import ChangeTask, CreateNode, UpdateCard
 
 __all__ = [
     "ChangeQueue",


### PR DESCRIPTION
## Summary
- deduplicate change queue provider and use it in card router
- document all FastAPI endpoints and mark migrations as complete

## Testing
- `poetry run pre-commit run --files docs/migration-tracker.md docs/python-architecture.md src/miro_backend/api/routers/cards.py src/miro_backend/queue/__init__.py src/miro_backend/main.py tests/test_cards_controller.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f9acb7370832b8cd487c04376b1df