### PR TITLE
feat(token): refresh expired access tokens

### DIFF
--- a/src/miro_backend/services/token_service.py
+++ b/src/miro_backend/services/token_service.py
@@ -1,0 +1,30 @@
+"""Helpers for ensuring OAuth access tokens remain valid."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from .miro_client import MiroClient
+from ..models.user import User
+
+
+async def get_valid_access_token(
+    session: Session, user_id: str, client: MiroClient
+) -> str:
+    """Return a valid access token for ``user_id``.
+
+    Refresh the user's tokens when expired using ``client.refresh_token``.
+    """
+    user = session.query(User).filter(User.user_id == user_id).one()
+    expires_at = user.expires_at.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    if expires_at <= now:
+        tokens = await client.refresh_token(user.refresh_token)
+        user.access_token = tokens["access_token"]
+        user.refresh_token = tokens["refresh_token"]
+        expires_in = int(tokens.get("expires_in", 0))
+        user.expires_at = now + timedelta(seconds=expires_in)
+        session.commit()
+    return user.access_token

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.models.user import User
+from miro_backend.services.token_service import get_valid_access_token
+
+
+class StubClient:
+    async def refresh_token(self, refresh_token: str) -> dict[str, str | int]:
+        return {
+            "access_token": "new_a",
+            "refresh_token": "new_r",
+            "expires_in": 3600,
+        }
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_get_valid_access_token_refreshes_expired_tokens() -> None:
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    try:
+        expired_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        session.add(
+            User(
+                user_id="u1",
+                name="n",
+                access_token="old_a",
+                refresh_token="old_r",
+                expires_at=expired_at,
+            )
+        )
+        session.commit()
+
+        token = await get_valid_access_token(session, "u1", StubClient())
+
+        assert token == "new_a"
+        row = session.query(User).filter_by(user_id="u1").one()
+        assert row.access_token == "new_a"
+        assert row.refresh_token == "new_r"
+        assert row.expires_at.replace(tzinfo=timezone.utc) > expired_at
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Summary
- implement token helper to refresh expired access tokens
- test refreshing expired tokens updates stored credentials

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/token_service.py tests/test_token_service.py`
- `poetry run pytest tests/test_token_service.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a06e5ef230832b89177ccce150f7ae