### PR TITLE
feat: persist idempotency and jobs in main database

### DIFF
--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -34,7 +34,7 @@ async def post_batch(
 
     with logfire.span("post batch"):
         if idempotency_key and queue.persistence is not None:
-            existing = await queue.persistence.get_response(idempotency_key)
+            existing = await queue.persistence.get_idempotent(idempotency_key)
             if existing is not None:
                 return BatchResponse.model_validate(existing)
 
@@ -47,7 +47,7 @@ async def post_batch(
         response = BatchResponse(enqueued=count)
 
         if idempotency_key and queue.persistence is not None:
-            await queue.persistence.save_response(
+            await queue.persistence.save_idempotent(
                 idempotency_key, response.model_dump()
             )
 

--- a/src/miro_backend/api/routers/jobs.py
+++ b/src/miro_backend/api/routers/jobs.py
@@ -1,0 +1,24 @@
+"""HTTP routes for job status queries."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ...db.session import get_session
+from ...models import Job as JobModel
+from ...schemas.job import Job as JobSchema
+from ...services.repository import Repository
+
+router = APIRouter(prefix="/api/jobs", tags=["jobs"])
+
+
+@router.get("/{job_id}", response_model=JobSchema)  # type: ignore[misc]
+def get_job(job_id: str, session: Session = Depends(get_session)) -> JobSchema:
+    """Return the job with ``job_id`` if present."""
+
+    repo: Repository[JobModel] = Repository(session, JobModel)
+    job = repo.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return JobSchema.model_validate(job)

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -48,6 +48,7 @@ from .api.routers.limits import router as limits_router  # noqa: E402
 from .api.routers.shapes import router as shapes_router  # noqa: E402
 from .api.routers.tags import router as tags_router  # noqa: E402
 from .api.routers.users import router as users_router  # noqa: E402
+from .api.routers.jobs import router as jobs_router  # noqa: E402
 from .api.routers.webhook import router as webhook_router  # noqa: E402
 
 
@@ -102,6 +103,7 @@ app.include_router(cards_router)
 app.include_router(cache_router)
 app.include_router(batch_router)
 app.include_router(limits_router)
+app.include_router(jobs_router)
 
 instrumentator = Instrumentator().instrument(app)
 instrumentator.registry.register(change_queue_length)

--- a/src/miro_backend/models/__init__.py
+++ b/src/miro_backend/models/__init__.py
@@ -2,12 +2,18 @@
 
 from .board import Board
 from .cache import CacheEntry
-from .user import User
-
-__all__ = ["CacheEntry", "User"]
-from .tag import Tag
-
-__all__ = ["Board", "CacheEntry", "Tag"]
 from .log_entry import LogEntry
+from .tag import Tag
+from .user import User
+from .idempotency import Idempotency
+from .job import Job
 
-__all__ = ["CacheEntry", "LogEntry"]
+__all__ = [
+    "Board",
+    "CacheEntry",
+    "Idempotency",
+    "Job",
+    "LogEntry",
+    "Tag",
+    "User",
+]

--- a/src/miro_backend/models/idempotency.py
+++ b/src/miro_backend/models/idempotency.py
@@ -1,0 +1,21 @@
+"""Database model for idempotent responses."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, JSON, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..db.session import Base
+
+
+class Idempotency(Base):
+    """Persisted idempotent API responses keyed by a client-provided token."""
+
+    __tablename__ = "idempotency"
+
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+    response: Mapped[dict[str, Any]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/src/miro_backend/models/job.py
+++ b/src/miro_backend/models/job.py
@@ -1,0 +1,29 @@
+"""Database model for background jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import DateTime, JSON, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..db.session import Base
+
+
+class Job(Base):
+    """Track long-running background jobs and their results."""
+
+    __tablename__ = "jobs"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid4())
+    )
+    status: Mapped[str] = mapped_column(String)
+    results: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, default=None, nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )

--- a/src/miro_backend/queue/provider.py
+++ b/src/miro_backend/queue/provider.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from .change_queue import ChangeQueue
-from .persistence import QueuePersistence
+from .persistence import SqlAlchemyQueuePersistence
 
-_change_queue = ChangeQueue(persistence=QueuePersistence())
+_change_queue = ChangeQueue(persistence=SqlAlchemyQueuePersistence())
 
 
 def get_change_queue() -> ChangeQueue:

--- a/src/miro_backend/schemas/job.py
+++ b/src/miro_backend/schemas/job.py
@@ -1,0 +1,19 @@
+"""Pydantic schema for job records."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Job(BaseModel):
+    """Representation of a background job."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    status: str
+    results: dict[str, Any] | None = None
+    updated_at: datetime

--- a/src/miro_backend/services/repository.py
+++ b/src/miro_backend/services/repository.py
@@ -44,7 +44,7 @@ class Repository(Generic[ModelT]):
     # Read operations
     # ------------------------------------------------------------------
     @logfire.instrument("get model")  # type: ignore[misc]
-    def get(self, id_: int) -> ModelT | None:
+    def get(self, id_: Any) -> ModelT | None:
         """Return an entity by primary key if present."""
 
         result = self.session.get(self.model, id_)

--- a/tests/integration/test_oauth_persist.py
+++ b/tests/integration/test_oauth_persist.py
@@ -21,6 +21,7 @@ from miro_backend.models.user import User
 from miro_backend.schemas.user_info import UserInfo
 from miro_backend.services.miro_client import MiroClient
 from miro_backend.services.user_store import UserStore, get_user_store
+from miro_backend.core.security import sign_state
 
 
 @asynccontextmanager
@@ -114,8 +115,9 @@ async def test_callback_persists_tokens(tmp_path: Path) -> None:
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
             ) as client:
+                state = sign_state("test-client-secret", "x", "u1")
                 res = await client.get(
-                    "/oauth/callback", params={"code": "c", "state": "x:u1"}
+                    "/oauth/callback", params={"code": "c", "state": state}
                 )
         assert res.status_code == 307
         assert res.headers["location"] == "/app.html"

--- a/tests/test_batch_controller.py
+++ b/tests/test_batch_controller.py
@@ -18,10 +18,10 @@ class MemoryPersistence:
     def __init__(self) -> None:
         self.responses: dict[str, dict[str, int]] = {}
 
-    async def get_response(self, key: str) -> dict[str, int] | None:
+    async def get_idempotent(self, key: str) -> dict[str, int] | None:
         return self.responses.get(key)
 
-    async def save_response(self, key: str, response: dict[str, int]) -> None:
+    async def save_idempotent(self, key: str, response: dict[str, int]) -> None:
         self.responses[key] = response
 
 

--- a/tests/test_batch_idempotency.py
+++ b/tests/test_batch_idempotency.py
@@ -1,43 +1,38 @@
-"""Tests idempotency behaviour of the batch endpoint."""
-
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from miro_backend.main import app
+from miro_backend.queue.change_queue import ChangeQueue
+from miro_backend.queue.persistence import SqlAlchemyQueuePersistence
 from miro_backend.queue.provider import get_change_queue
-from .utils.queues import DummyQueue
-
-
-class TrackingQueue(DummyQueue):
-    """Queue that counts dequeue operations."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.dequeued = 0
-
-    async def dequeue(self) -> object:
-        self.dequeued += 1
-        return self.tasks.pop(0)
+from miro_backend.db.session import Base
 
 
 @pytest.fixture  # type: ignore[misc]
-def client_queue() -> Iterator[tuple[TestClient, TrackingQueue]]:
-    queue = TrackingQueue()
+def client(tmp_path: Path) -> TestClient:
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'queue.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    persistence = SqlAlchemyQueuePersistence(Session)
+    queue = ChangeQueue(persistence=persistence)
     app.dependency_overrides[get_change_queue] = lambda: queue
     client = TestClient(app)
-    yield client, queue
+    yield client
     app.dependency_overrides.clear()
 
 
-def test_post_batch_is_idempotent(
-    client_queue: tuple[TestClient, TrackingQueue]
+def test_post_batch_is_idempotent_across_reloads(
+    client: TestClient, tmp_path: Path
 ) -> None:
-    client, queue = client_queue
     body = {
         "operations": [
             {"type": "create_node", "node_id": "n1", "data": {"x": 1}},
@@ -47,13 +42,26 @@ def test_post_batch_is_idempotent(
     headers = {"Idempotency-Key": "abc123", "X-User-Id": "u1"}
 
     first = client.post("/api/batch", json=body, headers=headers)
-    second = client.post("/api/batch", json=body, headers=headers)
+    assert first.status_code == 202
 
-    assert first.json() == second.json()
+    # Drain persisted tasks to simulate worker processing
+    queue: ChangeQueue = app.dependency_overrides[get_change_queue]()
 
-    async def drain(q: TrackingQueue) -> None:
-        while q.tasks:
+    async def drain(q: ChangeQueue) -> None:
+        while not q._queue.empty():
             await q.dequeue()
 
     asyncio.run(drain(queue))
-    assert queue.dequeued == len(body["operations"])
+
+    # Recreate queue to simulate process restart
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'queue.db'}", connect_args={"check_same_thread": False}
+    )
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    persistence = SqlAlchemyQueuePersistence(Session)
+    new_queue = ChangeQueue(persistence=persistence)
+    app.dependency_overrides[get_change_queue] = lambda: new_queue
+
+    second = client.post("/api/batch", json=body, headers=headers)
+    assert second.json() == first.json()
+    assert new_queue._queue.empty()

--- a/tests/test_idempotency_persistence.py
+++ b/tests/test_idempotency_persistence.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from miro_backend.queue.persistence import QueuePersistence
+from miro_backend.db.session import Base
+from miro_backend.queue.persistence import SqlAlchemyQueuePersistence
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
 async def test_save_and_get_idempotent(tmp_path: Path) -> None:
     """Saving and retrieving by key should round-trip the response."""
 
-    db = tmp_path / "idem.db"
-    persistence = QueuePersistence(db)
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'idem.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    persistence = SqlAlchemyQueuePersistence(Session)
     data = {"ok": True}
 
     await persistence.save_idempotent("k1", data)
@@ -25,6 +32,11 @@ async def test_save_and_get_idempotent(tmp_path: Path) -> None:
 async def test_get_idempotent_missing(tmp_path: Path) -> None:
     """Missing keys should return ``None``."""
 
-    persistence = QueuePersistence(tmp_path / "idem.db")
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'idem.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    persistence = SqlAlchemyQueuePersistence(Session)
 
     assert await persistence.get_idempotent("missing") is None

--- a/tests/test_jobs_controller.py
+++ b/tests/test_jobs_controller.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.models import Job
+from miro_backend.queue import ChangeQueue
+
+
+def setup_module() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_module() -> None:
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_get_job_returns_record() -> None:
+    session = SessionLocal()
+    job = Job(status="pending")
+    session.add(job)
+    session.commit()
+    job_id = job.id
+    session.close()
+
+    app_module = importlib.import_module("miro_backend.main")
+    app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
+    with TestClient(app_module.app) as client:
+        response = client.get(f"/api/jobs/{job_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == job_id
+        assert data["status"] == "pending"


### PR DESCRIPTION
## Summary
- move queued task persistence to SQLAlchemy and store idempotent responses
- add Job and Idempotency models with API to read job status
- update batch endpoint and repository helpers for generic primary keys

## Testing
- `poetry run pre-commit run --files src/miro_backend/models/__init__.py src/miro_backend/models/idempotency.py src/miro_backend/models/job.py src/miro_backend/services/repository.py src/miro_backend/queue/persistence.py src/miro_backend/queue/provider.py src/miro_backend/api/routers/batch.py src/miro_backend/api/routers/jobs.py src/miro_backend/main.py src/miro_backend/schemas/job.py tests/test_batch_controller.py tests/test_batch_idempotency.py tests/test_change_queue_persistence.py tests/test_idempotency_persistence.py tests/test_jobs_controller.py tests/test_crypto_tokens.py tests/integration/test_oauth_persist.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a088f571d8832bbc7d3f2e31e1a198