### PR TITLE
feat: support idempotent batch requests

### DIFF
--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Header, status
 import logfire
 
 from ...queue.change_queue import ChangeQueue
@@ -15,11 +15,24 @@ router = APIRouter(prefix="/api", tags=["batch"])
 
 @router.post("/batch", status_code=status.HTTP_202_ACCEPTED, response_model=BatchResponse)  # type: ignore[misc]
 async def post_batch(
-    request: BatchRequest, queue: ChangeQueue = Depends(get_change_queue)
+    request: BatchRequest,
+    queue: ChangeQueue = Depends(get_change_queue),
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
 ) -> BatchResponse:
     """Validate ``request`` and enqueue its operations."""
 
     with logfire.span("post batch"):
+        if idempotency_key and queue.persistence is not None:
+            existing = await queue.persistence.get_response(idempotency_key)
+            if existing is not None:
+                return BatchResponse.model_validate(existing)
+
         count = await enqueue_operations(request.operations, queue)
         logfire.info("batch operations enqueued", count=count)  # event after enqueuing
-        return BatchResponse(enqueued=count)
+        response = BatchResponse(enqueued=count)
+
+        if idempotency_key and queue.persistence is not None:
+            await queue.persistence.save_response(
+                idempotency_key, response.model_dump()
+            )
+        return response

--- a/src/miro_backend/queue/change_queue.py
+++ b/src/miro_backend/queue/change_queue.py
@@ -24,6 +24,12 @@ class ChangeQueue:
                 logfire.info("loaded persisted task", task=task)
                 self._queue.put_nowait(task)
 
+    @property
+    def persistence(self) -> Any | None:
+        """Return the persistence layer used by this queue."""
+
+        return self._persistence
+
     @logfire.instrument("enqueue task {task=}")  # type: ignore[misc]
     async def enqueue(self, task: ChangeTask) -> None:
         """Add ``task`` to the queue and persist it if supported."""

--- a/src/miro_backend/queue/persistence.py
+++ b/src/miro_backend/queue/persistence.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
-from typing import Type
+from typing import Any, Type, cast
 
 from .tasks import (
     ChangeTask,
@@ -38,6 +39,15 @@ class QueuePersistence:
                 CREATE TABLE IF NOT EXISTS tasks (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     type TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS responses (
+                    key TEXT PRIMARY KEY,
                     payload TEXT NOT NULL
                 )
                 """
@@ -84,3 +94,29 @@ class QueuePersistence:
                 continue
             tasks.append(cls.model_validate_json(payload))
         return tasks
+
+    async def get_response(self, key: str) -> dict[str, Any] | None:
+        """Return a stored response for ``key`` if present."""
+
+        return await asyncio.to_thread(self._get_response, key)
+
+    def _get_response(self, key: str) -> dict[str, Any] | None:
+        with sqlite3.connect(self._path) as conn:
+            cursor = conn.execute("SELECT payload FROM responses WHERE key = ?", (key,))
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return cast(dict[str, Any], json.loads(row[0]))
+
+    async def save_response(self, key: str, response: dict[str, Any]) -> None:
+        """Persist ``response`` under ``key``."""
+
+        await asyncio.to_thread(self._save_response, key, response)
+
+    def _save_response(self, key: str, response: dict[str, Any]) -> None:
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO responses (key, payload) VALUES (?, ?)",
+                (key, json.dumps(response)),
+            )
+            conn.commit()

--- a/tests/test_batch_controller.py
+++ b/tests/test_batch_controller.py
@@ -12,11 +12,25 @@ from miro_backend.queue.provider import get_change_queue
 from miro_backend.queue.tasks import CreateNode, UpdateCard
 
 
+class MemoryPersistence:
+    """In-memory store for idempotency responses."""
+
+    def __init__(self) -> None:
+        self.responses: dict[str, dict[str, int]] = {}
+
+    async def get_response(self, key: str) -> dict[str, int] | None:
+        return self.responses.get(key)
+
+    async def save_response(self, key: str, response: dict[str, int]) -> None:
+        self.responses[key] = response
+
+
 class DummyQueue:
     """Simple queue capturing enqueued tasks."""
 
-    def __init__(self) -> None:
+    def __init__(self, persistence: MemoryPersistence | None = None) -> None:
         self.tasks: list[object] = []
+        self.persistence = persistence
 
     async def enqueue(self, task: object) -> None:
         self.tasks.append(task)
@@ -25,7 +39,8 @@ class DummyQueue:
 # mypy struggles with pytest fixtures
 @pytest.fixture  # type: ignore[misc]
 def client_queue() -> Iterator[tuple[TestClient, DummyQueue]]:
-    queue = DummyQueue()
+    persistence = MemoryPersistence()
+    queue = DummyQueue(persistence=persistence)
     app.dependency_overrides[get_change_queue] = lambda: queue
     client = TestClient(app)
     yield client, queue
@@ -55,3 +70,34 @@ def test_post_batch_validates_payload(
     body = {"operations": [{"type": "create_node", "node_id": "n1"}]}
     response = client.post("/api/batch", json=body)
     assert response.status_code == 422
+
+
+def test_post_batch_returns_cached_response(
+    client_queue: tuple[TestClient, DummyQueue]
+) -> None:
+    client, queue = client_queue
+    assert queue.persistence is not None
+    queue.persistence.responses["key1"] = {"enqueued": 3}
+    body = {"operations": [{"type": "create_node", "node_id": "n1", "data": {"x": 1}}]}
+    response = client.post("/api/batch", json=body, headers={"Idempotency-Key": "key1"})
+    assert response.status_code == 202
+    assert response.json() == {"enqueued": 3}
+    assert len(queue.tasks) == 0
+
+
+def test_post_batch_saves_idempotent_response(
+    client_queue: tuple[TestClient, DummyQueue]
+) -> None:
+    client, queue = client_queue
+    key = "key2"
+    body = {
+        "operations": [
+            {"type": "create_node", "node_id": "n1", "data": {"x": 1}},
+            {"type": "update_card", "card_id": "c1", "payload": {"y": 2}},
+        ]
+    }
+    response = client.post("/api/batch", json=body, headers={"Idempotency-Key": key})
+    assert response.status_code == 202
+    assert response.json() == {"enqueued": 2}
+    assert queue.persistence is not None
+    assert queue.persistence.responses[key] == {"enqueued": 2}


### PR DESCRIPTION
## Summary
- allow setting Idempotency-Key for batch endpoint
- persist and reuse batch results via queue persistence
- test batch endpoint idempotency

## Testing
- `poetry run pre-commit run --files src/miro_backend/api/routers/batch.py src/miro_backend/queue/change_queue.py src/miro_backend/queue/persistence.py tests/test_batch_controller.py` *(fails: tests/test_miro_client.py import mismatch; tests/test_token_service.py SyntaxError)*
- `poetry run pytest tests/test_batch_controller.py tests/test_change_queue_persistence.py` *(fails: coverage 96% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a073e73b78832bbb00ccd2ea8a334d