### PR TITLE
feat: track batch job outcomes via jobs endpoint

### DIFF
--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Header, status
 import logfire
+from sqlalchemy.orm import Session
 
+from ...db.session import get_session
 from ...queue.change_queue import ChangeQueue
 from ...queue.provider import get_change_queue
 from ...schemas.batch import BatchRequest, BatchResponse
@@ -20,6 +22,7 @@ _IDEMPOTENCY_CACHE: dict[str, BatchResponse] = {}
 async def post_batch(
     request: BatchRequest,
     queue: ChangeQueue = Depends(get_change_queue),
+    session: Session = Depends(get_session),
     user_id: str = Header(alias="X-User-Id"),
     idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
 ) -> BatchResponse:
@@ -38,13 +41,13 @@ async def post_batch(
             if existing is not None:
                 return BatchResponse.model_validate(existing)
 
-        count = await enqueue_operations(request.operations, queue, user_id)
-        response = BatchResponse(enqueued=count)
+        job_id, count = await enqueue_operations(
+            request.operations, queue, user_id, session
+        )
+        response = BatchResponse(enqueued=count, job_id=job_id)
         logfire.info("batch operations enqueued", count=count)  # event after enqueuing
         if idempotency_key is not None:
             _IDEMPOTENCY_CACHE[idempotency_key] = response
-
-        response = BatchResponse(enqueued=count)
 
         if idempotency_key and queue.persistence is not None:
             await queue.persistence.save_idempotent(

--- a/src/miro_backend/queue/tasks.py
+++ b/src/miro_backend/queue/tasks.py
@@ -18,6 +18,7 @@ class ChangeTask(BaseModel, ABC):
     """Abstract base class for all change tasks."""
 
     user_id: str
+    job_id: str | None = None
 
     @abstractmethod
     async def apply(

--- a/src/miro_backend/schemas/batch.py
+++ b/src/miro_backend/schemas/batch.py
@@ -42,3 +42,4 @@ class BatchResponse(BaseModel):
     """Summary of enqueued operations."""
 
     enqueued: int
+    job_id: str

--- a/tests/test_batch_controller.py
+++ b/tests/test_batch_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,18 +11,19 @@ from fastapi.testclient import TestClient
 from miro_backend.main import app
 from miro_backend.queue.provider import get_change_queue
 from miro_backend.queue.tasks import CreateNode, UpdateCard
+from miro_backend.db.session import Base, engine
 
 
 class MemoryPersistence:
     """In-memory store for idempotency responses."""
 
     def __init__(self) -> None:
-        self.responses: dict[str, dict[str, int]] = {}
+        self.responses: dict[str, dict[str, Any]] = {}
 
-    async def get_idempotent(self, key: str) -> dict[str, int] | None:
+    async def get_idempotent(self, key: str) -> dict[str, Any] | None:
         return self.responses.get(key)
 
-    async def save_idempotent(self, key: str, response: dict[str, int]) -> None:
+    async def save_idempotent(self, key: str, response: dict[str, Any]) -> None:
         self.responses[key] = response
 
 
@@ -39,12 +41,14 @@ class DummyQueue:
 # mypy struggles with pytest fixtures
 @pytest.fixture  # type: ignore[misc]
 def client_queue() -> Iterator[tuple[TestClient, DummyQueue]]:
+    Base.metadata.create_all(bind=engine)
     persistence = MemoryPersistence()
     queue = DummyQueue(persistence=persistence)
     app.dependency_overrides[get_change_queue] = lambda: queue
     client = TestClient(app)
     yield client, queue
     app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
 
 
 def test_post_batch_enqueues_tasks(client_queue: tuple[TestClient, DummyQueue]) -> None:
@@ -57,7 +61,9 @@ def test_post_batch_enqueues_tasks(client_queue: tuple[TestClient, DummyQueue]) 
     }
     response = client.post("/api/batch", json=body, headers={"X-User-Id": "u1"})
     assert response.status_code == 202
-    assert response.json() == {"enqueued": 2}
+    data = response.json()
+    assert data["enqueued"] == 2
+    assert isinstance(data["job_id"], str)
     assert len(queue.tasks) == 2
     assert isinstance(queue.tasks[0], CreateNode)
     assert isinstance(queue.tasks[1], UpdateCard)
@@ -79,7 +85,7 @@ def test_post_batch_returns_cached_response(
 ) -> None:
     client, queue = client_queue
     assert queue.persistence is not None
-    queue.persistence.responses["key1"] = {"enqueued": 3}
+    queue.persistence.responses["key1"] = {"enqueued": 3, "job_id": "j1"}
     body = {"operations": [{"type": "create_node", "node_id": "n1", "data": {"x": 1}}]}
     response = client.post(
         "/api/batch",
@@ -87,7 +93,7 @@ def test_post_batch_returns_cached_response(
         headers={"Idempotency-Key": "key1", "X-User-Id": "u1"},
     )
     assert response.status_code == 202
-    assert response.json() == {"enqueued": 3}
+    assert response.json() == {"enqueued": 3, "job_id": "j1"}
     assert len(queue.tasks) == 0
 
 
@@ -108,6 +114,8 @@ def test_post_batch_saves_idempotent_response(
         headers={"Idempotency-Key": key, "X-User-Id": "u1"},
     )
     assert response.status_code == 202
-    assert response.json() == {"enqueued": 2}
+    data = response.json()
+    assert data["enqueued"] == 2
+    assert isinstance(data["job_id"], str)
     assert queue.persistence is not None
-    assert queue.persistence.responses[key] == {"enqueued": 2}
+    assert queue.persistence.responses[key] == data

--- a/tests/test_jobs_controller.py
+++ b/tests/test_jobs_controller.py
@@ -1,35 +1,90 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import importlib
+from typing import Any
 
-from fastapi.testclient import TestClient
+import httpx
+import pytest
 
 from miro_backend.db.session import Base, SessionLocal, engine
 from miro_backend.models import Job
 from miro_backend.queue import ChangeQueue
+from miro_backend.queue.provider import get_change_queue
 
 
-def setup_module() -> None:
+class SlowClient:
+    """Client that sleeps to expose intermediate job states."""
+
+    async def create_node(self, *_: Any) -> None:  # pragma: no cover - stub
+        await asyncio.sleep(0.05)
+
+    async def update_card(self, *_: Any) -> None:  # pragma: no cover - stub
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_job_status_transitions(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(bind=engine)
+    try:
+        app_module = importlib.import_module("miro_backend.main")
+        queue = ChangeQueue()
+        app_module.app.dependency_overrides[get_change_queue] = lambda: queue
 
+        async def _token(*_: Any) -> str:
+            return "t"
 
-def teardown_module() -> None:
-    Base.metadata.drop_all(bind=engine)
+        monkeypatch.setattr(
+            "miro_backend.queue.change_queue.get_valid_access_token", _token
+        )
 
+        async with httpx.AsyncClient(
+            app=app_module.app, base_url="http://test"
+        ) as client:
+            body = {
+                "operations": [
+                    {"type": "create_node", "node_id": "n1", "data": {"x": 1}},
+                    {"type": "update_card", "card_id": "c1", "payload": {"y": 2}},
+                ]
+            }
+            resp = await client.post(
+                "/api/batch", json=body, headers={"X-User-Id": "u1"}
+            )
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
 
-def test_get_job_returns_record() -> None:
-    session = SessionLocal()
-    job = Job(status="pending")
-    session.add(job)
-    session.commit()
-    job_id = job.id
-    session.close()
+            # Job should start as queued
+            with SessionLocal() as session:
+                job = session.get(Job, job_id)
+                assert job is not None
+                assert job.status == "queued"
 
-    app_module = importlib.import_module("miro_backend.main")
-    app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
-    with TestClient(app_module.app) as client:
-        response = client.get(f"/api/jobs/{job_id}")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["id"] == job_id
-        assert data["status"] == "pending"
+            worker_session = SessionLocal()
+            worker = asyncio.create_task(queue.worker(worker_session, SlowClient()))
+            statuses: list[str] = []
+            try:
+                while True:
+                    await asyncio.sleep(0.02)
+                    with SessionLocal() as session:
+                        job = session.get(Job, job_id)
+                        assert job is not None
+                        statuses.append(job.status)
+                        if job.status == "succeeded":
+                            break
+            finally:
+                worker.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await worker
+                worker_session.close()
+
+            assert "running" in statuses
+
+            result = await client.get(f"/api/jobs/{job_id}")
+            assert result.status_code == 200
+            data = result.json()
+            assert data["status"] == "succeeded"
+            assert len(data["results"]["operations"]) == 2
+    finally:
+        app_module.app.dependency_overrides.clear()
+        Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Summary
- generate job IDs when enqueuing batches and persist status/results
- expose job inspection via `/api/jobs/{job_id}`
- track job lifecycle in worker and return job id from batch API
- test job status transitions and update batch tests

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/batch.py src/miro_backend/queue/change_queue.py src/miro_backend/queue/tasks.py src/miro_backend/schemas/batch.py src/miro_backend/services/batch_service.py tests/test_batch_controller.py tests/test_jobs_controller.py tests/test_batch_idempotency.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f60d1b88832b848ffad78b17e1d0