### PR TITLE
feat: include user context in queued tasks

### DIFF
--- a/src/miro_backend/queue/tasks.py
+++ b/src/miro_backend/queue/tasks.py
@@ -17,9 +17,13 @@ from pydantic import BaseModel
 class ChangeTask(BaseModel, ABC):
     """Abstract base class for all change tasks."""
 
+    user_id: str
+
     @abstractmethod
-    async def apply(self, client: Any) -> None:  # pragma: no cover - interface
-        """Apply the change using ``client``."""
+    async def apply(
+        self, client: Any, token: str
+    ) -> None:  # pragma: no cover - interface
+        """Apply the change using ``client`` and ``token``."""
 
 
 class CreateNode(ChangeTask):
@@ -28,8 +32,8 @@ class CreateNode(ChangeTask):
     node_id: str
     data: dict[str, Any]
 
-    async def apply(self, client: Any) -> None:
-        await client.create_node(self.node_id, self.data)
+    async def apply(self, client: Any, token: str) -> None:
+        await client.create_node(self.node_id, self.data, token)
 
 
 class UpdateCard(ChangeTask):
@@ -38,8 +42,8 @@ class UpdateCard(ChangeTask):
     card_id: str
     payload: dict[str, Any]
 
-    async def apply(self, client: Any) -> None:
-        await client.update_card(self.card_id, self.payload)
+    async def apply(self, client: Any, token: str) -> None:
+        await client.update_card(self.card_id, self.payload, token)
 
 
 class CreateShape(ChangeTask):
@@ -49,8 +53,8 @@ class CreateShape(ChangeTask):
     shape_id: str
     data: dict[str, Any]
 
-    async def apply(self, client: Any) -> None:
-        await client.create_shape(self.board_id, self.shape_id, self.data)
+    async def apply(self, client: Any, token: str) -> None:
+        await client.create_shape(self.board_id, self.shape_id, self.data, token)
 
 
 class UpdateShape(ChangeTask):
@@ -60,8 +64,8 @@ class UpdateShape(ChangeTask):
     shape_id: str
     data: dict[str, Any]
 
-    async def apply(self, client: Any) -> None:
-        await client.update_shape(self.board_id, self.shape_id, self.data)
+    async def apply(self, client: Any, token: str) -> None:
+        await client.update_shape(self.board_id, self.shape_id, self.data, token)
 
 
 class DeleteShape(ChangeTask):
@@ -70,5 +74,5 @@ class DeleteShape(ChangeTask):
     board_id: str
     shape_id: str
 
-    async def apply(self, client: Any) -> None:
-        await client.delete_shape(self.board_id, self.shape_id)
+    async def apply(self, client: Any, token: str) -> None:
+        await client.delete_shape(self.board_id, self.shape_id, token)

--- a/src/miro_backend/schemas/card_create.py
+++ b/src/miro_backend/schemas/card_create.py
@@ -20,9 +20,9 @@ class CardCreate(BaseModel):
     fields: list[dict[str, Any]] | None = None
     taskStatus: str | None = None
 
-    def to_task(self) -> ChangeTask:
-        """Convert this definition into a :class:`ChangeTask`."""
+    def to_task(self, user_id: str) -> ChangeTask:
+        """Convert this definition into a :class:`ChangeTask` for ``user_id``."""
 
         payload = self.model_dump(exclude_none=True)
         node_id = payload.pop("id", "")
-        return CreateNode(node_id=node_id, data=payload)
+        return CreateNode(node_id=node_id, data=payload, user_id=user_id)

