### PR TITLE
feat(core): add configurable settings loader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,12 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        additional_dependencies: ["sqlalchemy", "pydantic"]
+        additional_dependencies: [
+          "sqlalchemy",
+          "pydantic",
+          "pydantic-settings",
+          "types-PyYAML",
+        ]
   - repo: local
     hooks:
       - id: pytest

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,8 @@
+# Example configuration for the Miro backend service
+# Copy to `config.yaml` and adjust values for your environment.
+database_url: sqlite:///./app.db
+cors_origins:
+  - "https://example.com"
+miro_client_id: your-client-id
+miro_client_secret: your-client-secret
+webhook_secret: change-me

--- a/poetry.lock
+++ b/poetry.lock
@@ -1481,6 +1481,30 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796"},
+    {file = "pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1886,6 +1910,18 @@ click = ">=8.0.0"
 rich = ">=10.11.0"
 shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250809"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_pyyaml-6.0.12.20250809-py3-none-any.whl", hash = "sha256:032b6003b798e7de1a1ddfeefee32fac6486bdfe4845e0ae0e7fb3ee4512b52f"},
+    {file = "types_pyyaml-6.0.12.20250809.tar.gz", hash = "sha256:af4a1aca028f18e75297da2ee0da465f799627370d74073e96fee876524f61b5"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -2344,4 +2380,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2fdf0a808437ca1e1988928206570c9ec7905af65f326c90e8d71b1e5f318ae5"
+content-hash = "d5e622c870e09689085676f74a00127a2035146d037379c194b19089f4599862"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ logfire = "^4.3.3"
 opentelemetry-instrumentation-fastapi = "^0.57b0"
 opentelemetry-instrumentation-sqlalchemy = "^0.57b0"
 opentelemetry-instrumentation-sqlite3 = "^0.57b0"
+pydantic-settings = "^2.10.1"
+pyyaml = "^6.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2"
@@ -26,6 +28,7 @@ pre-commit = "^3.7"
 httpx = "^0.27"
 pytest-cov = "^6.2.1"
 pytest-asyncio = "^1.1.0"
+types-pyyaml = "^6.0.12.20250809"
 
 [tool.black]
 line-length = 88

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -1,16 +1,66 @@
-"""Application configuration using pydantic settings."""
+"""Application configuration using environment variables and YAML files."""
 
-from pydantic import BaseModel, ConfigDict
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 
-class Settings(BaseModel):
-    """Defines application settings."""
+class Settings(BaseSettings):
+    """Defines runtime application settings."""
 
-    model_config = ConfigDict(extra="ignore")
-
-    app_name: str = "Miro Backend"
     database_url: str = "sqlite:///./app.db"
+    cors_origins: list[str] = ["*"]
+    miro_client_id: str = ""
+    miro_client_secret: str = ""
     webhook_secret: str = "dev-secret"
+
+    model_config = SettingsConfigDict(env_prefix="MIRO_", extra="ignore")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Load configuration from env vars with optional YAML file."""
+
+        return (
+            init_settings,
+            env_settings,
+            cast(PydanticBaseSettingsSource, cls._yaml_config_settings),
+            file_secret_settings,
+        )
+
+    @staticmethod
+    def _yaml_config_settings() -> dict[str, Any]:
+        """Read settings from a YAML file if it exists.
+
+        The path defaults to ``config.yaml`` but may be overridden by the
+        ``MIRO_CONFIG_FILE`` environment variable.
+        """
+
+        path_str = os.getenv("MIRO_CONFIG_FILE", "config.yaml")
+        path = Path(path_str)
+        if path.is_file():
+            with path.open(encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+                if not isinstance(data, dict):  # pragma: no cover - defensive
+                    raise ValueError("Configuration file must define a mapping")
+                return data
+        return {}
 
 
 settings = Settings()
+"""Singleton settings instance used throughout the application."""

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -1,5 +1,7 @@
+import argparse
 import asyncio
 import contextlib
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncIterator
@@ -11,8 +13,16 @@ from fastapi.staticfiles import StaticFiles
 
 import logfire
 
-from .queue import get_change_queue
-from .services.miro_client import MiroClient
+# Parse configuration file argument before importing modules that rely on it.
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--config")
+args, _ = parser.parse_known_args()
+if args.config:
+    os.environ["MIRO_CONFIG_FILE"] = args.config
+
+from .core.config import settings  # noqa: E402
+from .queue import get_change_queue  # noqa: E402
+from .services.miro_client import MiroClient  # noqa: E402
 
 change_queue = get_change_queue()
 
@@ -64,7 +74,7 @@ logfire.instrument_fastapi(app)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+"""Tests for application configuration loading."""
+
+from pathlib import Path
+
+import pytest
+
+from miro_backend.core.config import Settings
+
+
+def test_defaults_used_when_no_overrides() -> None:
+    """Defaults are applied when no env or file provided."""
+
+    settings = Settings()
+    assert settings.database_url == "sqlite:///./app.db"
+    assert settings.cors_origins == ["*"]
+
+
+def test_yaml_overrides_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Values from a YAML config file override defaults."""
+
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "database_url: sqlite:///yaml.db\ncors_origins:\n  - http://example.com\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MIRO_CONFIG_FILE", str(config))
+
+    settings = Settings()
+    assert settings.database_url == "sqlite:///yaml.db"
+    assert settings.cors_origins == ["http://example.com"]
+
+
+def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables take precedence over YAML config."""
+
+    config = tmp_path / "config.yaml"
+    config.write_text("database_url: sqlite:///yaml.db\n", encoding="utf-8")
+    monkeypatch.setenv("MIRO_CONFIG_FILE", str(config))
+    monkeypatch.setenv("MIRO_DATABASE_URL", "sqlite:///env.db")
+
+    settings = Settings()
+    assert settings.database_url == "sqlite:///env.db"


### PR DESCRIPTION
## Summary
- add BaseSettings-driven configuration with optional YAML source
- parse `--config` CLI flag and expose example `config.example.yaml`
- test configuration precedence of env vars over file defaults

## Testing
- `poetry run pre-commit run --files pyproject.toml poetry.lock src/miro_backend/core/config.py src/miro_backend/main.py config.example.yaml tests/test_config.py .pre-commit-config.yaml`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fe1f7b764832bb095460a3c1093e4