### PR TITLE
feat: implement Miro REST client methods

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,3 +8,4 @@ client_secret: your-client-secret
 webhook_secret: change-me
 logfire_service_name: miro-backend
 logfire_send_to_logfire: false
+http_timeout_seconds: 10.0

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     webhook_secret: SecretStr
     logfire_service_name: str = "miro-backend"
     logfire_send_to_logfire: bool = False
+    http_timeout_seconds: float = 10.0
 
     model_config = SettingsConfigDict(
         env_prefix="MIRO_", env_file=".env", extra="ignore"

--- a/src/miro_backend/services/miro_client.py
+++ b/src/miro_backend/services/miro_client.py
@@ -2,41 +2,142 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
+
+import httpx
+
+from ..core.config import settings
+
+
+TokenProvider = Callable[[], str | None]
 
 
 class MiroClient:
-    """Placeholder Miro client.
+    """HTTP client for a subset of the Miro REST API."""
 
-    The real implementation would perform HTTP requests to Miro's REST API. In
-    tests we provide a fake implementation that records calls.
-    """
+    def __init__(
+        self,
+        token: str | None = None,
+        token_provider: TokenProvider | None = None,
+    ) -> None:
+        self._token = token
+        self._token_provider = token_provider
+        self._base_url = "https://api.miro.com/v2"
 
-    async def create_node(
-        self, node_id: str, data: dict[str, Any]
-    ) -> None:  # pragma: no cover - stub
-        """Create a node on the board."""
+    def _auth_headers(self) -> dict[str, str]:
+        token = self._token or (
+            self._token_provider() if self._token_provider else None
+        )
+        return {"Authorization": f"Bearer {token}"} if token else {}
 
-    async def update_card(
-        self, card_id: str, payload: dict[str, Any]
-    ) -> None:  # pragma: no cover - stub
-        """Update a card on the board."""
+    async def create_node(self, node_id: str, data: dict[str, Any]) -> None:
+        """Create a graph node.
+
+        Parameters
+        ----------
+        node_id:
+            Identifier for the node to create.
+        data:
+            Attributes for the node.
+        """
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=settings.http_timeout_seconds
+        ) as client:
+            await client.put(
+                f"/graph/nodes/{node_id}",
+                json=data,
+                headers=self._auth_headers(),
+            )
+
+    async def update_card(self, card_id: str, payload: dict[str, Any]) -> None:
+        """Update an existing card.
+
+        Parameters
+        ----------
+        card_id:
+            Identifier of the card to update.
+        payload:
+            Changes to apply to the card.
+        """
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=settings.http_timeout_seconds
+        ) as client:
+            await client.patch(
+                f"/cards/{card_id}",
+                json=payload,
+                headers=self._auth_headers(),
+            )
 
     async def create_shape(
         self, board_id: str, shape_id: str, data: dict[str, Any]
-    ) -> None:  # pragma: no cover - stub
-        """Create a shape on ``board_id``."""
+    ) -> None:
+        """Create a shape on ``board_id`` with ``shape_id``.
+
+        Parameters
+        ----------
+        board_id:
+            Target board identifier.
+        shape_id:
+            Identifier for the new shape.
+        data:
+            Shape attributes to send to Miro.
+        """
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=settings.http_timeout_seconds
+        ) as client:
+            await client.put(
+                f"/boards/{board_id}/shapes/{shape_id}",
+                json=data,
+                headers=self._auth_headers(),
+            )
 
     async def update_shape(
         self, board_id: str, shape_id: str, data: dict[str, Any]
-    ) -> None:  # pragma: no cover - stub
-        """Update ``shape_id`` on ``board_id``."""
+    ) -> None:
+        """Update ``shape_id`` on ``board_id``.
 
-    async def delete_shape(
-        self, board_id: str, shape_id: str
-    ) -> None:  # pragma: no cover - stub
-        """Delete ``shape_id`` from ``board_id``."""
-        
+        Parameters
+        ----------
+        board_id:
+            Target board identifier.
+        shape_id:
+            Identifier of the shape to update.
+        data:
+            Updated attributes for the shape.
+        """
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=settings.http_timeout_seconds
+        ) as client:
+            await client.patch(
+                f"/boards/{board_id}/shapes/{shape_id}",
+                json=data,
+                headers=self._auth_headers(),
+            )
+
+    async def delete_shape(self, board_id: str, shape_id: str) -> None:
+        """Delete ``shape_id`` from ``board_id``.
+
+        Parameters
+        ----------
+        board_id:
+            Board containing the shape.
+        shape_id:
+            Identifier of the shape to delete.
+        """
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url, timeout=settings.http_timeout_seconds
+        ) as client:
+            await client.delete(
+                f"/boards/{board_id}/shapes/{shape_id}",
+                headers=self._auth_headers(),
+            )
+
     async def exchange_code(
         self, code: str, redirect_uri: str
     ) -> dict[str, Any]:  # pragma: no cover - stub

