### PR TITLE
feat(queue): persist idempotency and jobs

### DIFF
--- a/src/miro_backend/api/routers/jobs.py
+++ b/src/miro_backend/api/routers/jobs.py
@@ -1,0 +1,26 @@
+"""Job status endpoints."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ...db.session import get_session
+from ...models.job import Job as JobModel
+from ...schemas.job import JobRead
+from ...services.repository import Repository
+
+router = APIRouter(prefix="/api", tags=["jobs"])
+
+
+@router.get("/jobs/{job_id}", response_model=JobRead)  # type: ignore[misc]
+def get_job(job_id: UUID, session: Session = Depends(get_session)) -> JobRead:
+    """Return the persisted job with ``job_id`` or 404 if missing."""
+
+    repo: Repository[JobModel] = Repository(session, JobModel)
+    job = repo.get(str(job_id))
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+    return JobRead.model_validate(job, from_attributes=True)

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -43,6 +43,7 @@ from .api.routers.batch import router as batch_router  # noqa: E402
 from .api.routers.cache import router as cache_router  # noqa: E402
 from .api.routers.cards import router as cards_router  # noqa: E402
 from .api.routers.logs import router as logs_router  # noqa: E402
+from .api.routers.jobs import router as jobs_router  # noqa: E402
 from .api.routers.oauth import router as oauth_router  # noqa: E402
 from .api.routers.shapes import router as shapes_router  # noqa: E402
 from .api.routers.tags import router as tags_router  # noqa: E402
@@ -100,6 +101,7 @@ app.include_router(logs_router)
 app.include_router(cards_router)
 app.include_router(cache_router)
 app.include_router(batch_router)
+app.include_router(jobs_router)
 
 instrumentator = Instrumentator().instrument(app)
 instrumentator.registry.register(change_queue_length)

--- a/src/miro_backend/models/__init__.py
+++ b/src/miro_backend/models/__init__.py
@@ -1,13 +1,24 @@
-"""ORM models used by the service."""
+"""ORM models used by the service.
+
+This module re-exports the concrete SQLAlchemy models so they can be imported
+conveniently elsewhere in the codebase.  ``__all__`` provides a canonical list
+of public models for static analysis tools.
+"""
 
 from .board import Board
 from .cache import CacheEntry
+from .idempotency import Idempotency
+from .job import Job
+from .log_entry import LogEntry
+from .tag import Tag
 from .user import User
 
-__all__ = ["CacheEntry", "User"]
-from .tag import Tag
-
-__all__ = ["Board", "CacheEntry", "Tag"]
-from .log_entry import LogEntry
-
-__all__ = ["CacheEntry", "LogEntry"]
+__all__ = [
+    "Board",
+    "CacheEntry",
+    "Idempotency",
+    "Job",
+    "LogEntry",
+    "Tag",
+    "User",
+]

--- a/src/miro_backend/models/idempotency.py
+++ b/src/miro_backend/models/idempotency.py
@@ -1,0 +1,24 @@
+"""Database model for idempotent responses."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from ..db.session import Base
+
+
+class Idempotency(Base):
+    """Caches HTTP responses for an idempotency key."""
+
+    __tablename__ = "idempotency"
+
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+    response: Mapped[dict[str, Any]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )

--- a/src/miro_backend/models/job.py
+++ b/src/miro_backend/models/job.py
@@ -1,0 +1,26 @@
+"""Database model for background jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+from typing import Any
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from ..db.session import Base
+
+
+class Job(Base):
+    """Represents a long-running background job."""
+
+    __tablename__ = "jobs"
+
+    id: Mapped[UUID] = mapped_column(String, primary_key=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    results: Mapped[dict[str, Any] | None] = mapped_column(JSON, default=None)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/src/miro_backend/schemas/job.py
+++ b/src/miro_backend/schemas/job.py
@@ -1,0 +1,18 @@
+"""Schemas for job resources."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class JobRead(BaseModel):
+    """Representation of a background job."""
+
+    id: UUID
+    status: str
+    results: dict[str, Any] | None = None
+    updated_at: datetime

--- a/src/miro_backend/services/repository.py
+++ b/src/miro_backend/services/repository.py
@@ -44,8 +44,12 @@ class Repository(Generic[ModelT]):
     # Read operations
     # ------------------------------------------------------------------
     @logfire.instrument("get model")  # type: ignore[misc]
-    def get(self, id_: int) -> ModelT | None:
-        """Return an entity by primary key if present."""
+    def get(self, id_: Any) -> ModelT | None:
+        """Return an entity by primary key if present.
+
+        ``id_`` may be of any type supported by the underlying model, such as an
+        ``int``, ``str`` or ``UUID``.
+        """
 
         result = self.session.get(self.model, id_)
         logfire.info("entity retrieved", id=id_)  # event: retrieval

--- a/tests/test_batch_idempotency.py
+++ b/tests/test_batch_idempotency.py
@@ -1,43 +1,35 @@
-"""Tests idempotency behaviour of the batch endpoint."""
+"""Tests idempotency behaviour of the batch endpoint with persistence."""
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterator
+import asyncio
 
 import pytest
 from fastapi.testclient import TestClient
 
+from miro_backend.api.routers import batch as batch_router
 from miro_backend.main import app
+from miro_backend.queue import ChangeQueue
+from miro_backend.queue.change_queue import change_queue_length
 from miro_backend.queue.provider import get_change_queue
