### PR TITLE
feat: add database-backed user store

### DIFF
--- a/tests/test_auth_router_db.py
+++ b/tests/test_auth_router_db.py
@@ -1,0 +1,69 @@
+"""Integration tests for the auth router using the database store."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from miro_backend import main
+from miro_backend.main import app
+from miro_backend.db.session import Base, SessionLocal, engine, get_session
+from miro_backend.models import User
+from miro_backend.queue import ChangeQueue
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def setup_db() -> Iterator[None]:
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture  # type: ignore[misc]
+def client() -> Iterator[TestClient]:
+    def _get_session() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = _get_session
+    main.change_queue = ChangeQueue()
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    main.change_queue = ChangeQueue()
+
+
+def test_status_returns_ok_when_user_exists(client: TestClient) -> None:
+    """Endpoint should return 200 when the user tokens are stored."""
+
+    session = SessionLocal()
+    try:
+        session.add(
+            User(
+                user_id="u1",
+                name="Alice",
+                access_token="a",
+                refresh_token="r",
+                expires_at=datetime.now(timezone.utc),
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    response = client.get("/api/auth/status", headers={"X-User-Id": "u1"})
+    assert response.status_code == 200
+
+
+def test_status_returns_not_found_when_user_missing(client: TestClient) -> None:
+    """Endpoint should return 404 when tokens are absent."""
+
+    response = client.get("/api/auth/status", headers={"X-User-Id": "u2"})
+    assert response.status_code == 404

--- a/tests/test_db_user_store.py
+++ b/tests/test_db_user_store.py
@@ -1,0 +1,71 @@
+"""Tests for the database-backed user store."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.schemas.user_info import UserInfo
+from miro_backend.services.user_store import DbUserStore
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def setup_db() -> Iterator[None]:
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture  # type: ignore[misc]
+def session() -> Iterator[Session]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_store_and_retrieve(session: Session) -> None:
+    """Stored user info should round-trip through the database."""
+
+    store = DbUserStore(session)
+    info = UserInfo(
+        id="u1",
+        name="Test",
+        access_token="a",
+        refresh_token="r",
+        expires_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert store.retrieve("u1") is None
+    store.store(info)
+    assert store.retrieve("u1") == info
+
+
+def test_store_updates_existing_record(session: Session) -> None:
+    """Storing twice should update the existing user row."""
+
+    store = DbUserStore(session)
+    original = UserInfo(
+        id="u1",
+        name="Old",
+        access_token="a1",
+        refresh_token="r1",
+        expires_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
+    )
+    store.store(original)
+
+    updated = UserInfo(
+        id="u1",
+        name="New",
+        access_token="a2",
+        refresh_token="r2",
+        expires_at=datetime(2031, 1, 1, tzinfo=timezone.utc),
+    )
+    store.store(updated)
+
+    assert store.retrieve("u1") == updated


### PR DESCRIPTION
## Summary
- add DbUserStore backed by SQLAlchemy session
- expose get_user_store dependency returning DbUserStore
- test database-backed user store and auth status lookup

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/user_store.py tests/test_db_user_store.py tests/test_auth_router_db.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06bc465ac832b8c7b7d25579cc862