### PR TITLE
docs: update caching strategy and python TODOs

### DIFF
--- a/docs/MIRO_API_COSTS.md
+++ b/docs/MIRO_API_COSTS.md
@@ -23,9 +23,9 @@ Excessive use quickly exhausts the daily rate limit.
 
 ## 2 Design Decisions
 
-1. **Server‑side shape management** – Widget creation, update and deletion are performed by `ShapesController` in the .NET server. The client calls `/api/boards/{boardId}/shapes` via `ShapeClient`.
+1. **Server‑side shape management** – Widget creation, update and deletion are handled by the **FastAPI Shapes router**. The client calls `/api/boards/{boardId}/shapes` via `ShapeClient`.
 2. **In‑memory shape cache** – `IShapeCache` stores widgets by board and item identifier. Controllers update the cache after every change so lookups avoid `board.get` or `item` requests.
-3. **Planned persistent cache** – future versions will back the cache with Redis and **PostgreSQL** via **Entity Framework Core** so multiple server instances share widget data.
+3. **Planned persistent cache** – future versions will back the cache with Redis and **SQLite** via **SQLAlchemy** so multiple server instances share widget data.
 4. **Centralised logging** – `HttpLogSink` forwards front‑end log entries to the server so shape operations are traceable across the boundary.
 5. **Avoid direct board calls** – Front‑end modules now contain TODOs to replace remaining direct Web SDK calls (`board.getSelection`, `board.get`) with cached lookups.
 6. **Expanded REST coverage** – placeholder shim methods will wrap additional Miro endpoints so future features can reuse a consistent API layer.

--- a/docs/TWO_TIER_TODOS.md
+++ b/docs/TWO_TIER_TODOS.md
@@ -1,25 +1,26 @@
 # Two-Tier Architecture TODOs
 
-This document tracks outstanding tasks needed to optimise the add-on around a thin client and feature-rich .NET backend.
+This document tracks outstanding tasks needed to optimise the add-on around a thin client and feature-rich **FastAPI** backend.
 
 ## Data Model
-- [ ] Build a shared DTO layer compiled to both TypeScript and C#.
-- [ ] Persist board state in a **PostgreSQL** database managed via **Entity Framework Core** and expose typed REST endpoints.
-- [ ] Research open-source .NET clients for the Miro REST API or auto-generate one.
+- [ ] Build a shared DTO layer using **Pydantic** models and generate matching TypeScript types.
+- [ ] Persist board state in a **SQLite** database managed via **SQLAlchemy** and expose typed REST endpoints.
+- [ ] Research open-source Python clients for the Miro REST API or auto-generate one.
 
 ## Queueing and Persistence
-- [ ] Extend `ShapeQueueProcessor` with modify/delete queues and durable storage.
-- [ ] Persist queue entries in a database and expose an inspection API.
-- [ ] Cover queue behaviour with integration tests once persistence exists.
+- [ ] Extend the Python `ShapeQueueProcessor` with modify/delete queues and durable storage.
+- [ ] Persist queue entries in the database and expose an inspection API.
+- [ ] Cover queue behaviour with **pytest** integration tests once persistence exists.
 
 ## OAuth Flow
-- [ ] Implement full OAuth exchange using `AspNet.Security.OAuth.Miro`.
-- [ ] Store refreshed tokens via an ORM-backed `IUserStore`.
+- [ ] Implement full OAuth exchange using **Authlib**.
+- [ ] Store refreshed tokens via a SQLAlchemy-backed `UserStore`.
 - [ ] Add tests for token renewal and failure modes.
 
 ## Layout Engine
-- [ ] Evaluate .NET ports or cross-compilation of the Eclipse Layout Kernel.
+- [ ] Evaluate Python ports or FFI bindings for the Eclipse Layout Kernel.
 - [ ] Keep layout algorithms consistent across tiers.
-- [ ] Investigate **IKVM** as a path to run the Java-based ELK library on .NET.
+- [ ] Investigate running the Java-based ELK library via **JPype** or other bridging technologies.
 
 These tasks expand upon the TODO markers found throughout the source.
+


### PR DESCRIPTION
## Summary
- Clarify caching design to point to FastAPI Shapes router and SQLite/SQLAlchemy persistence
- Rewrite two-tier TODOs to outline Python-focused follow-ups

## Testing
- `poetry run pre-commit run --files docs/MIRO_API_COSTS.md docs/TWO_TIER_TODOS.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0634bcaec832bab0abece2a1053ab