### PR TITLE
feat(queue): add idempotent response persistence

### DIFF
--- a/tests/test_idempotency_persistence.py
+++ b/tests/test_idempotency_persistence.py
@@ -1,0 +1,30 @@
+"""Verify idempotency persistence helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miro_backend.queue.persistence import QueuePersistence
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_save_and_get_idempotent(tmp_path: Path) -> None:
+    """Saving and retrieving by key should round-trip the response."""
+
+    db = tmp_path / "idem.db"
+    persistence = QueuePersistence(db)
+    data = {"ok": True}
+
+    await persistence.save_idempotent("k1", data)
+    assert await persistence.get_idempotent("k1") == data
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_get_idempotent_missing(tmp_path: Path) -> None:
+    """Missing keys should return ``None``."""
+
+    persistence = QueuePersistence(tmp_path / "idem.db")
+
+    assert await persistence.get_idempotent("missing") is None


### PR DESCRIPTION
## Summary
- persist idempotent responses in new SQLite table
- expose async helpers to save and load idempotent responses
- cover idempotent persistence with tests

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/persistence.py tests/test_idempotency_persistence.py`
- `poetry run pytest tests/test_idempotency_persistence.py --cov-fail-under=0`
- `poetry run pytest` (fails: from __future__ imports must occur at the beginning of the file)


------
https://chatgpt.com/codex/tasks/task_e_68a073e3f0e8832bb7bd40ca4209c06b