### PR TITLE
feat: enforce https and load secrets from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+MIRO_CLIENT_ID=your-client-id
+MIRO_CLIENT_SECRET=your-client-secret
+MIRO_WEBHOOK_SECRET=change-me

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,8 +3,8 @@
 database_url: sqlite:///./app.db
 cors_origins:
   - "https://example.com"
-miro_client_id: your-client-id
-miro_client_secret: your-client-secret
+client_id: your-client-id
+client_secret: your-client-secret
 webhook_secret: change-me
 logfire_service_name: miro-backend
 logfire_send_to_logfire: false

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,3 +24,19 @@ Upload `web/client/dist/` to your static host (e.g., Vercel, Netlify or S3).
 - `LOG_LEVEL`
 
 See your hosting provider's documentation for setting environment variables. CI/CD and monitoring hooks are described in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## 4. Backend Secrets
+
+The FastAPI backend loads required secrets from environment variables or an `.env` file via `pydantic-settings`.
+
+### Local development
+
+On first run the backend will create `.env` and `config.yaml` from their example files and exit.
+Populate `.env` with values for:
+   - `MIRO_CLIENT_ID`
+   - `MIRO_CLIENT_SECRET`
+   - `MIRO_WEBHOOK_SECRET`
+
+### Continuous integration
+
+Provision the same variables through your CI secret store (e.g. GitHub Actions secrets) and expose them as environment variables at build and deploy time. Never commit real secret values to the repository.

--- a/src/miro_backend/api/routers/webhook.py
+++ b/src/miro_backend/api/routers/webhook.py
@@ -45,7 +45,7 @@ async def post_webhook(
         body = await request.body()
         with logfire.span("verify signature"):
             if signature is None or not _verify_signature(
-                settings.webhook_secret, body, signature
+                settings.webhook_secret.get_secret_value(), body, signature
             ):
                 logfire.warning(
                     "invalid webhook signature"

--- a/src/miro_backend/core/security.py
+++ b/src/miro_backend/core/security.py
@@ -1,0 +1,26 @@
+"""Security-related middleware and helpers."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import RedirectResponse, Response
+
+
+class ProxyHttpsRedirectMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+    """Redirect HTTP requests to HTTPS using ``X-Forwarded-Proto``."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        proto = request.headers.get("X-Forwarded-Proto")
+        if proto == "http":
+            url = request.url.replace(scheme="https")
+            return RedirectResponse(str(url), status_code=307)
+        return await call_next(request)
+
+
+def setup_security(app: FastAPI) -> None:
+    """Register security middleware."""
+
+    app.add_middleware(ProxyHttpsRedirectMiddleware)

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -25,6 +25,7 @@ if args.config:
 from .core.config import settings  # noqa: E402
 from .core.exceptions import add_exception_handlers  # noqa: E402
 from .core.logging import configure_logging, setup_fastapi  # noqa: E402
+from .core.security import setup_security  # noqa: E402
 from .core.telemetry import setup_telemetry  # noqa: E402
 from .queue import get_change_queue  # noqa: E402
 from .services.miro_client import MiroClient  # noqa: E402
@@ -69,6 +70,7 @@ app = FastAPI(lifespan=lifespan)
 
 # Instrument FastAPI and register middleware and handlers
 setup_fastapi(app)
+setup_security(app)
 setup_telemetry(app)
 add_exception_handlers(app)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# Provide required secrets for configuration during tests.
+os.environ["MIRO_CLIENT_ID"] = "test-client-id"
+os.environ["MIRO_CLIENT_SECRET"] = "test-client-secret"
+os.environ["MIRO_WEBHOOK_SECRET"] = "test-webhook-secret"

--- a/tests/test_https_redirect.py
+++ b/tests/test_https_redirect.py
@@ -1,0 +1,29 @@
+"""Tests for HTTPS redirect middleware."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from miro_backend.core.security import ProxyHttpsRedirectMiddleware
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(ProxyHttpsRedirectMiddleware)
+
+    @app.get("/")  # type: ignore[misc]
+    async def root() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+def test_http_request_redirects_to_https() -> None:
+    """Requests with ``X-Forwarded-Proto: http`` are redirected to HTTPS."""
+
+    client = TestClient(create_app())
+    response = client.get(
+        "/", headers={"X-Forwarded-Proto": "http"}, follow_redirects=False
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://testserver/"

--- a/tests/test_webhook_controller.py
+++ b/tests/test_webhook_controller.py
@@ -18,7 +18,8 @@ from miro_backend.schemas.webhook import WebhookEvent, WebhookPayload
 
 
 def _sign(body: bytes) -> str:
-    return hmac.new(settings.webhook_secret.encode(), body, hashlib.sha256).hexdigest()
+    secret = settings.webhook_secret.get_secret_value().encode()
+    return hmac.new(secret, body, hashlib.sha256).hexdigest()
 
 
 # mypy struggles with pytest decorators


### PR DESCRIPTION
## Summary
- load required secrets via pydantic-settings from an `.env` file
- redirect HTTP requests to HTTPS when `X-Forwarded-Proto` is `http`
- document secret provisioning for local and CI environments
- generate default `.env` and `config.yaml` files when missing

## Testing
- `poetry run pre-commit run --files src/miro_backend/core/config.py tests/test_config.py docs/DEPLOYMENT.md`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a017885be0832ba8e57eb2dfcebf4e