### PR TITLE
Add async HTTPX integration tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,37 @@
+# Testing Guide
+
+This project uses **pytest** for unit and integration tests. Integration tests run the
+application with full startup and shutdown behaviour and exercise real HTTP
+interactions.
+
+## Writing integration tests
+
+Integration tests live under `tests/integration/` and are marked with
+`@pytest.mark.integration`. The shared fixtures spin up the FastAPI app using
+its lifespan events and expose an `httpx.AsyncClient` backed by
+`ASGITransport` for exercising routes. A dummy queue is also provided for
+asserting background side-effects.
+
+```python
+import pytest
+from httpx import AsyncClient
+from .conftest import DummyQueue
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_shape(client_queue: tuple[AsyncClient, DummyQueue]) -> None:
+    client, queue = client_queue
+    # Arrange test state
+    ...
+    # Act on the API
+    response = await client.post("/api/resource", json={"content": "box"})
+    # Assert on response and queued side-effects
+    assert response.status_code == 201
+    assert len(queue.tasks) == 1
+```
+
+Run only the integration tests with:
+
+```bash
+poetry run pytest -m integration
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,7 @@
 addopts = --cov=src/miro_backend --cov-report=term --cov-report=xml --cov-fail-under=90
 pythonpath = src
 testpaths = tests
+markers =
+    integration: integration tests requiring app startup
 filterwarnings =
     ignore:Please use `import python_multipart` instead.:PendingDeprecationWarning

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,52 @@
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+
+from miro_backend.main import app
+from miro_backend.queue import provider as queue_provider
+
+
+class DummyQueue:
+    """Queue implementation that records enqueued tasks."""
+
+    def __init__(self) -> None:
+        self.tasks: list[object] = []
+
+    async def enqueue(self, task: object) -> None:
+        self.tasks.append(task)
+
+    async def worker(self, _client: object) -> None:  # pragma: no cover - never returns
+        await asyncio.Event().wait()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Run startup and shutdown events for ``app``."""
+
+    async with app.router.lifespan_context(app):
+        yield
+
+
+# ``pytest_asyncio`` is untyped; ignore to keep fixtures checked.
+@pytest_asyncio.fixture  # type: ignore[misc]
+async def client_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[tuple[httpx.AsyncClient, DummyQueue]]:
+    """Yield an ``AsyncClient`` connected to the app and the dummy queue."""
+
+    queue = DummyQueue()
+    # Replace the global queue used by the app and dependency provider
+    monkeypatch.setattr(queue_provider, "_change_queue", queue, raising=False)
+    monkeypatch.setattr("miro_backend.main.change_queue", queue, raising=False)
+
+    async with lifespan(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            yield client, queue

--- a/tests/integration/test_shapes.py
+++ b/tests/integration/test_shapes.py
@@ -1,0 +1,42 @@
+"""Integration tests for shape routes."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from typing import TYPE_CHECKING
+
+from miro_backend.queue.tasks import CreateShape
+from miro_backend.schemas.shape import ShapeCreate
+from miro_backend.services.shape_store import get_shape_store
+
+if TYPE_CHECKING:
+    from .conftest import DummyQueue
+
+
+@pytest.mark.integration  # type: ignore[misc]
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_create_shape_enqueues_task(
+    client_queue: tuple[httpx.AsyncClient, "DummyQueue"]
+) -> None:
+    """Creating a shape should persist it and enqueue a change task."""
+
+    client, queue = client_queue
+    store = get_shape_store()
+    store.add_board("b1", "user-1")
+
+    payload = ShapeCreate(content="box").model_dump()
+    response = await client.post(
+        "/api/boards/b1/shapes/",
+        headers={"X-User-Id": "user-1"},
+        json=payload,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["content"] == "box"
+    assert len(queue.tasks) == 1
+    task = queue.tasks[0]
+    assert isinstance(task, CreateShape)
+    assert task.board_id == "b1"
+    assert task.shape_id == data["id"]

--- a/tests/integration/test_tags.py
+++ b/tests/integration/test_tags.py
@@ -1,0 +1,41 @@
+"""Integration tests for tag routes."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from typing import TYPE_CHECKING
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.models import Board, Tag
+
+if TYPE_CHECKING:
+    from .conftest import DummyQueue
+
+
+@pytest.mark.integration  # type: ignore[misc]
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_list_tags_sorted(
+    client_queue: tuple[httpx.AsyncClient, "DummyQueue"]
+) -> None:
+    """The endpoint should return tags sorted alphabetically."""
+
+    client, _queue = client_queue
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    board = Board(name="test-board")
+    session.add(board)
+    session.commit()
+    board_id = int(board.id)
+    session.add_all(
+        [Tag(board_id=board_id, name="beta"), Tag(board_id=board_id, name="alpha")]
+    )
+    session.commit()
+    session.close()
+
+    response = await client.get(f"/api/boards/{board_id}/tags")
+    Base.metadata.drop_all(bind=engine)
+    assert response.status_code == 200
+    data = response.json()
+    assert [item["name"] for item in data] == ["alpha", "beta"]


### PR DESCRIPTION
## Summary
- add httpx.AsyncClient integration fixtures using lifespan
- cover shape creation and tag listing via full request/response cycles
- document integration testing patterns

## Testing
- `poetry run pre-commit run --files tests/integration/conftest.py tests/integration/test_shapes.py tests/integration/test_tags.py docs/testing.md pytest.ini`
- `poetry run pytest tests/integration -m integration --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a024533184832b9d0d0d655565e0b5