### PR TITLE
feat(core): add structured logging and error handling

### DIFF
--- a/src/miro_backend/api/routers/auth.py
+++ b/src/miro_backend/api/routers/auth.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from fastapi import APIRouter, Depends, Header, Response, status
+
+import logfire
+
+from ...core.exceptions import BadRequestError, NotFoundError
 
 from ...services.user_store import UserStore, get_user_store
 
@@ -16,15 +20,14 @@ def get_status(
     store: UserStore = Depends(get_user_store),
 ) -> Response:
     """Return 200 when tokens exist for the provided ``X-User-Id`` header."""
-
-    if user_id is None or user_id.strip() == "":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="X-User-Id header required",
-        )
-    if store.retrieve(user_id) is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User tokens not found",
-        )
-    return Response(status_code=status.HTTP_200_OK)
+    with logfire.span("auth status"):
+        if user_id is None or user_id.strip() == "":
+            logfire.warning("missing user id header")  # warn about absent user id
+            raise BadRequestError("X-User-Id header required")
+        if store.retrieve(user_id) is None:
+            logfire.warning(
+                "user tokens not found", user_id=user_id
+            )  # warn about missing tokens
+            raise NotFoundError("User tokens not found")
+        logfire.info("tokens verified", user_id=user_id)  # event when tokens exist
+        return Response(status_code=status.HTTP_200_OK)

--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, status
+import logfire
 
 from ...queue.change_queue import ChangeQueue
 from ...queue.provider import get_change_queue
@@ -18,5 +19,7 @@ async def post_batch(
 ) -> BatchResponse:
     """Validate ``request`` and enqueue its operations."""
 
-    count = await enqueue_operations(request.operations, queue)
-    return BatchResponse(enqueued=count)
+    with logfire.span("post batch"):
+        count = await enqueue_operations(request.operations, queue)
+        logfire.info("batch operations enqueued", count=count)  # event after enqueuing
+        return BatchResponse(enqueued=count)

--- a/src/miro_backend/api/routers/users.py
+++ b/src/miro_backend/api/routers/users.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
+import logfire
+
+from ...core.exceptions import ConflictError
 from sqlalchemy.orm import Session
 
 from ...db.session import get_session
@@ -17,19 +20,21 @@ router = APIRouter(prefix="/api/users", tags=["users"])
 def create_user(info: UserInfo, session: Session = Depends(get_session)) -> UserInfo:
     """Persist ``info`` and return it, rejecting duplicates."""
 
-    if session.query(User).filter_by(user_id=info.id).first() is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="User already exists",
-        )
+    with logfire.span("create user"):
+        if session.query(User).filter_by(user_id=info.id).first() is not None:
+            logfire.warning(
+                "user already exists", user_id=info.id
+            )  # warn when duplicate user
+            raise ConflictError("User already exists")
 
-    repo: Repository[User] = Repository(session, User)
-    user = User(
-        user_id=info.id,
-        name=info.name,
-        access_token=info.access_token,
-        refresh_token=info.refresh_token,
-        expires_at=info.expires_at,
-    )
-    repo.add(user)
-    return info
+        repo: Repository[User] = Repository(session, User)
+        user = User(
+            user_id=info.id,
+            name=info.name,
+            access_token=info.access_token,
+            refresh_token=info.refresh_token,
+            expires_at=info.expires_at,
+        )
+        repo.add(user)
+        logfire.info("user created", user_id=info.id)  # event after persisting user
+        return info

