### PR TITLE
feat(api): add job inspection endpoint

### DIFF
--- a/src/miro_backend/api/routers/jobs.py
+++ b/src/miro_backend/api/routers/jobs.py
@@ -1,0 +1,25 @@
+"""Endpoints for inspecting batch job outcomes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ...queue.change_queue import ChangeQueue
+from ...queue.provider import get_change_queue
+from ...schemas.job import JobStatusResponse
+
+router = APIRouter(prefix="/api", tags=["jobs"])
+
+
+@router.get("/jobs/{job_id}", response_model=JobStatusResponse, status_code=status.HTTP_200_OK)  # type: ignore[misc]
+async def get_job_status(
+    job_id: str, queue: ChangeQueue = Depends(get_change_queue)
+) -> JobStatusResponse:
+    """Return the persisted status and results for ``job_id``."""
+
+    if queue.persistence is None or not hasattr(queue.persistence, "get_job"):
+        raise HTTPException(status_code=404, detail="job not found")
+    job = await queue.persistence.get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return JobStatusResponse.model_validate(job)

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -48,6 +48,7 @@ from .api.routers.shapes import router as shapes_router  # noqa: E402
 from .api.routers.tags import router as tags_router  # noqa: E402
 from .api.routers.users import router as users_router  # noqa: E402
 from .api.routers.webhook import router as webhook_router  # noqa: E402
+from .api.routers.jobs import router as jobs_router  # noqa: E402
 
 
 @asynccontextmanager
@@ -100,6 +101,7 @@ app.include_router(logs_router)
 app.include_router(cards_router)
 app.include_router(cache_router)
 app.include_router(batch_router)
+app.include_router(jobs_router)
 
 instrumentator = Instrumentator().instrument(app)
 instrumentator.registry.register(change_queue_length)

--- a/src/miro_backend/queue/tasks.py
+++ b/src/miro_backend/queue/tasks.py
@@ -18,6 +18,8 @@ class ChangeTask(BaseModel, ABC):
     """Abstract base class for all change tasks."""
 
     user_id: str
+    job_id: str = ""
+    index: int = 0
 
     @abstractmethod
     async def apply(

--- a/src/miro_backend/schemas/batch.py
+++ b/src/miro_backend/schemas/batch.py
@@ -41,4 +41,5 @@ class BatchRequest(BaseModel):
 class BatchResponse(BaseModel):
     """Summary of enqueued operations."""
 
+    job_id: str
     enqueued: int

--- a/src/miro_backend/schemas/job.py
+++ b/src/miro_backend/schemas/job.py
@@ -1,0 +1,23 @@
+"""Pydantic models for job inspection endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class JobResult(BaseModel):
+    """Outcome of an individual operation within a job."""
+
+    index: int
+    status: Literal["succeeded", "failed"]
+    error: str | None = None
+
+
+class JobStatusResponse(BaseModel):
+    """Aggregated status and results for a submitted job."""
+
+    job_id: str
+    status: Literal["queued", "running", "succeeded", "failed"]
+    results: list[JobResult]

--- a/src/miro_backend/services/batch_service.py
+++ b/src/miro_backend/services/batch_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from ..queue.tasks import ChangeTask, CreateNode, UpdateCard
 
@@ -18,7 +19,7 @@ from ..schemas.batch import (
 
 async def enqueue_operations(
     operations: Sequence[Operation], queue: "ChangeQueue", user_id: str
-) -> int:
+) -> tuple[str, int]:
     """Convert ``operations`` into tasks and enqueue them.
 
     Args:
@@ -26,16 +27,32 @@ async def enqueue_operations(
         queue: Target :class:`ChangeQueue`.
 
     Returns:
-        Number of enqueued operations.
+        Tuple of generated job identifier and number of enqueued operations.
     """
 
-    for op in operations:
+    job_id = str(uuid4())
+    if queue.persistence is not None and hasattr(queue.persistence, "create_job"):
+        await queue.persistence.create_job(job_id, len(operations))
+
+    for index, op in enumerate(operations):
         task: ChangeTask
         if isinstance(op, CreateNodeOperation):
-            task = CreateNode(node_id=op.node_id, data=op.data, user_id=user_id)
+            task = CreateNode(
+                node_id=op.node_id,
+                data=op.data,
+                user_id=user_id,
+                job_id=job_id,
+                index=index,
+            )
         elif isinstance(op, UpdateCardOperation):
-            task = UpdateCard(card_id=op.card_id, payload=op.payload, user_id=user_id)
+            task = UpdateCard(
+                card_id=op.card_id,
+                payload=op.payload,
+                user_id=user_id,
+                job_id=job_id,
+                index=index,
+            )
         else:  # pragma: no cover - safeguarded by Pydantic validation
             continue
         await queue.enqueue(task)
-    return len(operations)
+    return job_id, len(operations)

--- a/tests/test_jobs_controller.py
+++ b/tests/test_jobs_controller.py
@@ -1,0 +1,63 @@
+"""Tests for job inspection endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+from fastapi.testclient import TestClient
+from pathlib import Path
+
+from miro_backend.main import app
+from miro_backend.queue.change_queue import ChangeQueue
+from miro_backend.queue.persistence import QueuePersistence
+from miro_backend.queue.provider import get_change_queue
+
+
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_job_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    persistence = QueuePersistence(tmp_path / "queue.db")
+    queue = ChangeQueue(persistence=persistence)
+    app.dependency_overrides[get_change_queue] = lambda: queue
+    client = TestClient(app)
+
+    body = {
+        "operations": [
+            {"type": "create_node", "node_id": "n1", "data": {"x": 1}},
+            {"type": "create_node", "node_id": "n2", "data": {"x": 2}},
+        ]
+    }
+    response = client.post("/api/batch", json=body, headers={"X-User-Id": "u1"})
+    job_id = response.json()["job_id"]
+
+    queued = client.get(f"/api/jobs/{job_id}").json()
+    assert queued == {"job_id": job_id, "status": "queued", "results": []}
+
+    class FakeClient:
+        async def create_node(self, *_: object, **__: object) -> None:
+            await asyncio.sleep(0.05)
+
+    async def _token(*_: object) -> str:
+        return "t"
+
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.get_valid_access_token", _token
+    )
+
+    worker = asyncio.create_task(queue.worker(object(), FakeClient()))
+    await asyncio.sleep(0.01)
+
+    running = client.get(f"/api/jobs/{job_id}").json()
+    assert running["status"] == "running"
+
+    await asyncio.sleep(0.2)
+    worker.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await worker
+
+    finished = client.get(f"/api/jobs/{job_id}").json()
+    assert finished["status"] == "succeeded"
+    assert len(finished["results"]) == 2
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- enqueue batch operations with a job identifier and return it
- expose `/jobs/{job_id}` to inspect batch status and per-operation results
- track job lifecycle in worker and persistence

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/batch.py src/miro_backend/main.py src/miro_backend/queue/change_queue.py src/miro_backend/queue/persistence.py src/miro_backend/queue/tasks.py src/miro_backend/schemas/batch.py src/miro_backend/services/batch_service.py src/miro_backend/api/routers/jobs.py src/miro_backend/schemas/job.py tests/test_batch_controller.py tests/test_jobs_controller.py`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68a084dec820832b93ffd0b2575db67f