### PR TITLE
feat(queue): add change queue length metric

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -28,6 +28,7 @@ from .core.logging import configure_logging, setup_fastapi  # noqa: E402
 from .core.security import setup_security  # noqa: E402
 from .core.telemetry import setup_telemetry  # noqa: E402
 from .queue import get_change_queue  # noqa: E402
+from .queue.change_queue import change_queue_length  # noqa: E402
 from .services.miro_client import MiroClient  # noqa: E402
 
 change_queue = get_change_queue()
@@ -98,6 +99,7 @@ app.include_router(cache_router)
 app.include_router(batch_router)
 
 instrumentator = Instrumentator().instrument(app)
+instrumentator.registry.register(change_queue_length)
 
 
 @app.get("/metrics")  # type: ignore[misc]

--- a/tests/test_change_queue_metric.py
+++ b/tests/test_change_queue_metric.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from miro_backend.queue import ChangeQueue
+from miro_backend.queue.tasks import CreateNode
+
+
+async def _idle_worker(_: Any) -> None:
+    await asyncio.Event().wait()
+
+
+def test_change_queue_length_metric(tmp_path: Path) -> None:
+    """Gauge should reflect queue size on enqueue and dequeue."""
+
+    static_dir = Path(__file__).resolve().parent.parent / "web" / "client" / "dist"
+    static_dir.mkdir(parents=True, exist_ok=True)
+
+    app_module = importlib.import_module("miro_backend.main")
+    queue = ChangeQueue()
+    queue.worker = _idle_worker
+    app_module.change_queue = queue  # type: ignore[attr-defined]
+
+    with TestClient(app_module.app) as client:
+
+        def gauge() -> float:
+            metrics = client.get("/metrics").text
+            for line in metrics.splitlines():
+                if line.startswith("change_queue_length"):
+                    return float(line.split()[-1])
+            return -1.0
+
+        assert gauge() == 0.0
+
+        asyncio.run(queue.enqueue(CreateNode(node_id="n1", data={})))
+        assert gauge() == 1.0
+
+        asyncio.run(queue.dequeue())
+        assert gauge() == 0.0


### PR DESCRIPTION
## Summary
- track change queue length with Prometheus gauge
- expose change queue length metric via /metrics
- test metric reports queue size

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/change_queue.py src/miro_backend/main.py tests/test_change_queue_metric.py`
- `poetry run pytest` *(fails: from __future__ imports must occur at the beginning of the file)*
- `poetry run pytest tests/test_change_queue_metric.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a073c74118832bba1235f40fd877f9