### PR TITLE
feat: raise typed HTTP errors for Miro client

### DIFF
--- a/src/miro_backend/services/__init__.py
+++ b/src/miro_backend/services/__init__.py
@@ -1,6 +1,7 @@
 """Service layer utilities."""
 
 from .batch_service import enqueue_operations
+from .errors import HttpError, RateLimitedError
 from .log_repository import LogRepository, get_log_repository
 from .miro_client import MiroClient, get_miro_client
 from .repository import Repository
@@ -12,4 +13,6 @@ __all__ = [
     "LogRepository",
     "get_log_repository",
     "enqueue_operations",
+    "HttpError",
+    "RateLimitedError",
 ]

--- a/src/miro_backend/services/errors.py
+++ b/src/miro_backend/services/errors.py
@@ -1,0 +1,38 @@
+"""Reusable HTTP error types."""
+
+from __future__ import annotations
+
+
+class HttpError(Exception):
+    """Exception representing an HTTP response failure.
+
+    Parameters
+    ----------
+    status:
+        HTTP status code from the response.
+    retry_after:
+        Optional number of seconds to wait before retrying.
+    message:
+        Optional error message.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        message: str | None = None,
+        *,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message or f"HTTP {status}")
+        self.status = status
+        self.status_code = status
+        self.retry_after = retry_after
+
+
+class RateLimitedError(HttpError):
+    """HTTP 429 response with optional retry-after delay."""
+
+    def __init__(
+        self, *, retry_after: float | None = None, message: str | None = None
+    ) -> None:
+        super().__init__(429, message or "rate limited", retry_after=retry_after)

--- a/tests/test_miro_client_errors.py
+++ b/tests/test_miro_client_errors.py
@@ -1,0 +1,24 @@
+import pytest
+import httpx
+
+from miro_backend.services.miro_client import MiroClient
+from miro_backend.services.errors import HttpError, RateLimitedError
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_raise_for_status_rate_limited() -> None:
+    client = MiroClient()
+    response = httpx.Response(429, headers={"Retry-After": "1"})
+    with pytest.raises(RateLimitedError) as exc:
+        client._raise_for_status(response)
+    assert exc.value.retry_after == 1
+    assert exc.value.status == 429
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_raise_for_status_server_error() -> None:
+    client = MiroClient()
+    response = httpx.Response(503)
+    with pytest.raises(HttpError) as exc:
+        client._raise_for_status(response)
+    assert exc.value.status == 503


### PR DESCRIPTION
## Summary
- add reusable HttpError and RateLimitedError with retry-after metadata
- raise typed errors on 429 and 5xx responses from MiroClient
- test worker backoff on 5xx and validate error mapping

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/errors.py src/miro_backend/services/__init__.py src/miro_backend/services/miro_client.py tests/test_worker_backoff.py tests/test_miro_client_errors.py`
- `poetry run pytest tests/test_worker_backoff.py tests/test_miro_client_errors.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a0847866a0832ba184792454fbf3f1