### PR TITLE
docs: reference CI workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,10 +424,10 @@ Run the helper script to reproduce the GitHub Actions pipeline locally. It
 executes lint checks, type verification, unit tests, the production build and
 the Storybook build in sequence. Semantic release is intentionally skipped.
 
-Pull requests trigger the `client-*` and `server-dotnet.yml` workflows to run
-linters, type checks and unit tests. Pushes to `main` additionally invoke
-`repo-sonar.yml`, `repo-codeql.yml` and `repo-release.yml` for coverage,
-static analysis and packaging tasks.
+Pull requests trigger the `client-*` workflows and the `ci.yml` workflow—which
+runs Python and Node jobs—to execute linters, type checks and unit tests.
+Pushes to `main` additionally invoke `repo-sonar.yml`, `repo-codeql.yml` and
+`repo-release.yml` for coverage, static analysis and packaging tasks.
 
 ```bash
 npm run ci:local


### PR DESCRIPTION
## Summary
- clarify that pull requests run the `ci.yml` workflow with Python and Node jobs

## Testing
- `poetry run pre-commit run --files README.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06872a104832bad7bf6a644deb907