### PR TITLE
fix(users): encrypt tokens on creation

### DIFF
--- a/src/miro_backend/api/routers/users.py
+++ b/src/miro_backend/api/routers/users.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from ...db.session import get_session
 from ...models.user import User
 from ...schemas.user_info import UserInfo
+from ...services import crypto
 from ...services.repository import Repository
 
 router = APIRouter(prefix="/api/users", tags=["users"])
@@ -31,8 +32,8 @@ def create_user(info: UserInfo, session: Session = Depends(get_session)) -> User
         user = User(
             user_id=info.id,
             name=info.name,
-            access_token=info.access_token,
-            refresh_token=info.refresh_token,
+            access_token=crypto.encrypt(info.access_token),
+            refresh_token=crypto.encrypt(info.refresh_token),
             expires_at=info.expires_at,
         )
         repo.add(user)

--- a/tests/test_users_crypto_tokens.py
+++ b/tests/test_users_crypto_tokens.py
@@ -1,0 +1,47 @@
+from importlib import reload
+from datetime import datetime, timezone
+
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from miro_backend.api.routers import users
+from miro_backend.core import config
+from miro_backend.db.session import engine
+from miro_backend.models.user import User
+from miro_backend.services import crypto as crypto_module
+
+
+def setup_app() -> TestClient:
+    app = FastAPI()
+    app.include_router(users.router)
+    return TestClient(app)
+
+
+def test_tokens_are_encrypted() -> None:
+    key = Fernet.generate_key().decode()
+    config.settings.encryption_key = key
+    reload(crypto_module)
+    client = setup_app()
+    User.__table__.create(bind=engine, checkfirst=True)
+    try:
+        payload = {
+            "id": "u1",
+            "name": "Alice",
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "expires_at": datetime.now(timezone.utc).isoformat(),
+        }
+        res = client.post("/api/users", json=payload)
+        assert res.status_code == 201
+        with Session(bind=engine) as db:
+            user = db.query(User).filter_by(user_id="u1").one()
+            assert user.access_token != "tok"
+            assert user.refresh_token != "ref"
+            assert crypto_module.decrypt(user.access_token) == "tok"
+            assert crypto_module.decrypt(user.refresh_token) == "ref"
+    finally:
+        config.settings.encryption_key = None
+        reload(crypto_module)
+        User.__table__.drop(bind=engine)


### PR DESCRIPTION
## Summary
- encrypt user tokens before storing
- verify user creation encrypts tokens

## Testing
- `poetry run pre-commit run --files src/miro_backend/api/routers/users.py tests/test_users_crypto_tokens.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08457d434832bb757932ad8e72de0