-from .utils.queues import DummyQueue
-
-
-class TrackingQueue(DummyQueue):
-    """Queue that counts dequeue operations."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.dequeued = 0
-
-    async def dequeue(self) -> object:
-        self.dequeued += 1
-        return self.tasks.pop(0)
+from miro_backend.queue.persistence import QueuePersistence
 
 
 @pytest.fixture  # type: ignore[misc]
-def client_queue() -> Iterator[tuple[TestClient, TrackingQueue]]:
-    queue = TrackingQueue()
+def client() -> Iterator[TestClient]:
+    persistence = QueuePersistence()
+    queue = ChangeQueue(persistence=persistence)
     app.dependency_overrides[get_change_queue] = lambda: queue
     client = TestClient(app)
-    yield client, queue
+    yield client
+    for task in queue.persistence.load():
+        asyncio.run(queue.persistence.delete(task))
+    change_queue_length.set(0)
     app.dependency_overrides.clear()
 
 
-def test_post_batch_is_idempotent(
-    client_queue: tuple[TestClient, TrackingQueue]
-) -> None:
-    client, queue = client_queue
+def test_post_batch_idempotent_across_restart(client: TestClient) -> None:
     body = {
         "operations": [
             {"type": "create_node", "node_id": "n1", "data": {"x": 1}},
@@ -47,13 +39,13 @@ def test_post_batch_is_idempotent(
     headers = {"Idempotency-Key": "abc123", "X-User-Id": "u1"}
 
     first = client.post("/api/batch", json=body, headers=headers)
-    second = client.post("/api/batch", json=body, headers=headers)
+
+    # Simulate new process by clearing in-memory cache and creating a new client
+    batch_router._IDEMPOTENCY_CACHE.clear()
+    app.dependency_overrides[get_change_queue] = lambda: ChangeQueue(
+        persistence=QueuePersistence()
+    )
+    new_client = TestClient(app)
+    second = new_client.post("/api/batch", json=body, headers=headers)
 
     assert first.json() == second.json()
-
-    async def drain(q: TrackingQueue) -> None:
-        while q.tasks:
-            await q.dequeue()
-
-    asyncio.run(drain(queue))
-    assert queue.dequeued == len(body["operations"])

--- a/tests/test_change_queue_persistence.py
+++ b/tests/test_change_queue_persistence.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest import mock
 
-from pathlib import Path
-
 import pytest
 
 from miro_backend.queue import ChangeQueue
@@ -30,11 +28,10 @@ async def test_enqueue_dequeue_persists() -> None:
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
-async def test_tasks_survive_restart(tmp_path: Path) -> None:
+async def test_tasks_survive_restart() -> None:
     """Tasks persisted to disk should reload after a restart."""
 
-    db_path = tmp_path / "tasks.db"
-    persistence = QueuePersistence(db_path)
+    persistence = QueuePersistence()
 
     queue = ChangeQueue(persistence=persistence)
     task = CreateNode(node_id="n1", data={}, user_id="u1")

--- a/tests/test_idempotency_persistence.py
+++ b/tests/test_idempotency_persistence.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from miro_backend.queue.persistence import QueuePersistence
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
-async def test_save_and_get_idempotent(tmp_path: Path) -> None:
+async def test_save_and_get_idempotent() -> None:
     """Saving and retrieving by key should round-trip the response."""
 
-    db = tmp_path / "idem.db"
-    persistence = QueuePersistence(db)
+    persistence = QueuePersistence()
     data = {"ok": True}
 
     await persistence.save_idempotent("k1", data)
@@ -22,9 +19,9 @@ async def test_save_and_get_idempotent(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
-async def test_get_idempotent_missing(tmp_path: Path) -> None:
+async def test_get_idempotent_missing() -> None:
     """Missing keys should return ``None``."""
 
-    persistence = QueuePersistence(tmp_path / "idem.db")
+    persistence = QueuePersistence()
 
     assert await persistence.get_idempotent("missing") is None

--- a/tests/test_jobs_controller.py
+++ b/tests/test_jobs_controller.py
@@ -1,0 +1,24 @@
+"""Tests for the jobs API."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from miro_backend.main import app
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.models.job import Job
+
+
+def test_get_job_returns_record() -> None:
+    Base.metadata.create_all(bind=engine)
+    job_id = uuid4()
+    with SessionLocal() as session:
+        session.add(Job(id=str(job_id), status="queued", results={}))
+        session.commit()
+
+    client = TestClient(app)
+    response = client.get(f"/api/jobs/{job_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == str(job_id)


### PR DESCRIPTION
## Summary
- persist idempotent responses and background jobs in the primary database
- migrate queue persistence to SQLAlchemy and expose job lookup endpoint
- test idempotency storage across restarts and job retrieval

## Testing
- `poetry run pre-commit run --files src/miro_backend/models/__init__.py src/miro_backend/models/idempotency.py src/miro_backend/models/job.py src/miro_backend/services/repository.py src/miro_backend/queue/persistence.py src/miro_backend/api/routers/jobs.py src/miro_backend/schemas/job.py src/miro_backend/main.py tests/test_batch_idempotency.py tests/test_change_queue_persistence.py tests/test_idempotency_persistence.py tests/test_jobs_controller.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a084b505f8832ba1ed8c27c6c68806