--- a/src/miro_backend/services/batch_service.py
+++ b/src/miro_backend/services/batch_service.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-from ..queue import ChangeQueue, ChangeTask, CreateNode, UpdateCard
+from ..queue.tasks import ChangeTask, CreateNode, UpdateCard
+
+if TYPE_CHECKING:
+    from ..queue.change_queue import ChangeQueue
 from ..schemas.batch import (
     CreateNodeOperation,
     Operation,
@@ -13,7 +17,7 @@ from ..schemas.batch import (
 
 
 async def enqueue_operations(
-    operations: Sequence[Operation], queue: ChangeQueue
+    operations: Sequence[Operation], queue: "ChangeQueue", user_id: str
 ) -> int:
     """Convert ``operations`` into tasks and enqueue them.
 
@@ -28,9 +32,9 @@ async def enqueue_operations(
     for op in operations:
         task: ChangeTask
         if isinstance(op, CreateNodeOperation):
-            task = CreateNode(node_id=op.node_id, data=op.data)
+            task = CreateNode(node_id=op.node_id, data=op.data, user_id=user_id)
         elif isinstance(op, UpdateCardOperation):
-            task = UpdateCard(card_id=op.card_id, payload=op.payload)
+            task = UpdateCard(card_id=op.card_id, payload=op.payload, user_id=user_id)
         else:  # pragma: no cover - safeguarded by Pydantic validation
             continue
         await queue.enqueue(task)

--- a/src/miro_backend/services/miro_client.py
+++ b/src/miro_backend/services/miro_client.py
@@ -7,10 +7,6 @@ from typing import Any, cast
 
 import httpx
 
-from miro_backend.core.config import settings
-
-import httpx
-
 from ..core.config import settings
 
 
@@ -29,13 +25,17 @@ class MiroClient:
         self._token_provider = token_provider
         self._base_url = "https://api.miro.com/v2"
 
-    def _auth_headers(self) -> dict[str, str]:
-        token = self._token or (
-            self._token_provider() if self._token_provider else None
+    def _auth_headers(self, access_token: str | None = None) -> dict[str, str]:
+        token = (
+            access_token
+            or self._token
+            or (self._token_provider() if self._token_provider else None)
         )
         return {"Authorization": f"Bearer {token}"} if token else {}
 
-    async def create_node(self, node_id: str, data: dict[str, Any]) -> None:
+    async def create_node(
+        self, node_id: str, data: dict[str, Any], access_token: str
+    ) -> None:
         """Create a graph node.
 
         Parameters
@@ -52,10 +52,12 @@ class MiroClient:
             await client.put(
                 f"/graph/nodes/{node_id}",
                 json=data,
-                headers=self._auth_headers(),
+                headers=self._auth_headers(access_token),
             )
 
-    async def update_card(self, card_id: str, payload: dict[str, Any]) -> None:
+    async def update_card(
+        self, card_id: str, payload: dict[str, Any], access_token: str
+    ) -> None:
         """Update an existing card.
 
         Parameters
@@ -72,11 +74,15 @@ class MiroClient:
             await client.patch(
                 f"/cards/{card_id}",
                 json=payload,
-                headers=self._auth_headers(),
+                headers=self._auth_headers(access_token),
             )
 
     async def create_shape(
-        self, board_id: str, shape_id: str, data: dict[str, Any]
+        self,
+        board_id: str,
+        shape_id: str,
+        data: dict[str, Any],
+        access_token: str,
     ) -> None:
         """Create a shape on ``board_id`` with ``shape_id``.
 
@@ -96,11 +102,15 @@ class MiroClient:
             await client.put(
                 f"/boards/{board_id}/shapes/{shape_id}",
                 json=data,
-                headers=self._auth_headers(),
+                headers=self._auth_headers(access_token),
             )
 
     async def update_shape(
-        self, board_id: str, shape_id: str, data: dict[str, Any]
+        self,
+        board_id: str,
+        shape_id: str,
+        data: dict[str, Any],
+        access_token: str,
     ) -> None:
         """Update ``shape_id`` on ``board_id``.
 
@@ -120,10 +130,12 @@ class MiroClient:
             await client.patch(
                 f"/boards/{board_id}/shapes/{shape_id}",
                 json=data,
-                headers=self._auth_headers(),
+                headers=self._auth_headers(access_token),
             )
 
-    async def delete_shape(self, board_id: str, shape_id: str) -> None:
+    async def delete_shape(
+        self, board_id: str, shape_id: str, access_token: str
+    ) -> None:
         """Delete ``shape_id`` from ``board_id``.
 
         Parameters
@@ -139,7 +151,7 @@ class MiroClient:
         ) as client:
             await client.delete(
                 f"/boards/{board_id}/shapes/{shape_id}",
-                headers=self._auth_headers(),
+                headers=self._auth_headers(access_token),
             )
 
     async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:

--- a/src/miro_backend/services/token_service.py
+++ b/src/miro_backend/services/token_service.py
@@ -1,5 +1,4 @@
 """Utilities for obtaining valid access tokens."""
-"""Helpers for ensuring OAuth access tokens remain valid."""
 
 from __future__ import annotations
 
@@ -11,6 +10,7 @@ from ..models.user import User
 from .miro_client import MiroClient
 
 REFRESH_MARGIN = timedelta(seconds=30)
+
 
 async def get_valid_access_token(
     session: Session, user_id: str, client: MiroClient
@@ -49,5 +49,5 @@ async def get_valid_access_token(
     expires_in = int(tokens.get("expires_in", 0))
     user.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
     session.commit()
-    
+
     return user.access_token

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,9 @@ class DummyQueue:
     async def enqueue(self, task: object) -> None:
         self.tasks.append(task)
 
-    async def worker(self, _client: object) -> None:  # pragma: no cover - never returns
+    async def worker(
+        self, _session: object, _client: object
+    ) -> None:  # pragma: no cover - never returns
         await asyncio.Event().wait()
 
 

--- a/tests/integration/test_miro_client.py
+++ b/tests/integration/test_miro_client.py
@@ -59,19 +59,27 @@ class DummyAsyncClient:
     [
         (
             "create_shape",
-            ("b1", "s1", {"x": 1}),
+            ("b1", "s1", {"x": 1}, "tok"),
             ("PUT", "/boards/b1/shapes/s1", {"x": 1}),
         ),
         (
             "update_shape",
-            ("b1", "s1", {"y": 2}),
+            ("b1", "s1", {"y": 2}, "tok"),
             ("PATCH", "/boards/b1/shapes/s1", {"y": 2}),
         ),
-        ("delete_shape", ("b1", "s1"), ("DELETE", "/boards/b1/shapes/s1", None)),
-        ("update_card", ("c1", {"title": "t"}), ("PATCH", "/cards/c1", {"title": "t"})),
+        (
+            "delete_shape",
+            ("b1", "s1", "tok"),
+            ("DELETE", "/boards/b1/shapes/s1", None),
+        ),
+        (
+            "update_card",
+            ("c1", {"title": "t"}, "tok"),
+            ("PATCH", "/cards/c1", {"title": "t"}),
+        ),
         (
             "create_node",
-            ("n1", {"kind": "card"}),
+            ("n1", {"kind": "card"}, "tok"),
             ("PUT", "/graph/nodes/n1", {"kind": "card"}),
         ),
     ],

--- a/tests/integration/test_shapes.py
+++ b/tests/integration/test_shapes.py
@@ -40,3 +40,4 @@ async def test_create_shape_enqueues_task(
     assert isinstance(task, CreateShape)
     assert task.board_id == "b1"
     assert task.shape_id == data["id"]
+    assert task.user_id == "user-1"

--- a/tests/test_batch_idempotency.py
+++ b/tests/test_batch_idempotency.py
@@ -44,7 +44,7 @@ def test_post_batch_is_idempotent(
             {"type": "update_card", "card_id": "c1", "payload": {"y": 2}},
         ]
     }
-    headers = {"Idempotency-Key": "abc123"}
+    headers = {"Idempotency-Key": "abc123", "X-User-Id": "u1"}
 
     first = client.post("/api/batch", json=body, headers=headers)
     second = client.post("/api/batch", json=body, headers=headers)

--- a/tests/test_cards_controller.py
+++ b/tests/test_cards_controller.py
@@ -20,7 +20,9 @@ class StubQueue:
     async def enqueue(self, task: ChangeTask) -> None:
         self.tasks.append(task)
 
-    async def worker(self, client: object) -> None:  # pragma: no cover - stub
+    async def worker(
+        self, _session: object, _client: object
+    ) -> None:  # pragma: no cover - stub
         """No-op worker used during testing."""
 
         return
@@ -40,6 +42,7 @@ def test_post_cards_enqueues_tasks(tmp_path: Path) -> None:
         response = client.post(
             "/api/cards",
             json=[{"id": "c1", "title": "t"}],
+            headers={"X-User-Id": "u1"},
         )
         assert response.status_code == 202
     app_module.app.dependency_overrides.clear()
@@ -49,3 +52,4 @@ def test_post_cards_enqueues_tasks(tmp_path: Path) -> None:
     assert isinstance(task, CreateNode)
     assert task.node_id == "c1"
     assert task.data["title"] == "t"
+    assert task.user_id == "u1"

--- a/tests/test_change_queue_metric.py
+++ b/tests/test_change_queue_metric.py
@@ -11,7 +11,7 @@ from miro_backend.queue import ChangeQueue
 from miro_backend.queue.tasks import CreateNode
 
 
-async def _idle_worker(_: Any) -> None:
+async def _idle_worker(_: Any, __: Any) -> None:
     await asyncio.Event().wait()
 
 
@@ -37,7 +37,7 @@ def test_change_queue_length_metric(tmp_path: Path) -> None:
 
         assert gauge() == 0.0
 
-        asyncio.run(queue.enqueue(CreateNode(node_id="n1", data={})))
+        asyncio.run(queue.enqueue(CreateNode(node_id="n1", data={}, user_id="u1")))
         assert gauge() == 1.0
 
         asyncio.run(queue.dequeue())

--- a/tests/test_change_queue_persistence.py
+++ b/tests/test_change_queue_persistence.py
@@ -20,7 +20,7 @@ async def test_enqueue_dequeue_persists() -> None:
     persistence = mock.AsyncMock()
     persistence.load = mock.Mock(return_value=[])
     queue = ChangeQueue(persistence=persistence)
-    task = CreateNode(node_id="n1", data={})
+    task = CreateNode(node_id="n1", data={}, user_id="u1")
 
     await queue.enqueue(task)
     persistence.save.assert_awaited_once_with(task)
@@ -37,7 +37,7 @@ async def test_tasks_survive_restart(tmp_path: Path) -> None:
     persistence = QueuePersistence(db_path)
 
     queue = ChangeQueue(persistence=persistence)
-    task = CreateNode(node_id="n1", data={})
+    task = CreateNode(node_id="n1", data={}, user_id="u1")
     await queue.enqueue(task)
 
     restored = ChangeQueue(persistence=persistence)

--- a/tests/test_shape_queue_processor.py
+++ b/tests/test_shape_queue_processor.py
@@ -1,4 +1,5 @@
 """Translation of ``ShapeQueueProcessorTests`` for the Python queue implementation."""
+
 from __future__ import annotations
 
 import asyncio
@@ -14,22 +15,33 @@ class FakeClient:
         self.created: list[tuple[str, dict[str, int]]] = []
         self.updated: list[tuple[str, dict[str, int]]] = []
 
-    async def create_node(self, node_id: str, data: dict[str, int]) -> None:
+    async def create_node(
+        self, node_id: str, data: dict[str, int], _token: str
+    ) -> None:
         self.created.append((node_id, data))
 
-    async def update_card(self, card_id: str, payload: dict[str, int]) -> None:
+    async def update_card(
+        self, card_id: str, payload: dict[str, int], _token: str
+    ) -> None:
         self.updated.append((card_id, payload))
 
 
-@pytest.mark.asyncio
-async def test_worker_processes_tasks() -> None:
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_worker_processes_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
     queue = ChangeQueue()
     client = FakeClient()
 
-    worker = asyncio.create_task(queue.worker(client))
+    async def _token(*_: object) -> str:
+        return "t"
 
-    await queue.enqueue(CreateNode(node_id="1", data={"x": 1}))
-    await queue.enqueue(UpdateCard(card_id="c1", payload={"y": 2}))
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.get_valid_access_token", _token
+    )
+
+    worker = asyncio.create_task(queue.worker(object(), client))
+
+    await queue.enqueue(CreateNode(node_id="1", data={"x": 1}, user_id="u1"))
+    await queue.enqueue(UpdateCard(card_id="c1", payload={"y": 2}, user_id="u1"))
 
     await asyncio.sleep(0.1)
 

--- a/tests/test_shapes_controller.py
+++ b/tests/test_shapes_controller.py
@@ -53,6 +53,7 @@ def test_create_shape_enqueues_task_and_returns_shape(
     assert isinstance(task, CreateShape)
     assert task.board_id == "b1"
     assert task.data == {"content": "c"}
+    assert task.user_id == "u1"
 
 
 def test_update_shape_enqueues_task(
@@ -71,6 +72,7 @@ def test_update_shape_enqueues_task(
     task = asyncio.run(queue.dequeue())
     assert isinstance(task, UpdateShape)
     assert task.shape_id == "s1"
+    assert task.user_id == "u1"
 
 
 def test_delete_shape_enqueues_task(
@@ -85,6 +87,7 @@ def test_delete_shape_enqueues_task(
     task = asyncio.run(queue.dequeue())
     assert isinstance(task, DeleteShape)
     assert task.board_id == "b1"
+    assert task.user_id == "u1"
 
 
 def test_get_shape_enforces_board_ownership(

--- a/tests/utils/queues.py
+++ b/tests/utils/queues.py
@@ -8,6 +8,7 @@ class DummyQueue:
 
     def __init__(self) -> None:
         self.tasks: list[object] = []
+        self.persistence: object | None = None
 
     async def enqueue(self, task: object) -> None:
         self.tasks.append(task)


### PR DESCRIPTION
## Summary
- associate queued change tasks with a user id and access token
- propagate user id through routers, services and worker
- adjust tests for user-based task processing

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/batch.py src/miro_backend/api/routers/cards.py src/miro_backend/api/routers/shapes.py src/miro_backend/main.py src/miro_backend/queue/change_queue.py src/miro_backend/queue/tasks.py src/miro_backend/schemas/card_create.py src/miro_backend/services/batch_service.py src/miro_backend/services/miro_client.py src/miro_backend/services/token_service.py tests/integration/conftest.py tests/integration/test_miro_client.py tests/integration/test_shapes.py tests/test_batch_controller.py tests/test_batch_idempotency.py tests/test_cards_controller.py tests/test_change_queue_metric.py tests/test_change_queue_persistence.py tests/test_shape_queue_processor.py tests/test_shapes_controller.py tests/test_worker_backoff.py tests/utils/queues.py`
- `poetry run pytest --no-cov tests/test_shapes_controller.py tests/test_cards_controller.py tests/test_batch_controller.py tests/test_batch_idempotency.py tests/test_change_queue_metric.py tests/test_change_queue_persistence.py tests/test_shape_queue_processor.py tests/test_worker_backoff.py tests/integration/test_shapes.py tests/integration/test_miro_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68a078b3d960832b8736c145f9354621