--- a/src/miro_backend/core/exceptions.py
+++ b/src/miro_backend/core/exceptions.py
@@ -1,0 +1,78 @@
+"""Application-specific exception types and handlers."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from starlette import status
+
+import logfire
+
+
+class ErrorResponse(BaseModel):
+    """Schema for error responses returned by handlers."""
+
+    code: str
+    message: str
+
+
+class AppError(Exception):
+    """Base class for application errors with HTTP semantics."""
+
+    status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR
+    code: str = "server_error"
+    message: str = "Internal server error"
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or self.message)
+        if message:
+            self.message = message
+
+
+class BadRequestError(AppError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "bad_request"
+
+
+class UnauthorizedError(AppError):
+    status_code = status.HTTP_401_UNAUTHORIZED
+    code = "unauthorized"
+
+
+class ForbiddenError(AppError):
+    status_code = status.HTTP_403_FORBIDDEN
+    code = "forbidden"
+
+
+class NotFoundError(AppError):
+    status_code = status.HTTP_404_NOT_FOUND
+    code = "not_found"
+
+
+class ConflictError(AppError):
+    status_code = status.HTTP_409_CONFLICT
+    code = "conflict"
+
+
+class PayloadTooLargeError(AppError):
+    status_code = status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    code = "payload_too_large"
+
+
+@logfire.instrument("handle app error")  # type: ignore[misc]
+async def handle_app_error(_: Request, exc: AppError) -> JSONResponse:
+    """Convert :class:`AppError` instances into JSON responses."""
+
+    # log structured details for the raised application error
+    logfire.warning(exc.message, code=exc.code)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=ErrorResponse(code=exc.code, message=exc.message).model_dump(),
+    )
+
+
+def add_exception_handlers(app: FastAPI) -> None:
+    """Register handlers for custom exceptions."""
+
+    app.add_exception_handler(AppError, handle_app_error)

--- a/src/miro_backend/core/logging.py
+++ b/src/miro_backend/core/logging.py
@@ -1,0 +1,43 @@
+"""Application logging configuration."""
+
+from __future__ import annotations
+
+import uuid
+
+import logfire
+from fastapi import FastAPI, Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+    """Attach a correlation ID to each request and log context."""
+
+    @logfire.instrument("request id middleware")  # type: ignore[misc]
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        with logfire.set_baggage(request_id=request_id):  # span to attach request id
+            response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
+@logfire.instrument("configure logging")  # type: ignore[misc]
+def configure_logging() -> None:
+    """Configure logfire and database instrumentation."""
+
+    logfire.configure(send_to_logfire=False, service_name="miro-backend")
+    from ..db.session import engine  # imported lazily
+
+    logfire.instrument_sqlite3()
+    logfire.instrument_sqlalchemy(engine)
+
+
+@logfire.instrument("setup fastapi")  # type: ignore[misc]
+def setup_fastapi(app: FastAPI) -> None:
+    """Instrument FastAPI and register request ID middleware."""
+
+    logfire.instrument_fastapi(app)
+    app.add_middleware(RequestIdMiddleware)

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,52 @@
+"""Tests for custom error handlers."""
+
+from __future__ import annotations
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+from miro_backend.db.session import Base, engine
+from miro_backend.queue import ChangeQueue
+from miro_backend.services.shape_store import get_shape_store
+
+
+def setup_module() -> None:
+    """Create database tables for tests."""
+
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_module() -> None:
+    """Drop database tables after tests."""
+
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_not_found_error_returns_typed_response() -> None:
+    """Missing resources should return structured 404 responses."""
+
+    app_module = importlib.import_module("miro_backend.main")
+    app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
+    with TestClient(app_module.app) as client:
+        response = client.get("/api/boards/999/tags")
+        assert response.status_code == 404
+        assert response.json() == {"code": "not_found", "message": "Board not found"}
+        assert "X-Request-ID" in response.headers
+
+
+def test_forbidden_error_returns_typed_response() -> None:
+    """Unauthorized access should return structured 403 responses."""
+
+    store = get_shape_store()
+    store.add_board("board1", "owner1")
+    app_module = importlib.import_module("miro_backend.main")
+    app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
+    with TestClient(app_module.app) as client:
+        response = client.get(
+            "/api/boards/board1/shapes/shape1",
+            headers={"X-User-Id": "other"},
+        )
+        assert response.status_code == 403
+        assert response.json() == {"code": "forbidden", "message": "Not board owner"}
+        assert "X-Request-ID" in response.headers


### PR DESCRIPTION
## Summary
- configure logfire with request correlation IDs
- add application exceptions with typed responses
- raise custom errors in routers and test handlers
- instrument logic branches with logfire spans and events

## Testing
- `poetry run pre-commit run --files src/miro_backend/api/routers/batch.py src/miro_backend/api/routers/cache.py src/miro_backend/api/routers/cards.py src/miro_backend/api/routers/logs.py src/miro_backend/api/routers/oauth.py src/miro_backend/api/routers/shapes.py src/miro_backend/api/routers/tags.py src/miro_backend/api/routers/users.py src/miro_backend/api/routers/webhook.py src/miro_backend/core/exceptions.py src/miro_backend/core/logging.py src/miro_backend/main.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe5481bb0832ba9e26af67e94a59c