### PR TITLE
docs: document VITE_BACKEND_URL for dev backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ each element can carry metadata that controls its appearance and placement.
 
 ### Environment
 
-Copy `web/client/.env.example` to `web/client/.env` and adjust the values as needed. `VITE_PORT` sets the client dev server port and `LOG_LEVEL` controls log verbosity. During development, the client proxies API requests to the backend using the Aspire-provided `services__server__https__0` or `services__server__http__0` environment variables.
+Copy `web/client/.env.example` to `web/client/.env` and adjust the values as needed. `VITE_PORT` sets the client dev server port, `LOG_LEVEL` controls log verbosity, and `VITE_BACKEND_URL` specifies the backend API (defaults to `http://localhost:8000`).
 
 ### Development
 

--- a/web/client/.env.example
+++ b/web/client/.env.example
@@ -1,2 +1,3 @@
+VITE_BACKEND_URL=http://localhost:8000
 VITE_PORT=5173
 LOG_LEVEL=info

--- a/web/client/default.conf.template
+++ b/web/client/default.conf.template
@@ -11,7 +11,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass ${services__server__https__0};
+        proxy_pass ${VITE_BACKEND_URL};
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- document VITE_BACKEND_URL for local backend routing
- update env example and nginx template to use VITE_BACKEND_URL

## Testing
- `poetry run pre-commit run --files README.md web/client/.env.example web/client/default.conf.template`
- `poetry run pytest`
- `npm --prefix web/client install`
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(hangs; process terminated)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a06876bcd8832ba4f2683ee5bec88a