### PR TITLE
docs: update cache documentation for FastAPI

### DIFF
--- a/docs/MIRO_API_COSTS.md
+++ b/docs/MIRO_API_COSTS.md
@@ -24,7 +24,7 @@ Excessive use quickly exhausts the daily rate limit.
 ## 2 Design Decisions
 
 1. **Server‑side shape management** – Widget creation, update and deletion are handled by the **FastAPI Shapes router**. The client calls `/api/boards/{boardId}/shapes` via `ShapeClient`.
-2. **In‑memory shape cache** – `IShapeCache` stores widgets by board and item identifier. Controllers update the cache after every change so lookups avoid `board.get` or `item` requests.
+2. **In‑memory shape cache** – `ShapeCache` stores widgets by board and item identifier. The FastAPI Shapes router updates the cache after each change so lookups avoid `board.get` or `item` requests.
 3. **Planned persistent cache** – future versions will back the cache with Redis and **SQLite** via **SQLAlchemy** so multiple server instances share widget data.
 4. **Centralised logging** – `HttpLogSink` forwards front‑end log entries to the server so shape operations are traceable across the boundary.
 5. **Avoid direct board calls** – Front‑end modules now contain TODOs to replace remaining direct Web SDK calls (`board.getSelection`, `board.get`) with cached lookups.


### PR DESCRIPTION
## Summary
- document ShapeCache in Miro API costs doc
- reflect FastAPI router updating cache instead of controllers

## Testing
- `poetry run pre-commit run --files docs/MIRO_API_COSTS.md`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06879e198832bbbb0321e48a5ff96