--- a/tests/integration/test_miro_client.py
+++ b/tests/integration/test_miro_client.py
@@ -1,0 +1,100 @@
+"""Tests for the Miro REST client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from miro_backend.core.config import settings
+from miro_backend.services.miro_client import MiroClient
+
+
+class DummyAsyncClient:
+    """Stub AsyncClient capturing request parameters."""
+
+    def __init__(self, record: dict[str, Any], **kwargs: Any) -> None:
+        record["base_url"] = kwargs.get("base_url")
+        record["timeout"] = kwargs.get("timeout")
+        self.record = record
+
+    async def __aenter__(self) -> "DummyAsyncClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+    async def put(
+        self,
+        url: str,
+        *,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        self.record["call"] = ("PUT", url, headers, json)
+        return httpx.Response(200)
+
+    async def patch(
+        self,
+        url: str,
+        *,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        self.record["call"] = ("PATCH", url, headers, json)
+        return httpx.Response(200)
+
+    async def delete(
+        self, url: str, *, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        self.record["call"] = ("DELETE", url, headers, None)
+        return httpx.Response(204)
+
+
+@pytest.mark.integration  # type: ignore[misc]
+@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.parametrize(  # type: ignore[misc]
+    ("method", "args", "expected"),
+    [
+        (
+            "create_shape",
+            ("b1", "s1", {"x": 1}),
+            ("PUT", "/boards/b1/shapes/s1", {"x": 1}),
+        ),
+        (
+            "update_shape",
+            ("b1", "s1", {"y": 2}),
+            ("PATCH", "/boards/b1/shapes/s1", {"y": 2}),
+        ),
+        ("delete_shape", ("b1", "s1"), ("DELETE", "/boards/b1/shapes/s1", None)),
+        ("update_card", ("c1", {"title": "t"}), ("PATCH", "/cards/c1", {"title": "t"})),
+        (
+            "create_node",
+            ("n1", {"kind": "card"}),
+            ("PUT", "/graph/nodes/n1", {"kind": "card"}),
+        ),
+    ],
+)
+async def test_miro_client_calls_correct_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    args: tuple[Any, ...],
+    expected: tuple[str, str, Any | None],
+) -> None:
+    record: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda **kw: DummyAsyncClient(record, **kw)
+    )
+    client = MiroClient(token="tok")
+    func = getattr(client, method)
+    await func(*args)
+    assert record["base_url"] == "https://api.miro.com/v2"
+    assert record["timeout"] == settings.http_timeout_seconds
+    verb, url, body = expected
+    call = record["call"]
+    assert call[0] == verb
+    assert call[1] == url
+    headers = call[2] or {}
+    assert headers.get("Authorization") == "Bearer tok"
+    assert call[3] == body


### PR DESCRIPTION
## Summary
- add `http_timeout_seconds` setting and sample configuration
- implement authenticated Miro REST calls for nodes, cards, and shapes
- test client request generation with mocked `httpx.AsyncClient`

## Testing
- `SKIP=pytest pre-commit run --files src/miro_backend/core/config.py src/miro_backend/services/miro_client.py config.example.yaml tests/integration/test_miro_client.py`
- `pytest` *(fails: Required test coverage of 96% not reached. Total coverage: 93.62%)*


------
https://chatgpt.com/codex/tasks/task_e_68a06c719c64832bb5b4a9493eb027a9