### PR TITLE
feat: add metrics and telemetry integration

### DIFF
--- a/docs/python-architecture.md
+++ b/docs/python-architecture.md
@@ -72,6 +72,15 @@
 cs/alerts.
 - A global fallback handler reports unhandled exceptions and returns a 500 response without leaking internals.
 
+## Observability
+
+- Prometheus scrapes `GET /metrics` for request counters and latency histograms.
+- Traces are exported via OpenTelemetry using either OTLP or Jaeger exporters.
+- Configure collector endpoints with the following environment variables:
+  - `OTEL_EXPORTER_OTLP_ENDPOINT` – HTTP endpoint for an OTLP collector.
+  - `JAEGER_AGENT_HOST` / `JAEGER_AGENT_PORT` – Jaeger agent host and port.
+- Metrics, logs and traces share the same request ID for cohesive diagnostics through Logfire.
+
 ## Security
 
 - Enforce HTTPS and HSTS at the edge.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1328,6 +1328,37 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.1"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094"},
+    {file = "prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "6.1.0"
+description = "Instrument your FastAPI with Prometheus metrics."
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+groups = ["main"]
+files = [
+    {file = "prometheus_fastapi_instrumentator-6.1.0-py3-none-any.whl", hash = "sha256:2279ac1cf5b9566a4c3a07f78c9c5ee19648ed90976ab87d73d672abc1bfa017"},
+    {file = "prometheus_fastapi_instrumentator-6.1.0.tar.gz", hash = "sha256:1820d7a90389ce100f7d1285495ead388818ae0882e761c1f3e6e62a410bdf13"},
+]
+
+[package.dependencies]
+fastapi = ">=0.38.1,<1.0.0"
+prometheus-client = ">=0.8.0,<1.0.0"
+
+[[package]]
 name = "protobuf"
 version = "6.32.0"
 description = ""
@@ -2380,4 +2411,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d5e622c870e09689085676f74a00127a2035146d037379c194b19089f4599862"
+content-hash = "11d54c83083d842aeb00e0f8e3a7f39b2b0812d6628dff4af68f93f86535e4ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ logfire = "^4.3.3"
 opentelemetry-instrumentation-fastapi = "^0.57b0"
 opentelemetry-instrumentation-sqlalchemy = "^0.57b0"
 opentelemetry-instrumentation-sqlite3 = "^0.57b0"
+prometheus-fastapi-instrumentator = "^6.1.0"
 pydantic-settings = "^2.10.1"
 pyyaml = "^6.0.2"
 

--- a/src/miro_backend/core/telemetry.py
+++ b/src/miro_backend/core/telemetry.py
@@ -1,0 +1,62 @@
+"""OpenTelemetry configuration for the application."""
+
+from __future__ import annotations
+
+import os
+from importlib import import_module
+from typing import Any
+
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from ..db.session import engine
+
+JaegerExporter: Any
+OTLPSpanExporter: Any
+try:  # pragma: no cover - optional dependency
+    JaegerExporter = import_module(
+        "opentelemetry.exporter.jaeger.thrift"
+    ).JaegerExporter
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    JaegerExporter = None
+
+try:  # pragma: no cover - optional dependency
+    OTLPSpanExporter = import_module(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+    ).OTLPSpanExporter
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    OTLPSpanExporter = None
+
+
+def setup_telemetry(app: FastAPI) -> None:
+    """Configure exporters and instrument the application."""
+
+    resource = Resource.create({"service.name": "miro-backend"})
+    provider = TracerProvider(resource=resource)
+
+    otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if otlp_endpoint and OTLPSpanExporter is not None:
+        provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint))
+        )
+
+    jaeger_host = os.getenv("JAEGER_AGENT_HOST")
+    if jaeger_host and JaegerExporter is not None:
+        jaeger_port = int(os.getenv("JAEGER_AGENT_PORT", "6831"))
+        provider.add_span_processor(
+            BatchSpanProcessor(
+                JaegerExporter(agent_host_name=jaeger_host, agent_port=jaeger_port)
+            )
+        )
+
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor.instrument_app(app)
+    SQLAlchemyInstrumentor().instrument(engine=engine)
+    SQLite3Instrumentor().instrument()

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,42 @@
+"""Integration tests for Prometheus metrics."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from miro_backend.queue import ChangeQueue
+
+
+def test_metrics_increment(tmp_path: Path) -> None:
+    """Metrics endpoint should expose request counters."""
+
+    static_dir = Path(__file__).resolve().parent.parent / "web" / "client" / "dist"
+    static_dir.mkdir(parents=True, exist_ok=True)
+
+    app_module = importlib.import_module("miro_backend.main")
+    app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
+    with TestClient(app_module.app) as client:
+
+        def count() -> float:
+            metrics = client.get("/metrics").text
+            for line in metrics.splitlines():
+                if (
+                    line.startswith(
+                        'http_requests_total{handler="/health",method="GET"'
+                    )
+                    and 'status="2xx"' in line
+                ):
+                    return float(line.split()[-1])
+            return 0.0
+
+        start = count()
+        client.get("/health")
+        after_first = count()
+        assert after_first == start + 1
+
+        client.get("/health")
+        after_second = count()
+        assert after_second == start + 2


### PR DESCRIPTION
## Summary
- expose Prometheus metrics at `/metrics` and log scrapes
- wire optional OTLP and Jaeger exporters with FastAPI and SQLAlchemy
- document observability setup and environment variables
- test metrics endpoint increments request counters

## Testing
- `poetry run pre-commit run --files src/miro_backend/main.py src/miro_backend/core/telemetry.py docs/python-architecture.md tests/test_metrics_endpoint.py pyproject.toml poetry.lock`
- `poetry run pytest --no-cov tests/test_metrics_endpoint.py tests/test_health.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68a003fd7214832ba0e5b72934fccd35