### PR TITLE
test(client): migrate jest mocks to vi

### DIFF
--- a/web/client/package-lock.json
+++ b/web/client/package-lock.json
@@ -38,7 +38,6 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3-dsv": "^3.0.7",
-        "@types/jest": "^30.0.0",
         "@types/node": "^24.1.0",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -1842,118 +1841,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.5.tgz",
-      "integrity": "sha512-F3lmTT7CXWYywoVUGTCmom0vXq3HTTkaZyTAzIy+bXSBizB7o5qzlC9VCtq0arOa8GqmNsbg/cE9C6HLn7Szew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/get-type": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
-      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
-      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
@@ -10814,13 +10701,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.38",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
-      "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -11713,66 +11593,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^30.0.0",
-        "pretty-format": "^30.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -11911,13 +11731,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
@@ -11932,23 +11745,6 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13269,22 +13065,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
-      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -15338,24 +15118,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/expect": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
-      "integrity": "sha512-P0te2pt+hHI5qLJkIR+iMvS+lYUZml8rKKsohVHAGY+uClp9XVbdyYNJOIjSRpHVp8s8YqxJCiHUkSYZGr8rtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.0.5",
-        "@jest/get-type": "30.0.1",
-        "jest-matcher-utils": "30.0.5",
-        "jest-message-util": "30.0.5",
-        "jest-mock": "30.0.5",
-        "jest-util": "30.0.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -17403,300 +17165,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
-      "integrity": "sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.0.1",
-        "@jest/get-type": "30.0.1",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.0.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
-      "integrity": "sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.0.1",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.0.5",
-        "pretty-format": "30.0.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.5.tgz",
-      "integrity": "sha512-NAiDOhsK3V7RU0Aa/HnrQo+E4JlbarbmI3q6Pi4KcxicdtjV82gcIUrejOtczChtVQR4kddu1E1EJlW6EN9IyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.0.5",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "micromatch": "^4.0.8",
-        "pretty-format": "30.0.5",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
-      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-mock": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
-      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.0.5",
-        "@types/node": "*",
-        "jest-util": "30.0.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
-      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.0.5",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-util/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jiti": {
@@ -24069,29 +23537,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/stackback": {

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -63,7 +63,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3-dsv": "^3.0.7",
-    "@types/jest": "^30.0.0",
     "@types/node": "^24.1.0",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/web/client/tests/app-ui-options.test.ts
+++ b/web/client/tests/app-ui-options.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { App } from '../src/app/App';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
@@ -14,7 +14,7 @@ function selectFile(): File {
 
 describe('App layout options and undo button', () => {
   test('updates layout options and passes them to processor', async () => {
-    const procSpy = jest
+    const procSpy = vi
       .spyOn(GraphProcessor.prototype, 'processFile')
       .mockResolvedValue(undefined);
     render(React.createElement(App));

--- a/web/client/tests/app-ui.test.ts
+++ b/web/client/tests/app-ui.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { colors } from '@mirohq/design-tokens';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { App } from '../src/app/App';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
@@ -17,13 +17,13 @@ describe('App UI integration', () => {
   beforeEach(() => {
     global.miro = {
       board: {
-        notifications: { showError: jest.fn().mockResolvedValue(undefined) },
+        notifications: { showError: vi.fn().mockResolvedValue(undefined) },
       },
     };
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
@@ -35,7 +35,7 @@ describe('App UI integration', () => {
   }
 
   test('renders and processes diagram file', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(GraphProcessor.prototype, 'processFile')
       .mockResolvedValue(undefined);
     render(React.createElement(App));
@@ -60,8 +60,8 @@ describe('App UI integration', () => {
 
   test('shows error notification', async () => {
     const error = new Error('fail');
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const spy = jest
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const spy = vi
       .spyOn(GraphProcessor.prototype, 'processFile')
       .mockRejectedValue(error);
     render(React.createElement(App));
@@ -76,7 +76,7 @@ describe('App UI integration', () => {
   });
 
   test('withFrame option forwards frame title', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(GraphProcessor.prototype, 'processFile')
       .mockResolvedValue(undefined);
     render(React.createElement(App));
@@ -99,8 +99,8 @@ describe('App UI integration', () => {
   });
 
   test('undoLastImport helper calls undo and clears state', async () => {
-    const proc = { undoLast: jest.fn().mockResolvedValue(undefined) } as {
-      undoLast: jest.Mock;
+    const proc = { undoLast: vi.fn().mockResolvedValue(undefined) } as {
+      undoLast: vi.Mock;
     };
     let cleared = false;
     await undoLastImport(proc, () => {

--- a/web/client/tests/arrange-tab.test.tsx
+++ b/web/client/tests/arrange-tab.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import * as grid from '../src/board/grid-tools';
 import * as spacing from '../src/board/spacing-tools';

--- a/web/client/tests/board-utils.test.ts
+++ b/web/client/tests/board-utils.test.ts
@@ -11,8 +11,8 @@ describe('forEachSelection', () => {
   describe('callback invocation', () =>
     test('invokes callback once per item', async () => {
       const items = [{ a: 1 }, { b: 2 }];
-      const board = { getSelection: jest.fn().mockResolvedValue(items) };
-      const cb = jest.fn();
+      const board = { getSelection: vi.fn().mockResolvedValue(items) };
+      const cb = vi.fn();
       await forEachSelection(cb, board);
       expect(cb).toHaveBeenCalledTimes(items.length);
       expect(cb).toHaveBeenNthCalledWith(1, items[0]);
@@ -21,7 +21,7 @@ describe('forEachSelection', () => {
 
   describe('error propagation', () =>
     test('rejects when callback throws', async () => {
-      const board = { getSelection: jest.fn().mockResolvedValue([{}]) };
+      const board = { getSelection: vi.fn().mockResolvedValue([{}]) };
       await expect(
         forEachSelection(() => {
           throw new Error('fail');
@@ -32,7 +32,7 @@ describe('forEachSelection', () => {
 
 describe('maybeSync', () => {
   test('invokes sync when present', async () => {
-    const item = { sync: jest.fn() };
+    const item = { sync: vi.fn() };
     await maybeSync(item);
     expect(item.sync).toHaveBeenCalled();
   });
@@ -44,13 +44,13 @@ describe('maybeSync', () => {
 describe('getFirstSelection', () => {
   test('returns first selected item', async () => {
     const items = [{ a: 1 }, { b: 2 }];
-    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const board = { getSelection: vi.fn().mockResolvedValue(items) };
     const result = await getFirstSelection(board);
     expect(result).toBe(items[0]);
   });
 
   test('returns undefined when selection empty', async () => {
-    const board = { getSelection: jest.fn().mockResolvedValue([]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([]) };
     const result = await getFirstSelection(board);
     expect(result).toBeUndefined();
   });

--- a/web/client/tests/boardbuilder-remove.test.ts
+++ b/web/client/tests/boardbuilder-remove.test.ts
@@ -8,12 +8,12 @@ declare const global: GlobalWithMiro;
 
 describe('BoardBuilder.removeItems', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
   test('removes provided items from board', async () => {
-    const remove = jest.fn();
+    const remove = vi.fn();
     global.miro = { board: { remove } };
     const builder = new BoardBuilder();
     const items = [{}, {}];

--- a/web/client/tests/button-icon.test.tsx
+++ b/web/client/tests/button-icon.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { Button } from '../src/ui/components/Button';
 

--- a/web/client/tests/button-size.test.tsx
+++ b/web/client/tests/button-size.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { Button } from '../src/ui/components/Button';
 

--- a/web/client/tests/card-load.test.ts
+++ b/web/client/tests/card-load.test.ts
@@ -6,7 +6,7 @@ interface ReaderEvent {
 
 describe('loadCards', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete (global as { FileReader?: unknown }).FileReader;
   });
 

--- a/web/client/tests/card-normalize.test.ts
+++ b/web/client/tests/card-normalize.test.ts
@@ -10,7 +10,7 @@ interface ReaderEvent {
 
 describe('CardLoader normalization', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete (global as { FileReader?: unknown }).FileReader;
   });
 

--- a/web/client/tests/cards-tab-branches.test.tsx
+++ b/web/client/tests/cards-tab-branches.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { CardProcessor } from '../src/board/card-processor';
 import { CardsTab } from '../src/ui/pages/CardsTab';

--- a/web/client/tests/cards-tab-undo.test.tsx
+++ b/web/client/tests/cards-tab-undo.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { CardProcessor } from '../src/board/card-processor';
 import * as uiUtils from '../src/ui/hooks/ui-utils';

--- a/web/client/tests/checkbox.test.tsx
+++ b/web/client/tests/checkbox.test.tsx
@@ -1,10 +1,9 @@
 /**
  * Integration test for the Checkbox component.
  *
- * @jest-environment jsdom
  */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { Checkbox } from '../src/ui/components/Checkbox';
 
@@ -22,7 +21,7 @@ test('renders label connected via htmlFor', () => {
 });
 
 test('triggers onChange when toggled on', () => {
-  const handler = jest.fn();
+  const handler = vi.fn();
   render(
     <Checkbox
       label='Option'
@@ -36,7 +35,7 @@ test('triggers onChange when toggled on', () => {
 });
 
 test('triggers onChange when toggled off', () => {
-  const handler = jest.fn();
+  const handler = vi.fn();
   render(
     <Checkbox
       label='Option'

--- a/web/client/tests/diagram-app.test.ts
+++ b/web/client/tests/diagram-app.test.ts
@@ -11,7 +11,7 @@ declare const global: GlobalWithMiro;
  */
 describe('DiagramApp', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
@@ -22,8 +22,8 @@ describe('DiagramApp', () => {
   });
 
   test('init registers handlers and opens panel for commands', async () => {
-    const openPanel = jest.fn().mockResolvedValue(undefined);
-    const on = jest.fn((e: string, cb: () => Promise<void>) => {
+    const openPanel = vi.fn().mockResolvedValue(undefined);
+    const on = vi.fn((e: string, cb: () => Promise<void>) => {
       if (e === 'icon:click' || e === 'custom:edit-metadata') {
         cb();
       }

--- a/web/client/tests/diagram-tab-advanced.test.tsx
+++ b/web/client/tests/diagram-tab-advanced.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { StructuredTab } from '../src/ui/pages/StructuredTab';
 

--- a/web/client/tests/diagram-tab-existing.test.tsx
+++ b/web/client/tests/diagram-tab-existing.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
 import { DiagramsTab } from '../src/ui/pages/DiagramsTab';

--- a/web/client/tests/diagrams-tab-switch.test.tsx
+++ b/web/client/tests/diagrams-tab-switch.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { DiagramsTab } from '../src/ui/pages/DiagramsTab';
 

--- a/web/client/tests/diagrams-tab.test.tsx
+++ b/web/client/tests/diagrams-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
 import { DiagramsTab } from '../src/ui/pages/DiagramsTab';
@@ -17,11 +17,11 @@ describe('DiagramsTab', () => {
   afterEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).miro;
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test('processes diagram file', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(GraphProcessor.prototype, 'processFile')
       .mockResolvedValue(undefined as unknown as void);
     render(<DiagramsTab />);

--- a/web/client/tests/dummy-tab.test.tsx
+++ b/web/client/tests/dummy-tab.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { DummyTab, tabDef } from '../src/ui/pages/DummyTab';
 

--- a/web/client/tests/edges.test.ts
+++ b/web/client/tests/edges.test.ts
@@ -12,13 +12,13 @@ describe('createEdges', () => {
   beforeEach(() => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        createConnector: jest
+        get: vi.fn().mockResolvedValue([]),
+        createConnector: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'c1',
             start: {},
             end: {},
@@ -28,7 +28,7 @@ describe('createEdges', () => {
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     graphService.resetBoardCache();
   });
 
@@ -56,7 +56,7 @@ describe('createEdges', () => {
     );
     expect(connectors).toHaveLength(1);
     expect(global.miro.board.createConnector).toHaveBeenCalled();
-    const args = (global.miro.board.createConnector as jest.Mock).mock
+    const args = (global.miro.board.createConnector as vi.Mock).mock
       .calls[0][0];
     expect(args.style).toBeDefined();
   });
@@ -91,7 +91,7 @@ describe('createEdges', () => {
       nodeMap,
       [hint as unknown],
     );
-    const args = (global.miro.board.createConnector as jest.Mock).mock
+    const args = (global.miro.board.createConnector as vi.Mock).mock
       .calls[0][0];
     expect(args.start.position).toEqual(hint.startPosition);
     expect(args.end.position).toEqual(hint.endPosition);
@@ -107,7 +107,7 @@ describe('createEdges', () => {
       edges as unknown as Array<{ from: string; to: string; label?: string }>,
       nodeMap,
     );
-    const args = (global.miro.board.createConnector as jest.Mock).mock
+    const args = (global.miro.board.createConnector as vi.Mock).mock
       .calls[0][0];
     expect(args.captions?.[0].content).toBe('L');
   });

--- a/web/client/tests/excel-tab-branches.test.tsx
+++ b/web/client/tests/excel-tab-branches.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 /* eslint-disable no-var */
 import React from 'react';
 import { ExcelTab } from '../src/ui/pages/ExcelTab';

--- a/web/client/tests/excel-tab.test.tsx
+++ b/web/client/tests/excel-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 /* eslint-disable no-var */
 import React from 'react';
 import { ExcelTab } from '../src/ui/pages/ExcelTab';

--- a/web/client/tests/file-utils.test.ts
+++ b/web/client/tests/file-utils.test.ts
@@ -6,14 +6,14 @@ interface ReaderEvent {
 
 describe('file utils', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete (global as { FileReader?: unknown }).FileReader;
   });
 
   test('readFileAsText uses text method when available', async () => {
     const file = {
       name: 'file.txt',
-      text: jest.fn().mockResolvedValue('abc'),
+      text: vi.fn().mockResolvedValue('abc'),
     } as unknown as File;
     const result = await fileUtils.readFileAsText(file);
     expect(result).toBe('abc');

--- a/web/client/tests/filter-dropdown.test.tsx
+++ b/web/client/tests/filter-dropdown.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { FilterDropdown } from '../src/ui/components/FilterDropdown';
 

--- a/web/client/tests/form-group.test.tsx
+++ b/web/client/tests/form-group.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { FormGroup } from '../src/ui/components/FormGroup';
 

--- a/web/client/tests/format-tools.test.ts
+++ b/web/client/tests/format-tools.test.ts
@@ -14,8 +14,8 @@ describe('format-tools', () => {
   };
 
   test('applyStylePreset updates style', async () => {
-    const item = { style: {}, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { style: {}, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await applyStylePreset(preset, board);
     expect(item.style).toEqual({
       color: preset.fontColor,
@@ -27,8 +27,8 @@ describe('format-tools', () => {
   });
 
   test('applyStylePreset handles items without style', async () => {
-    const item = { sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await applyStylePreset(preset, board);
     expect(item.style).toEqual({
       color: preset.fontColor,

--- a/web/client/tests/frame-tools.test.ts
+++ b/web/client/tests/frame-tools.test.ts
@@ -9,11 +9,11 @@ describe('frame-tools', () => {
   beforeEach(() => boardCache.reset());
   test('renameSelectedFrames updates titles in order', async () => {
     const frames = [
-      { x: 20, y: 0, title: 'old', sync: jest.fn(), type: 'frame' },
-      { x: 10, y: 0, title: 'old2', sync: jest.fn(), type: 'frame' },
+      { x: 20, y: 0, title: 'old', sync: vi.fn(), type: 'frame' },
+      { x: 10, y: 0, title: 'old2', sync: vi.fn(), type: 'frame' },
     ];
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(frames),
+      getSelection: vi.fn().mockResolvedValue(frames),
     };
     await renameSelectedFrames({ prefix: 'F-' }, board);
     expect(frames[1].title).toBe('F-0');
@@ -33,7 +33,7 @@ describe('frame-tools', () => {
       },
     };
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue([frame]),
+      getSelection: vi.fn().mockResolvedValue([frame]),
     };
     await renameSelectedFrames({ prefix: 'Z-' }, board);
     expect(contexts[0]).toBe(frame);
@@ -42,30 +42,28 @@ describe('frame-tools', () => {
 
   test('renameSelectedFrames ignores non-frames', async () => {
     const items = [
-      { x: 0, title: 'A', sync: jest.fn(), type: 'shape' },
-      { x: 1, title: 'B', sync: jest.fn(), type: 'frame' },
+      { x: 0, title: 'A', sync: vi.fn(), type: 'shape' },
+      { x: 1, title: 'B', sync: vi.fn(), type: 'frame' },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await renameSelectedFrames({ prefix: 'X' }, board);
     expect(items[0].title).toBe('A');
     expect(items[1].title).toBe('X0');
   });
 
   test('renameSelectedFrames does nothing when selection empty', async () => {
-    const board: BoardLike = { getSelection: jest.fn().mockResolvedValue([]) };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue([]) };
     await renameSelectedFrames({ prefix: 'N-' }, board);
     expect(board.getSelection).toHaveBeenCalled();
   });
 
   test('renameSelectedFrames sorts by y when x equal', async () => {
     const frames = [
-      { x: 0, y: 10, title: 'A', sync: jest.fn(), type: 'frame' },
-      { x: 0, y: 0, title: 'B', sync: jest.fn(), type: 'frame' },
+      { x: 0, y: 10, title: 'A', sync: vi.fn(), type: 'frame' },
+      { x: 0, y: 0, title: 'B', sync: vi.fn(), type: 'frame' },
     ];
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(frames),
+      getSelection: vi.fn().mockResolvedValue(frames),
     };
     await renameSelectedFrames({ prefix: 'Q' }, board);
     expect(frames[1].title).toBe('Q0');
@@ -75,7 +73,7 @@ describe('frame-tools', () => {
   test('renameSelectedFrames handles frames without sync or coordinates', async () => {
     const frame = { title: 'A', type: 'frame' };
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue([frame]),
+      getSelection: vi.fn().mockResolvedValue([frame]),
     };
     await renameSelectedFrames({ prefix: 'R-' }, board);
     expect(frame.title).toBe('R-0');
@@ -84,10 +82,10 @@ describe('frame-tools', () => {
   test('renameSelectedFrames sorts frames missing coordinates', async () => {
     const frames = [
       { title: 'A', type: 'frame' },
-      { x: 5, y: 0, title: 'B', type: 'frame', sync: jest.fn() },
+      { x: 5, y: 0, title: 'B', type: 'frame', sync: vi.fn() },
     ];
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(frames),
+      getSelection: vi.fn().mockResolvedValue(frames),
     };
     await renameSelectedFrames({ prefix: 'C' }, board);
     expect(frames[0].title).toBe('C0');
@@ -96,11 +94,11 @@ describe('frame-tools', () => {
 
   test('renameSelectedFrames handles missing y for sort', async () => {
     const frames = [
-      { x: 0, title: 'A', type: 'frame', sync: jest.fn() },
-      { x: 0, y: 2, title: 'B', type: 'frame', sync: jest.fn() },
+      { x: 0, title: 'A', type: 'frame', sync: vi.fn() },
+      { x: 0, y: 2, title: 'B', type: 'frame', sync: vi.fn() },
     ];
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(frames),
+      getSelection: vi.fn().mockResolvedValue(frames),
     };
     await renameSelectedFrames({ prefix: 'D' }, board);
     expect(frames[0].title).toBe('D0');
@@ -114,15 +112,15 @@ describe('frame-tools', () => {
 
   describe('lockSelectedFrames', () => {
     test('locks frames and children', async () => {
-      const child = { locked: false, sync: jest.fn() };
+      const child = { locked: false, sync: vi.fn() };
       const frame = {
         type: 'frame',
         locked: false,
-        sync: jest.fn(),
-        getChildren: jest.fn().mockResolvedValue([child]),
+        sync: vi.fn(),
+        getChildren: vi.fn().mockResolvedValue([child]),
       };
       const board: BoardLike = {
-        getSelection: jest.fn().mockResolvedValue([frame]),
+        getSelection: vi.fn().mockResolvedValue([frame]),
       };
       await lockSelectedFrames(board);
       expect(frame.locked).toBe(true);
@@ -135,11 +133,11 @@ describe('frame-tools', () => {
       const frame = {
         type: 'frame',
         locked: false,
-        sync: jest.fn(),
-        getChildren: jest.fn().mockResolvedValue([]),
+        sync: vi.fn(),
+        getChildren: vi.fn().mockResolvedValue([]),
       };
       const board: BoardLike = {
-        getSelection: jest.fn().mockResolvedValue([frame]),
+        getSelection: vi.fn().mockResolvedValue([frame]),
       };
       await lockSelectedFrames(board);
       expect(frame.locked).toBe(true);
@@ -149,24 +147,22 @@ describe('frame-tools', () => {
     test('locks frame even when getChildren missing', async () => {
       const frame = { type: 'frame', locked: false };
       const board: BoardLike = {
-        getSelection: jest.fn().mockResolvedValue([frame]),
+        getSelection: vi.fn().mockResolvedValue([frame]),
       };
       await lockSelectedFrames(board);
       expect(frame.locked).toBe(true);
     });
 
     test('does nothing when selection empty', async () => {
-      const board: BoardLike = {
-        getSelection: jest.fn().mockResolvedValue([]),
-      };
+      const board: BoardLike = { getSelection: vi.fn().mockResolvedValue([]) };
       await lockSelectedFrames(board);
       expect(board.getSelection).toHaveBeenCalled();
     });
 
     test('ignores non-frame widgets', async () => {
-      const item = { type: 'shape', locked: false, sync: jest.fn() };
+      const item = { type: 'shape', locked: false, sync: vi.fn() };
       const board: BoardLike = {
-        getSelection: jest.fn().mockResolvedValue([item]),
+        getSelection: vi.fn().mockResolvedValue([item]),
       };
       await lockSelectedFrames(board);
       expect(item.locked).toBe(false);

--- a/web/client/tests/frame-utils.test.ts
+++ b/web/client/tests/frame-utils.test.ts
@@ -5,8 +5,8 @@ import { clearActiveFrame, registerFrame } from '../src/board/frame-utils';
 describe('frame-utils', () => {
   test('registerFrame creates frame and records it', async () => {
     const builder = {
-      createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
-      setFrame: jest.fn(),
+      createFrame: vi.fn().mockResolvedValue({ id: 'f' }),
+      setFrame: vi.fn(),
     } as unknown as BoardBuilder;
     const list: Array<Frame> = [] as unknown as Array<Frame>;
     const frame = await registerFrame(
@@ -23,7 +23,7 @@ describe('frame-utils', () => {
   });
 
   test('clearActiveFrame resets builder state', () => {
-    const builder = { setFrame: jest.fn() } as unknown as BoardBuilder;
+    const builder = { setFrame: vi.fn() } as unknown as BoardBuilder;
     clearActiveFrame(builder);
     expect(builder.setFrame).toHaveBeenCalledWith(undefined);
   });

--- a/web/client/tests/frames-tab.test.tsx
+++ b/web/client/tests/frames-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 /* eslint-disable no-var */
 import React from 'react';
 import { FramesTab } from '../src/ui/pages/FramesTab';

--- a/web/client/tests/graph-convert.test.ts
+++ b/web/client/tests/graph-convert.test.ts
@@ -48,59 +48,59 @@ describe('graph conversion helpers', () => {
 
 describe('processor conversions', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
   test('GraphProcessor converts hierarchy input', async () => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        getSelection: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        get: vi.fn().mockResolvedValue([]),
+        getSelection: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
-          zoomTo: jest.fn(),
-          set: jest.fn(),
+          zoomTo: vi.fn(),
+          set: vi.fn(),
         },
-        createConnector: jest
+        createConnector: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'c1',
           }),
-        createShape: jest
+        createShape: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 's1',
             type: 'shape',
           }),
-        createText: jest
+        createText: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 't1',
             type: 'text',
           }),
-        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
-        group: jest
+        createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
+        group: vi
           .fn()
           .mockResolvedValue({
             type: 'group',
-            getItems: jest.fn().mockResolvedValue([]),
-            setMetadata: jest.fn(),
-            sync: jest.fn(),
+            getItems: vi.fn().mockResolvedValue([]),
+            setMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'g1',
           }),
       },
@@ -114,7 +114,7 @@ describe('processor conversions', () => {
         children: [{ id: 'c', label: 'C', type: 'Motivation' }],
       },
     ];
-    const spy = jest
+    const spy = vi
       .spyOn(layoutEngine, 'layoutGraph')
       .mockResolvedValue({
         nodes: {
@@ -138,56 +138,56 @@ describe('processor conversions', () => {
   test('GraphProcessor uses nested layout for box algorithm', async () => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        getSelection: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        get: vi.fn().mockResolvedValue([]),
+        getSelection: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
-          zoomTo: jest.fn(),
-          set: jest.fn(),
+          zoomTo: vi.fn(),
+          set: vi.fn(),
         },
-        createShape: jest
+        createShape: vi
           .fn()
           .mockResolvedValue({
             id: 's1',
             type: 'shape',
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
           }),
-        createText: jest
+        createText: vi
           .fn()
           .mockResolvedValue({
             id: 't1',
             type: 'text',
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
           }),
-        group: jest
+        group: vi
           .fn()
           .mockResolvedValue({
             id: 'g1',
             type: 'group',
-            getItems: jest.fn().mockResolvedValue([]),
-            setMetadata: jest.fn(),
-            sync: jest.fn(),
+            getItems: vi.fn().mockResolvedValue([]),
+            setMetadata: vi.fn(),
+            sync: vi.fn(),
           }),
-        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+        createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
       },
     } as unknown as GlobalWithMiro;
 
     const gp = new GraphProcessor();
-    const layoutSpy = jest
+    const layoutSpy = vi
       .spyOn(nestedLayout, 'layoutHierarchy')
       .mockResolvedValue({
         nodes: { p: { x: 0, y: 0, width: 10, height: 10 } },
       });
-    const hierSpy = jest.spyOn(layoutEngine, 'layoutGraph');
+    const hierSpy = vi.spyOn(layoutEngine, 'layoutGraph');
     const graph = {
       nodes: [{ id: 'p', label: 'P', type: 'Motivation' }],
       edges: [],
@@ -202,48 +202,46 @@ describe('processor conversions', () => {
   test('HierarchyProcessor converts graph input', async () => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        getSelection: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        get: vi.fn().mockResolvedValue([]),
+        getSelection: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
-          zoomTo: jest.fn(),
+          zoomTo: vi.fn(),
         },
-        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
-        group: jest.fn().mockResolvedValue({ id: 'g1', type: 'group' }),
-        createShape: jest
+        createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
+        group: vi.fn().mockResolvedValue({ id: 'g1', type: 'group' }),
+        createShape: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 's1',
             type: 'shape',
           }),
-        createText: jest
+        createText: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 't1',
             type: 'text',
           }),
       },
     } as unknown as GlobalWithMiro;
-    jest
-      .spyOn(templateManager, 'createFromTemplate')
-      .mockResolvedValue({
-        type: 'shape',
-        setMetadata: jest.fn(),
-        getItems: jest.fn().mockResolvedValue([]),
-        sync: jest.fn(),
-        id: 's1',
-      } as unknown);
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getItems: vi.fn().mockResolvedValue([]),
+      sync: vi.fn(),
+      id: 's1',
+    } as unknown);
     const proc = new HierarchyProcessor();
     const graph = {
       nodes: [
@@ -252,7 +250,7 @@ describe('processor conversions', () => {
       ],
       edges: [{ from: 'p', to: 'c' }],
     };
-    const spy = jest
+    const spy = vi
       .spyOn(nestedLayout, 'layoutHierarchy')
       .mockResolvedValue({
         nodes: {

--- a/web/client/tests/graph-load-any.test.ts
+++ b/web/client/tests/graph-load-any.test.ts
@@ -6,12 +6,12 @@ interface ReaderEvent {
 
 describe('loadAnyGraph', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete (global as { FileReader?: unknown }).FileReader;
   });
 
   test('parses graph data and resets cache', async () => {
-    const resetSpy = jest.spyOn(defaultBuilder, 'reset');
+    const resetSpy = vi.spyOn(defaultBuilder, 'reset');
 
     class FR {
       onload: ((e: ReaderEvent) => void) | null = null;

--- a/web/client/tests/graph-load.test.ts
+++ b/web/client/tests/graph-load.test.ts
@@ -11,12 +11,12 @@ interface ReaderEvent {
 
 describe('loadGraph', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete (global as { FileReader?: unknown }).FileReader;
   });
 
   test('parses valid file and resets cache', async () => {
-    const resetSpy = jest.spyOn(defaultBuilder, 'reset');
+    const resetSpy = vi.spyOn(defaultBuilder, 'reset');
 
     // Minimal FileReader mock that returns valid graph JSON
     class FR {

--- a/web/client/tests/graph-wrappers.test.ts
+++ b/web/client/tests/graph-wrappers.test.ts
@@ -5,10 +5,10 @@ import { defaultBuilder, graphService } from '../src/core/graph';
  */
 
 describe('graph service methods', () => {
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   test('findNode delegates to default builder', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(defaultBuilder, 'findNode')
       .mockResolvedValue('x' as unknown);
     const result = await graphService.findNode('t', 'l');
@@ -17,7 +17,7 @@ describe('graph service methods', () => {
   });
 
   test('createNode delegates to default builder', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(defaultBuilder, 'createNode')
       .mockResolvedValue('n' as unknown);
     const result = await graphService.createNode(
@@ -29,7 +29,7 @@ describe('graph service methods', () => {
   });
 
   test('createEdges delegates to default builder', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(defaultBuilder, 'createEdges')
       .mockResolvedValue(['e'] as unknown as string[]);
     const result = await graphService.createEdges(
@@ -42,13 +42,13 @@ describe('graph service methods', () => {
   });
 
   test('syncAll delegates to default builder', async () => {
-    const spy = jest.spyOn(defaultBuilder, 'syncAll').mockResolvedValue();
+    const spy = vi.spyOn(defaultBuilder, 'syncAll').mockResolvedValue();
     await graphService.syncAll([] as unknown as Array<unknown>);
     expect(spy).toHaveBeenCalled();
   });
 
   test('resetBoardCache calls builder.reset', () => {
-    const spy = jest.spyOn(defaultBuilder, 'reset');
+    const spy = vi.spyOn(defaultBuilder, 'reset');
     graphService.resetBoardCache();
     expect(spy).toHaveBeenCalled();
   });

--- a/web/client/tests/grid-tools.test.ts
+++ b/web/client/tests/grid-tools.test.ts
@@ -30,12 +30,12 @@ describe('grid-tools', () => {
 
   test('applyGridLayout positions widgets', async () => {
     const items = [
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'b' },
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'a' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), title: 'b' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), title: 'a' },
     ];
     const board = {
-      getSelection: jest.fn().mockResolvedValue(items),
-      group: jest.fn(),
+      getSelection: vi.fn().mockResolvedValue(items),
+      group: vi.fn(),
     } as BoardLike;
     await applyGridLayout(
       { cols: 1, padding: 5, sortByName: true, groupResult: true },
@@ -51,12 +51,10 @@ describe('grid-tools', () => {
 
   test('applyGridLayout handles groups as single items', async () => {
     const items = [
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), type: 'group' },
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), type: 'group' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn() },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applyGridLayout({ cols: 2, padding: 5 }, board);
     expect(items[1].x).toBe(15);
     expect(items[1].y).toBe(0);
@@ -64,18 +62,16 @@ describe('grid-tools', () => {
 
   test('applyGridLayout returns early with empty selection', async () => {
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue([]),
-      group: jest.fn(),
+      getSelection: vi.fn().mockResolvedValue([]),
+      group: vi.fn(),
     };
     await applyGridLayout({ cols: 1, padding: 0, groupResult: true }, board);
     expect(board.group).not.toHaveBeenCalled();
   });
 
   test('applyGridLayout skips grouping when API missing', async () => {
-    const items = [{ x: 0, y: 0, width: 10, height: 10, sync: jest.fn() }];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const items = [{ x: 0, y: 0, width: 10, height: 10, sync: vi.fn() }];
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applyGridLayout({ cols: 1, padding: 0, groupResult: true }, board);
     expect(items[0].x).toBe(0);
   });
@@ -87,7 +83,7 @@ describe('grid-tools', () => {
         y: 0,
         width: 10,
         height: 10,
-        sync: jest.fn(),
+        sync: vi.fn(),
         text: { plainText: 'b' },
       },
       {
@@ -95,13 +91,13 @@ describe('grid-tools', () => {
         y: 0,
         width: 10,
         height: 10,
-        sync: jest.fn(),
+        sync: vi.fn(),
         text: { plainText: 'a' },
       },
     ];
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-      group: jest.fn(),
+      getSelection: vi.fn().mockResolvedValue(items),
+      group: vi.fn(),
     };
     await applyGridLayout(
       { cols: 1, padding: 0, sortByName: true, groupResult: false },
@@ -113,14 +109,14 @@ describe('grid-tools', () => {
 
   test('applyGridLayout sorts vertically when requested', async () => {
     const items = [
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'b' },
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'a' },
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'd' },
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'c' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), title: 'b' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), title: 'a' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), title: 'd' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), title: 'c' },
     ];
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-      group: jest.fn(),
+      getSelection: vi.fn().mockResolvedValue(items),
+      group: vi.fn(),
     };
     await applyGridLayout(
       { cols: 2, padding: 5, sortByName: true, sortOrientation: 'vertical' },
@@ -134,12 +130,10 @@ describe('grid-tools', () => {
 
   test('applyGridLayout handles frames', async () => {
     const items = [
-      { x: 0, y: 0, width: 30, height: 20, sync: jest.fn(), type: 'frame' },
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), type: 'shape' },
+      { x: 0, y: 0, width: 30, height: 20, sync: vi.fn(), type: 'frame' },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn(), type: 'shape' },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applyGridLayout({ cols: 2, padding: 5 }, board);
     expect(items[1].x).toBe(35);
     expect(items[1].y).toBe(0);
@@ -147,12 +141,10 @@ describe('grid-tools', () => {
 
   test('applyGridLayout ignores unsupported items', async () => {
     const items = [
-      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, height: 10, sync: vi.fn() },
       { foo: 'bar' },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applyGridLayout({ cols: 1, padding: 5 }, board);
     expect(items[0].x).toBe(0);
     expect(items[0].y).toBe(0);

--- a/web/client/tests/help-tab.test.tsx
+++ b/web/client/tests/help-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { HelpTab } from '../src/ui/pages/HelpTab';
 

--- a/web/client/tests/hierarchy-processor.test.ts
+++ b/web/client/tests/hierarchy-processor.test.ts
@@ -9,13 +9,13 @@ declare const global: GlobalWithMiro;
 
 describe('HierarchyProcessor', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
   test('processFile loads data and delegates', async () => {
     const proc = new HierarchyProcessor();
-    const spy = jest
+    const spy = vi
       .spyOn(
         proc as unknown as {
           processHierarchy: (r: unknown, o?: unknown) => Promise<void>;
@@ -25,7 +25,7 @@ describe('HierarchyProcessor', () => {
       .mockResolvedValue();
     const file = {
       name: 'h.json',
-      text: jest
+      text: vi
         .fn()
         .mockResolvedValue('[{"id":"n","label":"L","type":"Motivation"}]'),
     } as unknown as File;
@@ -39,28 +39,26 @@ describe('HierarchyProcessor', () => {
   test('processHierarchy creates widgets and zooms', async () => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        get: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
-          zoomTo: jest.fn(),
+          zoomTo: vi.fn(),
         },
-        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+        createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
       },
     };
-    jest
-      .spyOn(templateManager, 'createFromTemplate')
-      .mockResolvedValue({
-        type: 'shape',
-        setMetadata: jest.fn(),
-        getItems: jest.fn().mockResolvedValue([]),
-        sync: jest.fn(),
-        id: 's1',
-      } as unknown);
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getItems: vi.fn().mockResolvedValue([]),
+      sync: vi.fn(),
+      id: 's1',
+    } as unknown);
     const proc = new HierarchyProcessor();
     await proc.processHierarchy([{ id: 'n', label: 'L', type: 'Motivation' }]);
     expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
@@ -69,29 +67,27 @@ describe('HierarchyProcessor', () => {
   test('processHierarchy groups parent and children', async () => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        get: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
-          zoomTo: jest.fn(),
+          zoomTo: vi.fn(),
         },
-        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
-        group: jest.fn().mockResolvedValue({ id: 'g1', type: 'group' }),
+        createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
+        group: vi.fn().mockResolvedValue({ id: 'g1', type: 'group' }),
       },
     } as unknown as GlobalWithMiro;
-    jest
-      .spyOn(templateManager, 'createFromTemplate')
-      .mockResolvedValue({
-        type: 'shape',
-        setMetadata: jest.fn(),
-        getItems: jest.fn().mockResolvedValue([]),
-        sync: jest.fn(),
-        id: 's1',
-      } as unknown);
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getItems: vi.fn().mockResolvedValue([]),
+      sync: vi.fn(),
+      id: 's1',
+    } as unknown);
     const proc = new HierarchyProcessor();
     await proc.processHierarchy([
       {
@@ -102,7 +98,7 @@ describe('HierarchyProcessor', () => {
       },
     ]);
     expect(
-      (global.miro.board.group as jest.Mock).mock.calls[0][0].items.length,
+      (global.miro.board.group as vi.Mock).mock.calls[0][0].items.length,
     ).toBe(2);
   });
 });

--- a/web/client/tests/index-error.test.ts
+++ b/web/client/tests/index-error.test.ts
@@ -10,7 +10,7 @@ vi.mock('../src/app/diagram-app', () => ({
 import * as log from '../src/logger';
 
 test('logs error when initialization fails', async () => {
-  const errorSpy = jest.spyOn(log, 'error').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => {});
   await import('../src/index');
   expect(errorSpy).toHaveBeenCalled();
 });

--- a/web/client/tests/index-import.test.ts
+++ b/web/client/tests/index-import.test.ts
@@ -10,7 +10,6 @@ describe('index entrypoint', () =>
     await import('../src/index');
     const { DiagramApp } = await import('../src/app/diagram-app');
     expect(DiagramApp.getInstance).toHaveBeenCalled();
-    const instance = (DiagramApp.getInstance as jest.Mock).mock.results[0]
-      .value;
+    const instance = (DiagramApp.getInstance as vi.Mock).mock.results[0].value;
     expect(instance.init).toHaveBeenCalled();
   }));

--- a/web/client/tests/inputfield.test.tsx
+++ b/web/client/tests/inputfield.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { InputField } from '../src/ui/components/InputField';
 
@@ -19,7 +19,7 @@ test('renders label and input', () => {
 });
 
 test('calls onValueChange with value', () => {
-  const handler = jest.fn();
+  const handler = vi.fn();
   render(
     <InputField
       label='Age'

--- a/web/client/tests/intro-screen.test.tsx
+++ b/web/client/tests/intro-screen.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { IntroScreen } from '../src/ui/components/IntroScreen';
 

--- a/web/client/tests/json-dropzone.test.tsx
+++ b/web/client/tests/json-dropzone.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { JsonDropZone } from '../src/ui/components/JsonDropZone';
 

--- a/web/client/tests/layout-branches.test.ts
+++ b/web/client/tests/layout-branches.test.ts
@@ -7,7 +7,7 @@ import { layoutEngine } from '../src/core/layout/elk-layout';
  */
 
 test('layoutGraph handles metadata and missing sections', async () => {
-  const layoutSpy = jest
+  const layoutSpy = vi
     .spyOn(ELK.prototype, 'layout')
     .mockImplementation(async (g: unknown) => {
       // Validate that metadata dimensions are passed through
@@ -55,7 +55,7 @@ test('layoutGraph handles metadata and missing sections', async () => {
 });
 
 test('layoutGraph uses defaults when layout values missing', async () => {
-  const layoutSpy = jest
+  const layoutSpy = vi
     .spyOn(ELK.prototype, 'layout')
     .mockResolvedValue({ children: [{ id: 'n2' }], edges: [] } as unknown);
   const graph = {
@@ -72,7 +72,7 @@ test('layoutGraph uses defaults when layout values missing', async () => {
 });
 
 test('layoutGraph uses template dimensions when metadata absent', async () => {
-  const spy = jest
+  const spy = vi
     .spyOn(ELK.prototype, 'layout')
     .mockImplementation(async (g: unknown) => {
       expect(g.children[0].width).toBe(160);
@@ -90,9 +90,10 @@ test('layoutGraph uses template dimensions when metadata absent', async () => {
 });
 
 test('layoutGraph handles missing edge sections array', async () => {
-  jest
-    .spyOn(ELK.prototype, 'layout')
-    .mockResolvedValue({ children: [], edges: undefined } as unknown);
+  vi.spyOn(ELK.prototype, 'layout').mockResolvedValue({
+    children: [],
+    edges: undefined,
+  } as unknown);
   const result = await layoutEngine.layoutGraph({
     nodes: [],
     edges: [],

--- a/web/client/tests/layout-engine-tab.test.tsx
+++ b/web/client/tests/layout-engine-tab.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { LayoutEngineTab } from '../src/ui/pages/LayoutEngineTab';
 

--- a/web/client/tests/layout-engine.test.ts
+++ b/web/client/tests/layout-engine.test.ts
@@ -23,7 +23,7 @@ describe('LayoutEngine', () => {
   });
 
   test('layoutGraph forwards options', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(ELK.prototype, 'layout')
       .mockResolvedValue({ children: [], edges: [] } as unknown);
     const graph = { nodes: [], edges: [] };

--- a/web/client/tests/metadata-command.test.tsx
+++ b/web/client/tests/metadata-command.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { App } from '../src/app/App';
 import { ExcelSyncService } from '../src/core/excel-sync-service';

--- a/web/client/tests/modal.test.tsx
+++ b/web/client/tests/modal.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { Modal } from '../src/ui/components/Modal';
 

--- a/web/client/tests/node.test.ts
+++ b/web/client/tests/node.test.ts
@@ -9,24 +9,22 @@ declare const global: GlobalWithMiro;
 
 describe('createNode', () => {
   beforeEach(() => {
-    global.miro = { board: { get: jest.fn().mockResolvedValue([]) } };
-    jest
-      .spyOn(templateManager, 'createFromTemplate')
-      .mockResolvedValue({
-        type: 'shape',
-        setMetadata: jest.fn(),
-        getMetadata: jest.fn(),
-        getItems: jest.fn().mockResolvedValue([]),
-        sync: jest.fn(),
-        id: 's1',
-      } as unknown as { type: string; setMetadata: jest.Mock } & Record<
-        string,
-        unknown
-      >);
+    global.miro = { board: { get: vi.fn().mockResolvedValue([]) } };
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getMetadata: vi.fn(),
+      getItems: vi.fn().mockResolvedValue([]),
+      sync: vi.fn(),
+      id: 's1',
+    } as unknown as { type: string; setMetadata: vi.Mock } & Record<
+      string,
+      unknown
+    >);
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     graphService.resetBoardCache();
   });
 
@@ -45,14 +43,14 @@ describe('createNode', () => {
     const existing = {
       type: 'shape',
       style: {},
-      setMetadata: jest.fn(),
-      getMetadata: jest
+      setMetadata: vi.fn(),
+      getMetadata: vi
         .fn()
         .mockResolvedValue({ type: 'Motivation', label: 'L' }),
-      sync: jest.fn(),
+      sync: vi.fn(),
       id: 'sExisting',
     } as Record<string, unknown>;
-    (global.miro.board.get as jest.Mock).mockResolvedValueOnce([existing]);
+    (global.miro.board.get as vi.Mock).mockResolvedValueOnce([existing]);
     const result = await graphService.createNode(node, pos);
     expect(result).not.toBe(existing);
   });

--- a/web/client/tests/notifications.test.ts
+++ b/web/client/tests/notifications.test.ts
@@ -11,14 +11,14 @@ describe('showError', () => {
   beforeEach(() => {
     global.miro = {
       board: {
-        notifications: { showError: jest.fn().mockResolvedValue(undefined) },
+        notifications: { showError: vi.fn().mockResolvedValue(undefined) },
       },
     };
-    jest.spyOn(log, 'error').mockImplementation(() => {});
+    vi.spyOn(log, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
@@ -34,7 +34,7 @@ describe('showError', () => {
     const long = 'a'.repeat(90);
     await showError(long);
     expect(log.error).toHaveBeenCalledWith(long);
-    const arg = (global.miro.board.notifications.showError as jest.Mock).mock
+    const arg = (global.miro.board.notifications.showError as vi.Mock).mock
       .calls[0][0];
     expect(arg.length).toBeLessThanOrEqual(80);
     expect(arg.endsWith('...')).toBe(true);

--- a/web/client/tests/page-help.test.tsx
+++ b/web/client/tests/page-help.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { PageHelp } from '../src/ui/components/PageHelp';
 

--- a/web/client/tests/processor-existing.test.ts
+++ b/web/client/tests/processor-existing.test.ts
@@ -10,7 +10,7 @@ declare const global: GlobalWithMiro;
 
 describe('GraphProcessor with existing nodes', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete global.miro;
   });
 
@@ -21,55 +21,53 @@ describe('GraphProcessor with existing nodes', () => {
       type: 'shape',
       x: 5,
       y: 6,
-      sync: jest.fn(),
-      setMetadata: jest.fn(),
-      getMetadata: jest.fn(),
+      sync: vi.fn(),
+      setMetadata: vi.fn(),
+      getMetadata: vi.fn(),
     } as Record<string, unknown>;
     global.miro = {
       board: {
-        getSelection: jest.fn().mockResolvedValue([shape]),
-        get: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        getSelection: vi.fn().mockResolvedValue([shape]),
+        get: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 1000, height: 1000 }),
-          zoomTo: jest.fn(),
-          set: jest.fn(),
+          zoomTo: vi.fn(),
+          set: vi.fn(),
         },
-        createConnector: jest
+        createConnector: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'c',
           }),
-        createShape: jest.fn(),
-        createText: jest.fn(),
-        createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
-        group: jest
+        createShape: vi.fn(),
+        createText: vi.fn(),
+        createFrame: vi.fn().mockResolvedValue({ id: 'f' }),
+        group: vi
           .fn()
           .mockResolvedValue({
             type: 'group',
-            getItems: jest.fn().mockResolvedValue([]),
+            getItems: vi.fn().mockResolvedValue([]),
           }),
       },
     };
-    jest
-      .spyOn(BoardBuilder.prototype, 'findNodeInSelection')
-      .mockResolvedValue(shape as unknown);
-    jest
-      .spyOn(BoardBuilder.prototype, 'createNode')
-      .mockResolvedValue(shape as unknown);
-    jest
-      .spyOn(layoutEngine, 'layoutGraph')
-      .mockResolvedValue({
-        nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
-        edges: [],
-      });
+    vi.spyOn(BoardBuilder.prototype, 'findNodeInSelection').mockResolvedValue(
+      shape as unknown,
+    );
+    vi.spyOn(BoardBuilder.prototype, 'createNode').mockResolvedValue(
+      shape as unknown,
+    );
+    vi.spyOn(layoutEngine, 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
     const graph = { nodes: [{ id: 'n1', label: 'L', type: 'T' }], edges: [] };
     await processor.processGraph(graph as unknown, {
       existingMode: 'ignore',
@@ -86,47 +84,47 @@ describe('GraphProcessor with existing nodes', () => {
       type: 'shape',
       x: 10,
       y: 20,
-      sync: jest.fn(),
-      setMetadata: jest.fn(),
-      getMetadata: jest.fn(),
+      sync: vi.fn(),
+      setMetadata: vi.fn(),
+      getMetadata: vi.fn(),
     } as Record<string, unknown>;
     global.miro = {
       board: {
-        getSelection: jest.fn().mockResolvedValue([shape]),
-        get: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        getSelection: vi.fn().mockResolvedValue([shape]),
+        get: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 1000, height: 1000 }),
-          zoomTo: jest.fn(),
-          set: jest.fn(),
+          zoomTo: vi.fn(),
+          set: vi.fn(),
         },
-        createConnector: jest
+        createConnector: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'c',
           }),
-        createShape: jest.fn(),
-        createText: jest.fn(),
-        createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
-        group: jest
+        createShape: vi.fn(),
+        createText: vi.fn(),
+        createFrame: vi.fn().mockResolvedValue({ id: 'f' }),
+        group: vi
           .fn()
           .mockResolvedValue({
             type: 'group',
-            getItems: jest.fn().mockResolvedValue([]),
+            getItems: vi.fn().mockResolvedValue([]),
           }),
       },
     };
-    jest
-      .spyOn(BoardBuilder.prototype, 'findNodeInSelection')
-      .mockResolvedValue(shape as unknown);
-    const spy = jest
+    vi.spyOn(BoardBuilder.prototype, 'findNodeInSelection').mockResolvedValue(
+      shape as unknown,
+    );
+    const spy = vi
       .spyOn(layoutEngine, 'layoutGraph')
       .mockImplementation(async g => {
         expect((g as { nodes: unknown[] }).nodes[0]).toHaveProperty('metadata');

--- a/web/client/tests/processor-file.test.ts
+++ b/web/client/tests/processor-file.test.ts
@@ -7,7 +7,7 @@ import { GraphProcessor } from '../src/core/graph/graph-processor';
  */
 
 describe('GraphProcessor.processFile', () => {
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   test('throws on invalid file', async () => {
     const gp = new GraphProcessor();
@@ -23,8 +23,8 @@ describe('GraphProcessor.processFile', () => {
       GraphProcessor['processGraph']
     >[0];
     // Stub out loadAnyGraph and internal processGraph
-    jest.spyOn(graphService, 'loadAnyGraph').mockResolvedValue(mockGraph);
-    const processSpy = jest
+    vi.spyOn(graphService, 'loadAnyGraph').mockResolvedValue(mockGraph);
+    const processSpy = vi
       .spyOn(
         gp as unknown as {
           processGraph: (g: unknown, o?: unknown) => Promise<void>;

--- a/web/client/tests/processor.test.ts
+++ b/web/client/tests/processor.test.ts
@@ -19,97 +19,91 @@ describe('GraphProcessor', () => {
   beforeEach(() => {
     global.miro = {
       board: {
-        get: jest.fn().mockResolvedValue([]),
-        getSelection: jest.fn().mockResolvedValue([]),
-        findEmptySpace: jest
+        get: vi.fn().mockResolvedValue([]),
+        getSelection: vi.fn().mockResolvedValue([]),
+        findEmptySpace: vi
           .fn()
           .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
         viewport: {
-          get: jest
+          get: vi
             .fn()
             .mockResolvedValue({ x: 0, y: 0, width: 1000, height: 1000 }),
-          set: jest.fn().mockResolvedValue({}),
-          zoomTo: jest.fn(),
+          set: vi.fn().mockResolvedValue({}),
+          zoomTo: vi.fn(),
         },
-        createConnector: jest
+        createConnector: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'c1',
           }),
-        createShape: jest
+        createShape: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 's1',
             type: 'shape',
           }),
-        createText: jest
+        createText: vi
           .fn()
           .mockResolvedValue({
-            setMetadata: jest.fn(),
-            getMetadata: jest.fn(),
-            sync: jest.fn(),
+            setMetadata: vi.fn(),
+            getMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 't1',
             type: 'text',
           }),
-        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
-        group: jest
+        createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
+        group: vi
           .fn()
           .mockResolvedValue({
             type: 'group',
-            getItems: jest.fn().mockResolvedValue([]),
-            setMetadata: jest.fn(),
-            sync: jest.fn(),
+            getItems: vi.fn().mockResolvedValue([]),
+            setMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'g1',
           }),
       },
     };
     graphService.resetBoardCache();
-    jest
-      .spyOn(templateManager, 'createFromTemplate')
-      .mockResolvedValue({
-        type: 'shape',
-        setMetadata: jest.fn(),
-        getMetadata: jest.fn(),
-        getItems: jest.fn(),
-        sync: jest.fn(),
-        id: 's1',
-      } as unknown);
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getMetadata: vi.fn(),
+      getItems: vi.fn(),
+      sync: vi.fn(),
+      id: 's1',
+    } as unknown);
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     graphService.resetBoardCache();
   });
 
   it('processGraph runs without throwing and syncs items once after validation', async () => {
-    const spy = jest
-      .spyOn(BoardBuilder.prototype, 'syncAll')
-      .mockResolvedValue();
+    const spy = vi.spyOn(BoardBuilder.prototype, 'syncAll').mockResolvedValue();
     await processor.processGraph(sample as unknown);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('delegates work to helper methods', async () => {
     const gp = new GraphProcessor();
-    const frameSpy = jest
+    const frameSpy = vi
       .spyOn(frameUtils, 'registerFrame')
       .mockResolvedValue(undefined as unknown as Frame);
-    jest.spyOn(frameUtils, 'clearActiveFrame').mockImplementation(() => {});
-    const nodeSpy = jest.spyOn(gp as unknown, 'createNodes');
-    const connectorSpy = jest.spyOn(gp as unknown, 'createConnectorsAndZoom');
+    vi.spyOn(frameUtils, 'clearActiveFrame').mockImplementation(() => {});
+    const nodeSpy = vi.spyOn(gp as unknown, 'createNodes');
+    const connectorSpy = vi.spyOn(gp as unknown, 'createConnectorsAndZoom');
 
-    jest
-      .spyOn(layoutEngine, 'layoutGraph')
-      .mockResolvedValue({
-        nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
-        edges: [],
-      });
+    vi.spyOn(layoutEngine, 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
 
     const simpleGraph = {
       nodes: [{ id: 'n1', label: 'A', type: 'Motivation' }],
@@ -123,7 +117,7 @@ describe('GraphProcessor', () => {
   });
 
   it('forwards layout options', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(layoutEngine, 'layoutGraph')
       .mockResolvedValue({ nodes: {}, edges: [] } as unknown);
     const simpleGraph = { nodes: [], edges: [] };
@@ -146,16 +140,14 @@ describe('GraphProcessor', () => {
       edges: [],
     };
     // Mock layout with a single node to make dimensions deterministic
-    jest
-      .spyOn(layoutEngine, 'layoutGraph')
-      .mockResolvedValue({
-        nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
-        edges: [],
-      });
+    vi.spyOn(layoutEngine, 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
 
     await processor.processGraph(simpleGraph as unknown);
 
-    const createArgs = (global.miro.board.createFrame as jest.Mock).mock
+    const createArgs = (global.miro.board.createFrame as vi.Mock).mock
       .calls[0][0];
     expect(createArgs.width).toBe(210);
     expect(createArgs.height).toBe(210);
@@ -182,12 +174,10 @@ describe('GraphProcessor', () => {
       nodes: [{ id: 'n1', label: 'A', type: 'Motivation' }],
       edges: [],
     };
-    jest
-      .spyOn(layoutEngine, 'layoutGraph')
-      .mockResolvedValue({
-        nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
-        edges: [],
-      });
+    vi.spyOn(layoutEngine, 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
 
     await processor.processGraph(simpleGraph as unknown, {
       createFrame: false,
@@ -205,12 +195,10 @@ describe('GraphProcessor', () => {
       ],
       edges: [],
     };
-    jest
-      .spyOn(layoutEngine, 'layoutGraph')
-      .mockResolvedValue({
-        nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
-        edges: [],
-      });
+    vi.spyOn(layoutEngine, 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
 
     await processor.processGraph(simpleGraph as unknown);
 

--- a/web/client/tests/regex-search-field.test.tsx
+++ b/web/client/tests/regex-search-field.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { RegexSearchField } from '../src/ui/components/RegexSearchField';
 

--- a/web/client/tests/resize-tab-extra.test.tsx
+++ b/web/client/tests/resize-tab-extra.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import * as resizeTools from '../src/board/resize-tools';
 import { ResizeTab } from '../src/ui/pages/ResizeTab';
@@ -8,19 +8,19 @@ import { ResizeTab } from '../src/ui/pages/ResizeTab';
 // Helper to provide a mock Miro board API
 function setupBoard(): void {
   (globalThis as { miro?: { board?: unknown } }).miro = {
-    board: { getSelection: jest.fn().mockResolvedValue([]) },
+    board: { getSelection: vi.fn().mockResolvedValue([]) },
   };
 }
 
 describe('ResizeTab extra coverage', () => {
   beforeEach(() => setupBoard());
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     delete (globalThis as { miro?: unknown }).miro;
   });
 
   test('shows warning when size exceeds viewport limit', async () => {
-    const spy = jest
+    const spy = vi
       .spyOn(resizeTools, 'applySizeToSelection')
       .mockResolvedValue(undefined as unknown as void);
     render(React.createElement(ResizeTab));
@@ -37,10 +37,11 @@ describe('ResizeTab extra coverage', () => {
   });
 
   test('keyboard shortcuts copy and apply size', async () => {
-    jest
-      .spyOn(resizeTools, 'copySizeFromSelection')
-      .mockResolvedValue({ width: 20, height: 30 });
-    const applySpy = jest
+    vi.spyOn(resizeTools, 'copySizeFromSelection').mockResolvedValue({
+      width: 20,
+      height: 30,
+    });
+    const applySpy = vi
       .spyOn(resizeTools, 'applySizeToSelection')
       .mockResolvedValue(undefined as unknown as void);
     render(React.createElement(ResizeTab));

--- a/web/client/tests/resize-tools.test.ts
+++ b/web/client/tests/resize-tools.test.ts
@@ -9,15 +9,15 @@ describe('resize-tools', () => {
   beforeEach(() => boardCache.reset());
   test('copySizeFromSelection returns size', async () => {
     const board = {
-      getSelection: jest.fn().mockResolvedValue([{ width: 5, height: 6 }]),
+      getSelection: vi.fn().mockResolvedValue([{ width: 5, height: 6 }]),
     };
     const size = await copySizeFromSelection(board);
     expect(size).toEqual({ width: 5, height: 6 });
   });
 
   test('applySizeToSelection updates widgets', async () => {
-    const item = { width: 1, height: 1, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { width: 1, height: 1, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await applySizeToSelection({ width: 10, height: 20 }, board);
     expect(item.width).toBe(10);
     expect(item.height).toBe(20);
@@ -25,23 +25,23 @@ describe('resize-tools', () => {
   });
 
   test('applySizeToSelection updates frames', async () => {
-    const item = { width: 30, height: 40, sync: jest.fn(), type: 'frame' };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { width: 30, height: 40, sync: vi.fn(), type: 'frame' };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await applySizeToSelection({ width: 50, height: 60 }, board);
     expect(item.width).toBe(50);
     expect(item.height).toBe(60);
   });
 
   test('applySizeToSelection skips unsupported items', async () => {
-    const items = [{ width: 1, height: 1, sync: jest.fn() }, { foo: 'bar' }];
-    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const items = [{ width: 1, height: 1, sync: vi.fn() }, { foo: 'bar' }];
+    const board = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySizeToSelection({ width: 5, height: 5 }, board);
     expect(items[0].width).toBe(5);
     expect(items[1]).toEqual({ foo: 'bar' });
   });
 
   test('copySizeFromSelection returns null when invalid', async () => {
-    const board = { getSelection: jest.fn().mockResolvedValue([{}]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([{}]) };
     const size = await copySizeFromSelection(board);
     expect(size).toBeNull();
   });
@@ -52,8 +52,8 @@ describe('resize-tools', () => {
     ));
 
   test('scaleSelection multiplies widget dimensions', async () => {
-    const item = { width: 10, height: 5, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { width: 10, height: 5, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await scaleSelection(2, board);
     expect(item.width).toBe(20);
     expect(item.height).toBe(10);
@@ -61,8 +61,8 @@ describe('resize-tools', () => {
   });
 
   test('scaleSelection ignores unsupported items', async () => {
-    const items = [{ width: 4, height: 4, sync: jest.fn() }, { foo: 'bar' }];
-    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const items = [{ width: 4, height: 4, sync: vi.fn() }, { foo: 'bar' }];
+    const board = { getSelection: vi.fn().mockResolvedValue(items) };
     await scaleSelection(0.5, board);
     expect(items[0].width).toBe(2);
     expect(items[0].height).toBe(2);

--- a/web/client/tests/row-inspector.test.tsx
+++ b/web/client/tests/row-inspector.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { RowInspector } from '../src/ui/components/RowInspector';
 import { useRowData } from '../src/ui/hooks/use-row-data';

--- a/web/client/tests/search-tab.test.tsx
+++ b/web/client/tests/search-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import * as searchTools from '../src/board/search-tools';
 import { renderSearchTab } from './render-utils';
 

--- a/web/client/tests/search-tools.test.ts
+++ b/web/client/tests/search-tools.test.ts
@@ -18,7 +18,7 @@ const makeBoard = () => {
       assigneeId: 'u1',
       createdBy: 'c1',
       lastModifiedBy: 'm1',
-      sync: jest.fn(),
+      sync: vi.fn(),
     },
     {
       type: 'card',
@@ -28,7 +28,7 @@ const makeBoard = () => {
       assignee: 'u2',
       createdBy: 'c2',
       lastModifiedBy: 'm2',
-      sync: jest.fn(),
+      sync: vi.fn(),
     },
     {
       type: 'sticky_note',
@@ -37,7 +37,7 @@ const makeBoard = () => {
       style: { fillColor: '#00f' },
       createdBy: 'c3',
       lastModifiedBy: 'm3',
-      sync: jest.fn(),
+      sync: vi.fn(),
     },
     {
       type: 'shape',
@@ -45,7 +45,7 @@ const makeBoard = () => {
       style: { fillColor: '#0f0' },
       createdBy: 'c1',
       lastModifiedBy: 'm2',
-      sync: jest.fn(),
+      sync: vi.fn(),
     },
     {
       type: 'text',
@@ -53,7 +53,7 @@ const makeBoard = () => {
       style: { backgroundColor: '#fff' },
       createdBy: 'c1',
       lastModifiedBy: 'm3',
-      sync: jest.fn(),
+      sync: vi.fn(),
     },
     {
       type: 'shape',
@@ -63,12 +63,12 @@ const makeBoard = () => {
       assigneeId: 'u1',
       createdBy: 'c4',
       lastModifiedBy: 'm1',
-      sync: jest.fn(),
+      sync: vi.fn(),
     },
   ];
   const board: BoardQueryLike = {
-    getSelection: jest.fn().mockResolvedValue(items.slice(0, 2)),
-    get: jest.fn(async ({ type }) =>
+    getSelection: vi.fn().mockResolvedValue(items.slice(0, 2)),
+    get: vi.fn(async ({ type }) =>
       type === 'widget' ? items : items.filter(i => i.type === type),
     ),
   } as unknown as BoardQueryLike;
@@ -158,7 +158,7 @@ describe('search-tools', () => {
     );
     expect(cs).toHaveLength(1);
     expect(cs[0].item).toBe(items[0]);
-    (board.get as jest.Mock).mockClear();
+    (board.get as vi.Mock).mockClear();
     const sel = await searchBoardContent(
       { query: 'hello', inSelection: true },
       board,
@@ -222,12 +222,12 @@ describe('search-tools', () => {
 
   test('replaceBoardContent skips widgets lacking text fields', async () => {
     const items = [
-      { type: 'shape', sync: jest.fn() },
-      { type: 'sticky_note', plainText: 'hello', sync: jest.fn() },
+      { type: 'shape', sync: vi.fn() },
+      { type: 'sticky_note', plainText: 'hello', sync: vi.fn() },
     ];
     const board: BoardQueryLike = {
-      getSelection: jest.fn().mockResolvedValue([]),
-      get: jest.fn().mockResolvedValue(items),
+      getSelection: vi.fn().mockResolvedValue([]),
+      get: vi.fn().mockResolvedValue(items),
     } as unknown as BoardQueryLike;
     const count = await replaceBoardContent(
       { query: 'hello', replacement: 'hi' },

--- a/web/client/tests/segmented-control.test.tsx
+++ b/web/client/tests/segmented-control.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { SegmentedControl } from '../src/ui/components/SegmentedControl';
 
 describe('SegmentedControl', () =>
   test('click triggers onChange with value', () => {
-    const handler = jest.fn();
+    const handler = vi.fn();
     const options = [
       { label: 'One', value: '1' },
       { label: 'Two', value: '2' },

--- a/web/client/tests/selectfield.test.tsx
+++ b/web/client/tests/selectfield.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { SelectOption } from '../src/ui/components';
 import { SelectField } from '../src/ui/components/SelectField';

--- a/web/client/tests/setupTests.ts
+++ b/web/client/tests/setupTests.ts
@@ -1,8 +1,8 @@
 import { afterEach, vi } from 'vitest';
 
-// alias jest global to vitest for compatibility
+// alias vi global to vitest for compatibility
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(globalThis as any).jest = vi;
+(globalThis as any).vi = vi;
 
 // Silence noisy console output from third-party libraries during tests
 const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/web/client/tests/spacing-tools.test.ts
+++ b/web/client/tests/spacing-tools.test.ts
@@ -11,13 +11,11 @@ describe('spacing-tools', () => {
 
   test('applySpacingLayout spaces widgets horizontally by edges', async () => {
     const items = [
-      { x: 0, y: 0, width: 10, sync: jest.fn() },
-      { x: 0, y: 0, width: 20, sync: jest.fn() },
-      { x: 0, y: 0, width: 10, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, sync: vi.fn() },
+      { x: 0, y: 0, width: 20, sync: vi.fn() },
+      { x: 0, y: 0, width: 10, sync: vi.fn() },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySpacingLayout({ axis: 'x', spacing: 5 }, board);
     expect(items.map(i => i.x)).toEqual([0, 20, 40]);
     expect(items[0].sync).toHaveBeenCalled();
@@ -25,13 +23,11 @@ describe('spacing-tools', () => {
 
   test('applySpacingLayout grows widgets horizontally', async () => {
     const items = [
-      { x: 0, y: 0, width: 10, sync: jest.fn() },
-      { x: 30, y: 0, width: 20, sync: jest.fn() },
-      { x: 60, y: 0, width: 10, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, sync: vi.fn() },
+      { x: 30, y: 0, width: 20, sync: vi.fn() },
+      { x: 60, y: 0, width: 10, sync: vi.fn() },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySpacingLayout({ axis: 'x', spacing: 5, mode: 'grow' }, board);
     expect(items.map(i => i.width)).toEqual([20, 20, 20]);
     expect(items.map(i => i.x)).toEqual([5, 30, 55]);
@@ -39,12 +35,10 @@ describe('spacing-tools', () => {
 
   test('applySpacingLayout grows widgets vertically', async () => {
     const items = [
-      { x: 0, y: 0, height: 10, sync: jest.fn() },
-      { x: 0, y: 30, height: 20, sync: jest.fn() },
+      { x: 0, y: 0, height: 10, sync: vi.fn() },
+      { x: 0, y: 30, height: 20, sync: vi.fn() },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySpacingLayout({ axis: 'y', spacing: 5, mode: 'grow' }, board);
     expect(items.map(i => i.height)).toEqual([20, 20]);
     expect(items.map(i => i.y)).toEqual([5, 30]);
@@ -52,21 +46,17 @@ describe('spacing-tools', () => {
 
   test('applySpacingLayout handles frames', async () => {
     const items = [
-      { x: 0, y: 0, width: 30, sync: jest.fn(), type: 'frame' },
-      { x: 40, y: 0, width: 10, sync: jest.fn(), type: 'shape' },
+      { x: 0, y: 0, width: 30, sync: vi.fn(), type: 'frame' },
+      { x: 40, y: 0, width: 10, sync: vi.fn(), type: 'shape' },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySpacingLayout({ axis: 'x', spacing: 5 }, board);
     expect(items.map(i => i.x)).toEqual([0, 25]);
   });
 
   test('applySpacingLayout skips unsupported items', async () => {
-    const items = [{ x: 0, y: 0, width: 10, sync: jest.fn() }, { foo: 'bar' }];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const items = [{ x: 0, y: 0, width: 10, sync: vi.fn() }, { foo: 'bar' }];
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySpacingLayout({ axis: 'x', spacing: 5 }, board);
     expect(items[0].x).toBe(0);
     expect(items[0].sync).toHaveBeenCalled();
@@ -74,19 +64,17 @@ describe('spacing-tools', () => {
 
   test('applySpacingLayout spaces widgets vertically by edges', async () => {
     const items = [
-      { x: 0, y: 0, height: 10, sync: jest.fn() },
-      { x: 0, y: 0, height: 20, sync: jest.fn() },
+      { x: 0, y: 0, height: 10, sync: vi.fn() },
+      { x: 0, y: 0, height: 20, sync: vi.fn() },
     ];
-    const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue(items),
-    };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue(items) };
     await applySpacingLayout({ axis: 'y', spacing: 3 }, board);
     expect(items.map(i => i.y)).toEqual([0, 18]);
     expect(items[1].sync).toHaveBeenCalled();
   });
 
   test('applySpacingLayout returns early on empty selection', async () => {
-    const board: BoardLike = { getSelection: jest.fn().mockResolvedValue([]) };
+    const board: BoardLike = { getSelection: vi.fn().mockResolvedValue([]) };
     await applySpacingLayout({ axis: 'y', spacing: 5 }, board);
     expect(board.getSelection).toHaveBeenCalled();
   });

--- a/web/client/tests/story-wrapper.test.tsx
+++ b/web/client/tests/story-wrapper.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { ExcelStoryWrapper } from '../src/stories/ExcelStoryWrapper';
 import { useExcelData } from '../src/ui/hooks/excel-data-context';

--- a/web/client/tests/structured-tab-branches.test.tsx
+++ b/web/client/tests/structured-tab-branches.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 /* eslint-disable no-var */
 import React from 'react';
 import { StructuredTab } from '../src/ui/pages/StructuredTab';

--- a/web/client/tests/structured-tab.test.tsx
+++ b/web/client/tests/structured-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 /* eslint-disable no-var */
 import React from 'react';
 import { handleFileDrop, StructuredTab } from '../src/ui/pages/StructuredTab';

--- a/web/client/tests/style-presets.test.ts
+++ b/web/client/tests/style-presets.test.ts
@@ -2,7 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, test } from 'vitest';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import templatesJson from '../../templates/shapeTemplates.json';
 import type { TemplateDefinition } from '../src/board/templates';
 import { templateManager } from '../src/board/templates';

--- a/web/client/tests/style-tab-extra.test.tsx
+++ b/web/client/tests/style-tab-extra.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import * as formatTools from '../src/board/format-tools';
 import * as styleTools from '../src/board/style-tools';

--- a/web/client/tests/style-tools.test.ts
+++ b/web/client/tests/style-tools.test.ts
@@ -13,9 +13,9 @@ describe('style-tools', () => {
   test('tweakFillColor adjusts fill and font', async () => {
     const item = {
       style: { fillColor: '#808080', color: '#808080' },
-      sync: jest.fn(),
+      sync: vi.fn(),
     };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakFillColor(0.5, board);
     expect(item.style.fillColor).toBe('#c0c0c0');
     expect(item.style.color).toMatch(/^#(fff|000|1c1c1e)/i);
@@ -25,10 +25,10 @@ describe('style-tools', () => {
   test('tweakFillColor updates frame styles', async () => {
     const item = {
       style: { fillColor: '#333333', color: '#ffffff' },
-      sync: jest.fn(),
+      sync: vi.fn(),
       type: 'frame',
     };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakFillColor(0.2, board);
     expect(item.style.fillColor).toMatch(/^#/);
     expect(item.sync).toHaveBeenCalled();
@@ -37,9 +37,9 @@ describe('style-tools', () => {
   test('tweakFillColor respects textColor', async () => {
     const item = {
       style: { fillColor: '#555555', textColor: '#000000' },
-      sync: jest.fn(),
+      sync: vi.fn(),
     };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakFillColor(-0.2, board);
     expect(item.style.fillColor).toMatch(/^#/);
     expect(item.style.textColor).toMatch(/^#/);
@@ -48,20 +48,17 @@ describe('style-tools', () => {
   test('tweakFillColor supports backgroundColor', async () => {
     const item = {
       style: { backgroundColor: '#777777', color: '#ffffff' },
-      sync: jest.fn(),
+      sync: vi.fn(),
     };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakFillColor(0.1, board);
     expect(item.style.backgroundColor).toMatch(/^#/);
     expect(item.style.color).toMatch(/^#/);
   });
 
   test('tweakFillColor skips unsupported items', async () => {
-    const items = [
-      { style: { fillColor: '#fff' }, sync: jest.fn() },
-      { foo: 1 },
-    ];
-    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const items = [{ style: { fillColor: '#fff' }, sync: vi.fn() }, { foo: 1 }];
+    const board = { getSelection: vi.fn().mockResolvedValue(items) };
     await tweakFillColor(0.1, board);
     expect(items[0].sync).toHaveBeenCalled();
     expect(items[1]).toEqual({ foo: 1 });
@@ -74,7 +71,7 @@ describe('style-tools', () => {
 
   test('copyFillFromSelection returns colour', async () => {
     const board = {
-      getSelection: jest
+      getSelection: vi
         .fn()
         .mockResolvedValue([{ style: { fillColor: '#abcdef' } }]),
     };
@@ -83,7 +80,7 @@ describe('style-tools', () => {
   });
 
   test('copyFillFromSelection returns null when missing', async () => {
-    const board = { getSelection: jest.fn().mockResolvedValue([{}]) };
+    const board = { getSelection: vi.fn().mockResolvedValue([{}]) };
     const colour = await copyFillFromSelection(board);
     expect(colour).toBeNull();
   });
@@ -101,46 +98,46 @@ describe('style-tools', () => {
   });
 
   test('tweakOpacity adjusts fillOpacity', async () => {
-    const item = { style: { fillOpacity: 0.4 }, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { style: { fillOpacity: 0.4 }, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakOpacity(0.3, board);
     expect(item.style.fillOpacity).toBeCloseTo(0.7);
     expect(item.sync).toHaveBeenCalled();
   });
 
   test('tweakOpacity clamps between 0 and 1', async () => {
-    const item = { style: { opacity: 0.9 }, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { style: { opacity: 0.9 }, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakOpacity(0.3, board);
     expect(item.style.opacity).toBe(1);
   });
 
   test('tweakOpacity skips unsupported items', async () => {
-    const items = [{ style: { opacity: 0.5 }, sync: jest.fn() }, { foo: 1 }];
-    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const items = [{ style: { opacity: 0.5 }, sync: vi.fn() }, { foo: 1 }];
+    const board = { getSelection: vi.fn().mockResolvedValue(items) };
     await tweakOpacity(0.1, board);
     expect(items[0].style.opacity).toBeCloseTo(0.6);
     expect(items[1]).toEqual({ foo: 1 });
   });
 
   test('tweakBorderWidth updates border style', async () => {
-    const item = { style: { borderWidth: 1 }, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { style: { borderWidth: 1 }, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakBorderWidth(2, board);
     expect(item.style.borderWidth).toBe(3);
     expect(item.sync).toHaveBeenCalled();
   });
 
   test('tweakBorderWidth handles strokeWidth', async () => {
-    const item = { style: { strokeWidth: 2 }, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    const item = { style: { strokeWidth: 2 }, sync: vi.fn() };
+    const board = { getSelection: vi.fn().mockResolvedValue([item]) };
     await tweakBorderWidth(-1, board);
     expect(item.style.strokeWidth).toBe(1);
   });
 
   test('tweakBorderWidth skips unsupported items', async () => {
-    const items = [{ style: { lineWidth: 1 }, sync: jest.fn() }, { bar: 2 }];
-    const board = { getSelection: jest.fn().mockResolvedValue(items) };
+    const items = [{ style: { lineWidth: 1 }, sync: vi.fn() }, { bar: 2 }];
+    const board = { getSelection: vi.fn().mockResolvedValue(items) };
     await tweakBorderWidth(1, board);
     expect(items[0].style.lineWidth).toBe(2);
     expect(items[1]).toEqual({ bar: 2 });

--- a/web/client/tests/tab-panel.test.tsx
+++ b/web/client/tests/tab-panel.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { TabPanel } from '../src/ui/components/TabPanel';
 

--- a/web/client/tests/tabbar.test.tsx
+++ b/web/client/tests/tabbar.test.tsx
@@ -1,15 +1,12 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { App } from '../src/app/App';
 
 beforeEach(() => {
   (globalThis as { miro?: { board?: unknown } }).miro = {
-    board: {
-      getSelection: jest.fn().mockResolvedValue([]),
-      ui: { on: jest.fn() },
-    },
+    board: { getSelection: vi.fn().mockResolvedValue([]), ui: { on: vi.fn() } },
   };
 });
 

--- a/web/client/tests/template.test.ts
+++ b/web/client/tests/template.test.ts
@@ -11,33 +11,33 @@ describe('createFromTemplate', () => {
   beforeEach(() => {
     global.miro = {
       board: {
-        get: jest.fn(),
-        group: jest
+        get: vi.fn(),
+        group: vi
           .fn()
           .mockResolvedValue({
             type: 'group',
-            getItems: jest.fn().mockResolvedValue([]),
-            setMetadata: jest.fn(),
-            sync: jest.fn(),
+            getItems: vi.fn().mockResolvedValue([]),
+            setMetadata: vi.fn(),
+            sync: vi.fn(),
             id: 'g1',
           }),
       },
     } as unknown as GlobalWithMiro['miro'];
-    jest
-      .spyOn(ShapeClient.prototype, 'createShapes')
-      .mockResolvedValue([{ id: 's1' }]);
-    (global.miro.board.get as jest.Mock).mockResolvedValue([
+    vi.spyOn(ShapeClient.prototype, 'createShapes').mockResolvedValue([
+      { id: 's1' },
+    ]);
+    (global.miro.board.get as vi.Mock).mockResolvedValue([
       {
         type: 'shape',
-        setMetadata: jest.fn(),
-        getMetadata: jest.fn(),
-        sync: jest.fn(),
+        setMetadata: vi.fn(),
+        getMetadata: vi.fn(),
+        sync: vi.fn(),
         id: 's1',
       },
     ]);
   });
 
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
   test('creates a single shape with correct style', async () => {
     const widget = await templateManager.createFromTemplate(
@@ -47,7 +47,7 @@ describe('createFromTemplate', () => {
       0,
     );
     expect(widget.type).toBe('shape');
-    const args = (ShapeClient.prototype.createShapes as jest.Mock).mock
+    const args = (ShapeClient.prototype.createShapes as vi.Mock).mock
       .calls[0][0][0];
     expect(args.shape).toBe('round_rectangle');
     expect(args.style.fillColor).toBe('#B5A9FF');
@@ -63,26 +63,26 @@ describe('createFromTemplate', () => {
         { text: 'test' },
       ],
     };
-    (ShapeClient.prototype.createShapes as jest.Mock).mockResolvedValue([
+    (ShapeClient.prototype.createShapes as vi.Mock).mockResolvedValue([
       { id: 's1' },
       { id: 't1' },
     ]);
-    (global.miro.board.get as jest.Mock)
+    (global.miro.board.get as vi.Mock)
       .mockResolvedValueOnce([
         {
           type: 'shape',
-          setMetadata: jest.fn(),
-          getMetadata: jest.fn(),
-          sync: jest.fn(),
+          setMetadata: vi.fn(),
+          getMetadata: vi.fn(),
+          sync: vi.fn(),
           id: 's1',
         },
       ])
       .mockResolvedValueOnce([
         {
           type: 'text',
-          setMetadata: jest.fn(),
-          getMetadata: jest.fn(),
-          sync: jest.fn(),
+          setMetadata: vi.fn(),
+          getMetadata: vi.fn(),
+          sync: vi.fn(),
           id: 't1',
         },
       ]);
@@ -94,7 +94,7 @@ describe('createFromTemplate', () => {
     );
     expect(widget.type).toBe('group');
     expect(ShapeClient.prototype.createShapes).toHaveBeenCalled();
-    const items = (global.miro.board.group as jest.Mock).mock.calls[0][0].items;
+    const items = (global.miro.board.group as vi.Mock).mock.calls[0][0].items;
     expect(items).toHaveLength(2);
   });
 
@@ -108,18 +108,18 @@ describe('createFromTemplate', () => {
       ],
     };
     const frame = {
-      add: jest.fn(),
+      add: vi.fn(),
     } as unknown as import('@mirohq/websdk-types').Frame;
-    (ShapeClient.prototype.createShapes as jest.Mock).mockResolvedValue([
+    (ShapeClient.prototype.createShapes as vi.Mock).mockResolvedValue([
       { id: 's1' },
       { id: 't1' },
     ]);
-    (global.miro.board.get as jest.Mock)
+    (global.miro.board.get as vi.Mock)
       .mockResolvedValueOnce([
-        { type: 'shape', id: 's1', setMetadata: jest.fn(), sync: jest.fn() },
+        { type: 'shape', id: 's1', setMetadata: vi.fn(), sync: vi.fn() },
       ])
       .mockResolvedValueOnce([
-        { type: 'text', id: 't1', setMetadata: jest.fn(), sync: jest.fn() },
+        { type: 'text', id: 't1', setMetadata: vi.fn(), sync: vi.fn() },
       ]);
     const widget = await templateManager.createFromTemplate(
       'withFrame',
@@ -136,11 +136,11 @@ describe('createFromTemplate', () => {
     (
       templateManager as unknown as { templates: Record<string, unknown> }
     ).templates.textOnly = { elements: [{ text: 'T' }] };
-    (ShapeClient.prototype.createShapes as jest.Mock).mockResolvedValue([
+    (ShapeClient.prototype.createShapes as vi.Mock).mockResolvedValue([
       { id: 't1' },
     ]);
-    (global.miro.board.get as jest.Mock).mockResolvedValueOnce([
-      { type: 'text', id: 't1', setMetadata: jest.fn(), sync: jest.fn() },
+    (global.miro.board.get as vi.Mock).mockResolvedValueOnce([
+      { type: 'text', id: 't1', setMetadata: vi.fn(), sync: vi.fn() },
     ]);
     const widget = await templateManager.createFromTemplate(
       'textOnly',
@@ -158,13 +158,13 @@ describe('createFromTemplate', () => {
       elements: [{ shape: 'ellipse', width: 10, height: 10 }],
     };
     const frame = {
-      add: jest.fn(),
+      add: vi.fn(),
     } as unknown as import('@mirohq/websdk-types').Frame;
-    (ShapeClient.prototype.createShapes as jest.Mock).mockResolvedValue([
+    (ShapeClient.prototype.createShapes as vi.Mock).mockResolvedValue([
       { id: 's1' },
     ]);
-    (global.miro.board.get as jest.Mock).mockResolvedValueOnce([
-      { type: 'shape', id: 's1', setMetadata: jest.fn(), sync: jest.fn() },
+    (global.miro.board.get as vi.Mock).mockResolvedValueOnce([
+      { type: 'shape', id: 's1', setMetadata: vi.fn(), sync: vi.fn() },
     ]);
     const widget = await templateManager.createFromTemplate(
       'frameSingle',
@@ -184,11 +184,11 @@ describe('createFromTemplate', () => {
     ).templates.fillStyle = {
       elements: [{ shape: 'rect', fill: '#fff', style: {} }],
     };
-    (ShapeClient.prototype.createShapes as jest.Mock).mockResolvedValue([
+    (ShapeClient.prototype.createShapes as vi.Mock).mockResolvedValue([
       { id: 's1' },
     ]);
-    (global.miro.board.get as jest.Mock).mockResolvedValueOnce([
-      { type: 'shape', id: 's1', setMetadata: jest.fn(), sync: jest.fn() },
+    (global.miro.board.get as vi.Mock).mockResolvedValueOnce([
+      { type: 'shape', id: 's1', setMetadata: vi.fn(), sync: vi.fn() },
     ]);
     const widget = await templateManager.createFromTemplate(
       'fillStyle',
@@ -197,7 +197,7 @@ describe('createFromTemplate', () => {
       0,
     );
     const args = (
-      ShapeClient.prototype.createShapes as jest.Mock
+      ShapeClient.prototype.createShapes as vi.Mock
     ).mock.calls.pop()[0][0];
     expect(args.style.fillColor).toBe('#fff');
     expect(widget.type).toBe('shape');

--- a/web/client/tests/tools-tab.test.tsx
+++ b/web/client/tests/tools-tab.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { ToolsTab } from '../src/ui/pages/ToolsTab';
 

--- a/web/client/tests/tooltip.test.tsx
+++ b/web/client/tests/tooltip.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { Button } from '../src/ui/components/Button';
 import { Tooltip } from '../src/ui/components/Tooltip';

--- a/web/client/tests/undo-utils.test.ts
+++ b/web/client/tests/undo-utils.test.ts
@@ -4,17 +4,17 @@ import { syncOrUndo, undoWidgets } from '../src/board/undo-utils';
 
 describe('undoWidgets', () => {
   test('removes items when registry populated', async () => {
-    const builder = { removeItems: jest.fn() } as unknown as BoardBuilder;
+    const builder = { removeItems: vi.fn() } as unknown as BoardBuilder;
     const list: Array<Frame> = [{} as Frame];
     const orig = [...list];
     await undoWidgets(builder, list);
-    const callArg = (builder.removeItems as jest.Mock).mock.calls[0][0];
+    const callArg = (builder.removeItems as vi.Mock).mock.calls[0][0];
     expect(callArg).toEqual(orig);
     expect(list.length).toBe(0);
   });
 
   test('skips removal when registry empty', async () => {
-    const builder = { removeItems: jest.fn() } as unknown as BoardBuilder;
+    const builder = { removeItems: vi.fn() } as unknown as BoardBuilder;
     const list: Array<Frame> = [];
     await undoWidgets(builder, list);
     expect(builder.removeItems).not.toHaveBeenCalled();
@@ -24,8 +24,8 @@ describe('undoWidgets', () => {
 describe('syncOrUndo', () => {
   test('rolls back when sync fails', async () => {
     const builder = {
-      syncAll: jest.fn().mockRejectedValue(new Error('fail')),
-      removeItems: jest.fn(),
+      syncAll: vi.fn().mockRejectedValue(new Error('fail')),
+      removeItems: vi.fn(),
     } as unknown as BoardBuilder;
     const reg: Array<Frame> = [{} as Frame];
     await expect(
@@ -37,8 +37,8 @@ describe('syncOrUndo', () => {
 
   test('leaves items intact when sync succeeds', async () => {
     const builder = {
-      syncAll: jest.fn(),
-      removeItems: jest.fn(),
+      syncAll: vi.fn(),
+      removeItems: vi.fn(),
     } as unknown as BoardBuilder;
     const reg: Array<Frame> = [{} as Frame];
     await syncOrUndo(builder, reg, [reg[0] as unknown as Frame]);

--- a/web/client/tests/undoable-processor.test.ts
+++ b/web/client/tests/undoable-processor.test.ts
@@ -19,7 +19,7 @@ class Dummy extends UndoableProcessor<BaseItem> {
 describe('UndoableProcessor', () => {
   test('undoLast removes widgets', async () => {
     const builder = new BoardBuilder();
-    const remove = jest.spyOn(builder, 'removeItems').mockResolvedValue();
+    const remove = vi.spyOn(builder, 'removeItems').mockResolvedValue();
     const proc = new Dummy(builder);
     const item = {} as BaseItem;
     proc.add(item);
@@ -29,7 +29,7 @@ describe('UndoableProcessor', () => {
 
   test('undoLast handles empty list', async () => {
     const builder = new BoardBuilder();
-    const remove = jest.spyOn(builder, 'removeItems').mockResolvedValue();
+    const remove = vi.spyOn(builder, 'removeItems').mockResolvedValue();
     const proc = new Dummy(builder);
     await proc.undoLast();
     expect(remove).not.toHaveBeenCalled();
@@ -44,10 +44,10 @@ describe('UndoableProcessor', () => {
 
   test('syncOrUndo rolls back on failure', async () => {
     const builder = new BoardBuilder();
-    const sync = jest
+    const sync = vi
       .spyOn(builder, 'syncAll')
       .mockRejectedValue(new Error('fail'));
-    const remove = jest.spyOn(builder, 'removeItems').mockResolvedValue();
+    const remove = vi.spyOn(builder, 'removeItems').mockResolvedValue();
     const proc = new Dummy(builder);
     proc.add({} as BaseItem);
     await expect(proc.doSync([{} as BaseItem])).rejects.toThrow('fail');

--- a/web/client/tests/useSelection.test.ts
+++ b/web/client/tests/useSelection.test.ts
@@ -6,8 +6,8 @@ import { useSelection } from '../src/ui/hooks/use-selection';
 describe('useSelection', () => {
   test('fetches initial selection', async () => {
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue([{ id: 1 }]),
-      ui: { on: jest.fn(), off: jest.fn() },
+      getSelection: vi.fn().mockResolvedValue([{ id: 1 }]),
+      ui: { on: vi.fn(), off: vi.fn() },
     };
     const { result } = renderHook(() => useSelection(board));
     await act(async () => await Promise.resolve());
@@ -17,15 +17,15 @@ describe('useSelection', () => {
   test('updates when event fires', async () => {
     let cb: (ev: { items: unknown[] }) => void = () => {};
     const board: BoardLike = {
-      getSelection: jest
+      getSelection: vi
         .fn()
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([{ id: 2 }]),
       ui: {
-        on: jest.fn().mockImplementation((_, fn) => {
+        on: vi.fn().mockImplementation((_, fn) => {
           cb = fn;
         }),
-        off: jest.fn(),
+        off: vi.fn(),
       },
     };
     const { result, unmount } = renderHook(() => useSelection(board));
@@ -45,7 +45,7 @@ describe('useSelection', () => {
 
   test('works with board lacking ui API', async () => {
     const board: BoardLike = {
-      getSelection: jest.fn().mockResolvedValue([{ id: 3 }]),
+      getSelection: vi.fn().mockResolvedValue([{ id: 3 }]),
     };
     const { result } = renderHook(() => useSelection(board));
     await act(async () => await Promise.resolve());


### PR DESCRIPTION
## Summary
- replace Jest mocks, spies and imports with Vitest `vi` equivalents across client tests
- drop `@types/jest` and rely on Vitest globals

## Testing
- `npm --prefix web/client run typecheck`
- `npm --prefix web/client test` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json" and other errors)*
- `npm --prefix web/client run lint`
- `npm --prefix web/client run stylelint`
- `npm --prefix web/client run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68a063845118832b9318b2f3f6b7d508