### PR TITLE
feat(backend): add token refresh service

### DIFF
--- a/src/miro_backend/services/token_service.py
+++ b/src/miro_backend/services/token_service.py
@@ -1,0 +1,53 @@
+"""Utilities for obtaining valid access tokens."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from ..models.user import User
+from .miro_client import MiroClient
+
+REFRESH_MARGIN = timedelta(seconds=30)
+
+
+async def get_valid_access_token(
+    session: Session, user_id: str, client: MiroClient
+) -> str:
+    """Return a valid access token for ``user_id``.
+
+    Refreshes the token via ``client`` when the stored one is about to expire.
+    The updated token information is persisted by committing ``session``.
+
+    Args:
+        session: Active database session.
+        user_id: Miro user identifier.
+        client: Client used to refresh access tokens.
+
+    Returns:
+        A valid access token for the user.
+
+    Raises:
+        ValueError: If no user exists for ``user_id``.
+    """
+    user = session.query(User).filter(User.user_id == user_id).one_or_none()
+    if user is None:
+        raise ValueError(f"Unknown user_id {user_id!r}")
+
+    expires_at = (
+        user.expires_at
+        if user.expires_at.tzinfo is not None
+        else user.expires_at.replace(tzinfo=timezone.utc)
+    )
+    if expires_at - datetime.now(timezone.utc) > REFRESH_MARGIN:
+        return user.access_token
+
+    tokens = await client.refresh_token(user.refresh_token)
+    user.access_token = tokens["access_token"]
+    if refresh := tokens.get("refresh_token"):
+        user.refresh_token = refresh
+    expires_in = int(tokens.get("expires_in", 0))
+    user.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    session.commit()
+    return user.access_token

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -1,0 +1,86 @@
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.models.user import User
+from miro_backend.services.token_service import get_valid_access_token
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def setup_db() -> Iterator[None]:
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture  # type: ignore[misc]
+def session() -> Iterator[Session]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class DummyClient:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.called_with: list[str] = []
+
+    async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+        self.called_with.append(refresh_token)
+        return self.response
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_returns_existing_token_when_not_expiring(session: Session) -> None:
+    user = User(
+        user_id="u1",
+        name="Test",
+        access_token="tok",
+        refresh_token="ref",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+    session.add(user)
+    session.commit()
+    client = DummyClient({})
+
+    token = await get_valid_access_token(session, "u1", cast(Any, client))
+
+    assert token == "tok"
+    assert client.called_with == []
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_refreshes_token_when_expiring(session: Session) -> None:
+    user = User(
+        user_id="u2",
+        name="Test",
+        access_token="old",
+        refresh_token="r1",
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=1),
+    )
+    session.add(user)
+    session.commit()
+
+    response = {
+        "access_token": "new",
+        "refresh_token": "r2",
+        "expires_in": 60,
+    }
+    client = DummyClient(response)
+
+    token = await get_valid_access_token(session, "u2", cast(Any, client))
+
+    assert token == "new"
+    refreshed = session.query(User).filter_by(user_id="u2").one()
+    assert refreshed.access_token == "new"
+    assert refreshed.refresh_token == "r2"
+    assert refreshed.expires_at.replace(tzinfo=timezone.utc) > datetime.now(
+        timezone.utc
+    )
+    assert client.called_with == ["r1"]


### PR DESCRIPTION
## Summary
- add `get_valid_access_token` utility to refresh user tokens when near expiry
- cover token refresh scenarios with new tests

## Testing
- `poetry run ruff check src/miro_backend/services/token_service.py tests/test_token_service.py`
- `PYTHONPATH=src poetry run mypy src/miro_backend/services/token_service.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06e5e5008832bb076e1eab1e085ec