### PR TITLE
test(queue): verify retry-after backoff

### DIFF
--- a/tests/test_worker_backoff.py
+++ b/tests/test_worker_backoff.py
@@ -1,0 +1,59 @@
+"""Test the worker's handling of retry-after backoff."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from miro_backend.queue import ChangeQueue, CreateNode
+
+
+class RetryAfterError(Exception):
+    """Error carrying ``retry_after`` and ``status`` for backoff."""
+
+    def __init__(self, retry_after: float) -> None:
+        super().__init__("retry later")
+        self.status = 429
+        self.retry_after = retry_after
+
+
+class FlakyClient:
+    """Client that fails twice before succeeding."""
+
+    def __init__(self, retry_after: float) -> None:
+        self._retry_after = retry_after
+        self.calls = 0
+        self.created: list[tuple[str, dict[str, int]]] = []
+
+    async def create_node(self, node_id: str, data: dict[str, int]) -> None:
+        self.calls += 1
+        if self.calls < 3:
+            raise RetryAfterError(self._retry_after)
+        self.created.append((node_id, data))
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_worker_respects_retry_after_backoff() -> None:
+    queue = ChangeQueue()
+    retry_delay = 0.1
+    client = FlakyClient(retry_delay)
+
+    worker = asyncio.create_task(queue.worker(client))
+    try:
+        await queue.enqueue(CreateNode(node_id="n1", data={"x": 1}))
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        while not client.created:
+            await asyncio.sleep(0.01)
+        duration = loop.time() - start
+    finally:
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+
+    assert client.created == [("n1", {"x": 1})]
+    assert client.calls == 3
+    assert duration >= retry_delay * 2
+    assert duration < 1


### PR DESCRIPTION
## Summary
- add unit test ensuring worker honors `retry_after` delays and eventually succeeds

## Testing
- `poetry run pre-commit run black --files tests/test_worker_backoff.py`
- `poetry run pre-commit run ruff --files tests/test_worker_backoff.py`
- `poetry run pre-commit run mypy --files tests/test_worker_backoff.py`
- `poetry run pytest tests/test_worker_backoff.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a073ed92c0832bb5fc8bbeb47335c0