### PR TITLE
feat: refresh board cache after change queue writes

### DIFF
--- a/src/miro_backend/services/repository.py
+++ b/src/miro_backend/services/repository.py
@@ -67,6 +67,19 @@ class Repository(Generic[ModelT]):
         logfire.info("board state fetched", board_id=board_id)  # event: cache lookup
         return entry.value if entry else None
 
+    @logfire.instrument("set board state")  # type: ignore[misc]
+    def set_board_state(self, board_id: str, state: dict[str, Any]) -> None:
+        """Persist ``state`` for ``board_id`` in the cache."""
+
+        entry = self.session.query(CacheEntry).filter_by(key=board_id).one_or_none()
+        if entry is None:
+            entry = CacheEntry(key=board_id, value=state)
+            self.session.add(entry)
+        else:
+            entry.value = state
+        self.session.commit()
+        logfire.info("board state saved", board_id=board_id)  # event: cache upsert
+
     # ------------------------------------------------------------------
     # Delete operations
     # ------------------------------------------------------------------

--- a/tests/integration/test_cache_refresh.py
+++ b/tests/integration/test_cache_refresh.py
@@ -1,0 +1,62 @@
+"""Integration test for cache refresh after change queue writes."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.models import CacheEntry
+from miro_backend.queue import ChangeQueue, CreateShape
+from miro_backend.services.repository import Repository
+
+
+class FakeClient:
+    async def create_shape(
+        self, board_id: str, shape_id: str, data: dict[str, int], token: str
+    ) -> None:  # pragma: no cover - behavior stubbed
+        return None
+
+
+@pytest.mark.integration  # type: ignore[misc]
+@pytest.mark.asyncio  # type: ignore[misc]
+async def test_cache_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    queue = ChangeQueue()
+    client = FakeClient()
+
+    async def _token(*_: object) -> str:
+        return "t"
+
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.get_valid_access_token", _token
+    )
+
+    async def _fetch(_client: object, board_id: str, token: str) -> dict[str, str]:
+        return {"id": board_id, "status": "fresh"}
+
+    monkeypatch.setattr("miro_backend.queue.change_queue._fetch_board_snapshot", _fetch)
+
+    worker = asyncio.create_task(queue.worker(session, client))
+
+    await queue.enqueue(
+        CreateShape(board_id="b1", shape_id="s1", data={}, user_id="u1")
+    )
+    await asyncio.sleep(0.2)
+    worker.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await worker
+
+    repo = Repository(session, CacheEntry)
+    assert repo.get_board_state("b1") == {"id": "b1", "status": "fresh"}
+
+    # Exercise update path and listing for coverage
+    repo.set_board_state("b1", {"id": "b1", "status": "updated"})
+    assert repo.get_board_state("b1") == {"id": "b1", "status": "updated"}
+    assert repo.list()  # pragma: no branch - ensures list coverage
+
+    session.close()
+    Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
## Summary
- debounce board cache refreshes after change queue tasks
- upsert board snapshots into cache repository
- test cache refresh after shape creation

## Testing
- `poetry run pre-commit run --files src/miro_backend/queue/change_queue.py src/miro_backend/services/repository.py tests/integration/test_cache_refresh.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a084f8a938832b81f8fb354b680e46