### PR TITLE
feat(oauth): expand OAuth configuration

### DIFF
--- a/tests/integration/test_oauth_persist.py
+++ b/tests/integration/test_oauth_persist.py
@@ -52,22 +52,29 @@ class DBUserStore(UserStore):  # type: ignore[misc]
 
     def store(self, info: UserInfo) -> None:
         with self._factory() as session:
-            session.add(
-                User(
-                    user_id=info.id,
-                    name=info.name,
-                    access_token=info.access_token,
-                    refresh_token=info.refresh_token,
-                    expires_at=info.expires_at,
-                )
-            )
+            user = session.query(User).filter_by(user_id=info.id).one_or_none()
+            if user is None:
+                user = User(user_id=info.id, name=info.name)
+                session.add(user)
+            user.name = info.name
+            user.access_token = info.access_token
+            user.refresh_token = info.refresh_token
+            user.expires_at = info.expires_at
             session.commit()
 
 
 class StubMiroClient(MiroClient):  # type: ignore[misc]
     """Stubbed Miro client returning fixed tokens."""
 
-    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, int | str]:
+    async def exchange_code(
+        self,
+        code: str,
+        redirect_uri: str,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, int | str]:
         return {
             "access_token": "access_token",
             "refresh_token": "refresh_token",

--- a/tests/test_miro_client.py
+++ b/tests/test_miro_client.py
@@ -21,7 +21,14 @@ async def test_exchange_code(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: async_client)
 
     client = MiroClient()
-    res = await client.exchange_code("c", "redir")
+    res = await client.exchange_code(
+        "c",
+        "redir",
+        "https://api.miro.com/v1/oauth/token",
+        settings.client_id,
+        settings.client_secret.get_secret_value(),
+        None,
+    )
 
     assert res == {"ok": True}
     assert captured == {

--- a/tests/test_o_auth_controller.py
+++ b/tests/test_o_auth_controller.py
@@ -23,7 +23,15 @@ class StubClient(MiroClient):  # type: ignore[misc]
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
 
-    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, int | str]:
+    async def exchange_code(
+        self,
+        code: str,
+        redirect_uri: str,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, int | str]:
         self.calls.append((code, redirect_uri))
         return {"access_token": "tok", "refresh_token": "ref", "expires_in": 3600}
 
@@ -34,7 +42,15 @@ class CountingStub(MiroClient):  # type: ignore[misc]
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
 
-    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, int | str]:
+    async def exchange_code(
+        self,
+        code: str,
+        redirect_uri: str,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, int | str]:
         self.calls.append((code, redirect_uri))
         n = len(self.calls)
         return {
@@ -53,6 +69,9 @@ def client_store() -> Iterator[tuple[TestClient, InMemoryUserStore, StubClient]]
         client_id="id",
         client_secret="secret",
         redirect_uri="http://redir",
+        scope="boards:read boards:write",
+        token_url="http://token",
+        timeout_seconds=1.0,
     )
     app.dependency_overrides[get_user_store] = lambda: store
     app.dependency_overrides[oauth.get_miro_client] = lambda: stub
@@ -73,6 +92,9 @@ def client_store_db() -> Iterator[tuple[TestClient, InMemoryUserStore, CountingS
         client_id="id",
         client_secret="secret",
         redirect_uri="http://redir",
+        scope="boards:read boards:write",
+        token_url="http://token",
+        timeout_seconds=1.0,
     )
     app.dependency_overrides[get_user_store] = lambda: store
     app.dependency_overrides[oauth.get_miro_client] = lambda: stub


### PR DESCRIPTION
## Summary
- extend OAuthConfig with scope, token_url and timeout fields
- build login and callback routes from injected OAuthConfig
- allow MiroClient.exchange_code to accept token URL and timeout

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/oauth.py src/miro_backend/services/miro_client.py tests/integration/test_oauth_persist.py tests/test_miro_client.py tests/test_o_auth_controller.py`
- `PYTEST_ADDOPTS="--cov-fail-under=0" poetry run pytest tests/test_o_auth_controller.py tests/test_miro_client.py tests/integration/test_oauth_persist.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0780b7888832bae912e8d5bfd33c5