### PR TITLE
feat(api): add limits diagnostic endpoint

### DIFF
--- a/src/miro_backend/api/routers/limits.py
+++ b/src/miro_backend/api/routers/limits.py
@@ -1,0 +1,21 @@
+"""Diagnostic endpoints for queue and rate limits."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+import logfire
+
+from ...queue.change_queue import change_queue_length
+from ...services.rate_limiter import RateLimiter, get_rate_limiter
+
+router = APIRouter(prefix="/api", tags=["limits"])
+
+
+@router.get("/limits", status_code=status.HTTP_200_OK)  # type: ignore[misc]
+def get_limits(limiter: RateLimiter = Depends(get_rate_limiter)) -> dict[str, object]:
+    """Return queue length and current bucket fill per user."""
+    with logfire.span("get limits"):
+        return {
+            "queue_length": int(change_queue_length._value.get()),
+            "bucket_fill": limiter.bucket_fill(),
+        }

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -44,6 +44,7 @@ from .api.routers.cache import router as cache_router  # noqa: E402
 from .api.routers.cards import router as cards_router  # noqa: E402
 from .api.routers.logs import router as logs_router  # noqa: E402
 from .api.routers.oauth import router as oauth_router  # noqa: E402
+from .api.routers.limits import router as limits_router  # noqa: E402
 from .api.routers.shapes import router as shapes_router  # noqa: E402
 from .api.routers.tags import router as tags_router  # noqa: E402
 from .api.routers.users import router as users_router  # noqa: E402
@@ -100,6 +101,7 @@ app.include_router(logs_router)
 app.include_router(cards_router)
 app.include_router(cache_router)
 app.include_router(batch_router)
+app.include_router(limits_router)
 
 instrumentator = Instrumentator().instrument(app)
 instrumentator.registry.register(change_queue_length)

--- a/src/miro_backend/services/__init__.py
+++ b/src/miro_backend/services/__init__.py
@@ -3,6 +3,7 @@
 from .batch_service import enqueue_operations
 from .log_repository import LogRepository, get_log_repository
 from .miro_client import MiroClient, get_miro_client
+from .rate_limiter import RateLimiter, get_rate_limiter
 from .repository import Repository
 
 __all__ = [
@@ -11,5 +12,7 @@ __all__ = [
     "get_miro_client",
     "LogRepository",
     "get_log_repository",
+    "RateLimiter",
+    "get_rate_limiter",
     "enqueue_operations",
 ]

--- a/src/miro_backend/services/rate_limiter.py
+++ b/src/miro_backend/services/rate_limiter.py
@@ -1,0 +1,26 @@
+"""Simple in-memory token bucket limiter state."""
+
+from __future__ import annotations
+
+from threading import Lock
+
+
+class RateLimiter:
+    """Track token bucket fill per user."""
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, int] = {}
+        self._lock = Lock()
+
+    def bucket_fill(self) -> dict[str, int]:
+        """Return current bucket fill per user."""
+        with self._lock:
+            return dict(self._buckets)
+
+
+_limiter = RateLimiter()
+
+
+def get_rate_limiter() -> RateLimiter:
+    """Provide the shared :class:`RateLimiter` instance."""
+    return _limiter

--- a/tests/test_limits_endpoint.py
+++ b/tests/test_limits_endpoint.py
@@ -1,0 +1,42 @@
+import asyncio
+import importlib
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from miro_backend.queue import ChangeQueue
+from miro_backend.queue.provider import get_change_queue
+from miro_backend.services.rate_limiter import get_rate_limiter
+
+
+class DummyLimiter:
+    """Stub limiter returning fixed bucket fills."""
+
+    def bucket_fill(self) -> dict[str, int]:
+        return {"user": 1}
+
+
+async def _idle_worker(_: Any, __: Any) -> None:
+    await asyncio.Event().wait()
+
+
+def test_limits_endpoint_returns_shape() -> None:
+    app_module = importlib.import_module("miro_backend.main")
+    queue = ChangeQueue()
+    queue.worker = _idle_worker
+    app_module.change_queue = queue  # type: ignore[attr-defined]
+    app_module.app.dependency_overrides[get_change_queue] = lambda: queue
+    app_module.app.dependency_overrides[get_rate_limiter] = lambda: DummyLimiter()
+    with TestClient(app_module.app) as client:
+        response = client.get("/api/limits")
+    app_module.app.dependency_overrides.clear()
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {"queue_length", "bucket_fill"}
+    assert data["bucket_fill"] == {"user": 1}
+    assert isinstance(data["queue_length"], int)
+
+
+def test_rate_limiter_default_state() -> None:
+    limiter = get_rate_limiter()
+    assert limiter.bucket_fill() == {}


### PR DESCRIPTION
## Summary
- add `/api/limits` endpoint exposing queue length and bucket fill
- introduce simple in-memory `RateLimiter` service
- register limits router in FastAPI app

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/rate_limiter.py src/miro_backend/services/__init__.py src/miro_backend/api/routers/limits.py src/miro_backend/main.py tests/test_limits_endpoint.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a084908574832b8d64f9f6d46e8b28