### PR TITLE
feat(db): add initial Alembic migration

### DIFF
--- a/src/miro_backend/db/migrations/env.py
+++ b/src/miro_backend/db/migrations/env.py
@@ -7,8 +7,8 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from ..session import Base
-from ...core.config import settings
+from miro_backend.db.session import Base
+from miro_backend.core.config import settings
 
 # This is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -24,16 +24,18 @@ config.set_main_option("sqlalchemy.url", settings.database_url)
 target_metadata = Base.metadata
 
 
-def run_migrations_offline() -> None:
+def run_migrations_offline() -> None:  # pragma: no cover - CLI entrypoint
     """Run migrations in 'offline' mode."""
 
-    context.configure(url=settings.database_url, target_metadata=target_metadata, literal_binds=True)
+    context.configure(
+        url=settings.database_url, target_metadata=target_metadata, literal_binds=True
+    )
 
     with context.begin_transaction():
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
+def run_migrations_online() -> None:  # pragma: no cover - CLI entrypoint
     """Run migrations in 'online' mode."""
 
     connectable = engine_from_config(
@@ -53,4 +55,3 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/src/miro_backend/db/migrations/script.py.mako
+++ b/src/miro_backend/db/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/src/miro_backend/db/migrations/versions/bfd3c77b385f_initial.py
+++ b/src/miro_backend/db/migrations/versions/bfd3c77b385f_initial.py
@@ -1,0 +1,61 @@
+"""initial
+
+Revision ID: bfd3c77b385f
+Revises: 
+Create Date: 2025-08-16 13:19:50.738055
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bfd3c77b385f"
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:  # pragma: no cover - migration code
+    """Create initial tables."""
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("access_token", sa.String(), nullable=False),
+        sa.Column("refresh_token", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(op.f("ix_users_user_id"), "users", ["user_id"], unique=True)
+
+    op.create_table(
+        "cache_entries",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("value", sa.JSON(), nullable=False),
+    )
+    op.create_index(op.f("ix_cache_entries_key"), "cache_entries", ["key"], unique=True)
+
+    op.create_table(
+        "idempotency",
+        sa.Column("key", sa.String(), primary_key=True),
+        sa.Column("response", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+    )
+
+
+def downgrade() -> None:  # pragma: no cover - migration code
+    """Drop tables created in upgrade."""
+
+    op.drop_table("idempotency")
+    op.drop_index(op.f("ix_cache_entries_key"), table_name="cache_entries")
+    op.drop_table("cache_entries")
+    op.drop_index(op.f("ix_users_user_id"), table_name="users")
+    op.drop_table("users")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,23 @@
+"""Smoke tests for database migrations."""
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+import importlib
+import miro_backend.core.config as app_config
+
+
+def test_alembic_upgrade_creates_tables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``alembic upgrade head`` succeeds against a temporary SQLite database."""
+    db_path = tmp_path / "test.db"
+    db_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("MIRO_DATABASE_URL", db_url)
+    importlib.reload(app_config)
+    config = Config("alembic.ini")
+    config.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(config, "head")
+    assert db_path.exists()


### PR DESCRIPTION
## Summary
- add Alembic revision creating users, cache_entries, and idempotency tables
- ensure Alembic env uses absolute imports
- add smoke test exercising `alembic upgrade head`

## Testing
- `poetry run pre-commit run --files src/miro_backend/db/migrations/versions/bfd3c77b385f_initial.py src/miro_backend/db/migrations/script.py.mako src/miro_backend/db/migrations/env.py tests/test_migrations.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0846c626c832bb3abf13fe724c918