### PR TITLE
feat(core): add oauth config and timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 MIRO_CLIENT_ID=your-client-id
 MIRO_CLIENT_SECRET=your-client-secret
 MIRO_WEBHOOK_SECRET=change-me
+MIRO_REDIRECT_URI=https://example.com/oauth/callback

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,10 @@ cors_origins:
 client_id: your-client-id
 client_secret: your-client-secret
 webhook_secret: change-me
+oauth_auth_base: https://miro.com/oauth/authorize
+oauth_token_url: https://api.miro.com/v1/oauth/token
+oauth_scope: boards:read boards:write
+oauth_redirect_uri: https://example.com/oauth/callback
 logfire_service_name: miro-backend
 logfire_send_to_logfire: false
 http_timeout_seconds: 10.0

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -8,7 +8,7 @@ from shutil import copyfile
 from typing import Any, cast
 
 import yaml
-from pydantic import SecretStr, ValidationError
+from pydantic import Field, SecretStr, ValidationError
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -19,17 +19,65 @@ from pydantic_settings import (
 class Settings(BaseSettings):
     """Defines runtime application settings."""
 
-    database_url: str = "sqlite:///./app.db"
-    cors_origins: list[str] = ["*"]
-    client_id: str
-    client_secret: SecretStr
-    webhook_secret: SecretStr
-    logfire_service_name: str = "miro-backend"
-    logfire_send_to_logfire: bool = False
-    http_timeout_seconds: float = 10.0
+    database_url: str = Field(
+        default="sqlite:///./app.db",
+        alias="MIRO_DATABASE_URL",
+        description="Database connection URL.",
+    )
+    cors_origins: list[str] = Field(
+        default=["*"],
+        alias="MIRO_CORS_ORIGINS",
+        description="List of allowed CORS origins.",
+    )
+    client_id: str = Field(
+        alias="MIRO_CLIENT_ID",
+        description="OAuth client identifier issued by Miro.",
+    )
+    client_secret: SecretStr = Field(
+        alias="MIRO_CLIENT_SECRET",
+        description="OAuth client secret issued by Miro.",
+    )
+    webhook_secret: SecretStr = Field(
+        alias="MIRO_WEBHOOK_SECRET",
+        description="Secret token used to verify Miro webhooks.",
+    )
+    oauth_auth_base: str = Field(
+        default="https://miro.com/oauth/authorize",
+        alias="MIRO_OAUTH_AUTH_BASE",
+        description="Base URL for the Miro OAuth authorization endpoint.",
+    )
+    oauth_token_url: str = Field(
+        default="https://api.miro.com/v1/oauth/token",
+        alias="MIRO_OAUTH_TOKEN_URL",
+        description="Miro OAuth token endpoint for exchanging authorization codes.",
+    )
+    oauth_scope: str = Field(
+        default="boards:read boards:write",
+        alias="MIRO_OAUTH_SCOPE",
+        description="Space-separated list of OAuth scopes requested.",
+    )
+    oauth_redirect_uri: str = Field(
+        alias="MIRO_REDIRECT_URI",
+        description="Callback URL registered with Miro for OAuth redirects.",
+    )
+    logfire_service_name: str = Field(
+        default="miro-backend",
+        alias="MIRO_LOGFIRE_SERVICE_NAME",
+        description="Service name reported to Logfire.",
+    )
+    logfire_send_to_logfire: bool = Field(
+        default=False,
+        alias="MIRO_LOGFIRE_SEND_TO_LOGFIRE",
+        description="Whether to send logs to Logfire.",
+    )
+    http_timeout_seconds: float = Field(
+        default=10.0,
+        alias="MIRO_HTTP_TIMEOUT_SECONDS",
+        description="Default timeout in seconds for outbound HTTP requests.",
+    )
 
     model_config = SettingsConfigDict(
-        env_prefix="MIRO_", env_file=".env", extra="ignore"
+        env_file=".env", extra="ignore", populate_by_name=True
     )
 
     @classmethod


### PR DESCRIPTION
## Summary
- add oauth-related configuration fields with environment variable aliases
- provide defaults for oauth URLs, scope, and HTTP timeout
- document new settings and update example configuration files

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/core/config.py config.example.yaml .env.example`
- `poetry run pytest` (fails: SyntaxError in tests/test_token_service.py)


------
https://chatgpt.com/codex/tasks/task_e_68a0780bc944832ba735905c5dbdbdc5