### PR TITLE
feat: persist shapes in database store

### DIFF
--- a/src/miro_backend/models/__init__.py
+++ b/src/miro_backend/models/__init__.py
@@ -2,12 +2,16 @@
 
 from .board import Board
 from .cache import CacheEntry
+from .log_entry import LogEntry
+from .shape import Shape
+from .tag import Tag
 from .user import User
 
-__all__ = ["CacheEntry", "User"]
-from .tag import Tag
-
-__all__ = ["Board", "CacheEntry", "Tag"]
-from .log_entry import LogEntry
-
-__all__ = ["CacheEntry", "LogEntry"]
+__all__ = [
+    "Board",
+    "CacheEntry",
+    "LogEntry",
+    "Shape",
+    "Tag",
+    "User",
+]

--- a/src/miro_backend/models/board.py
+++ b/src/miro_backend/models/board.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..db.session import Base
 
 if TYPE_CHECKING:
+    from .shape import Shape
     from .tag import Tag
 
 
@@ -19,8 +20,15 @@ class Board(Base):
     __tablename__ = "boards"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String, unique=True, index=True)
+    board_id: Mapped[str] = mapped_column(String, unique=True, index=True)
+    owner_id: Mapped[str] = mapped_column(String, index=True)
+    name: Mapped[str | None] = mapped_column(
+        String, unique=True, index=True, nullable=True
+    )
 
     tags: Mapped[list["Tag"]] = relationship(
         "Tag", back_populates="board", cascade="all, delete-orphan"
+    )
+    shapes: Mapped[list["Shape"]] = relationship(
+        "Shape", back_populates="board", cascade="all, delete-orphan"
     )

--- a/src/miro_backend/models/shape.py
+++ b/src/miro_backend/models/shape.py
@@ -1,0 +1,32 @@
+"""Database model for shapes stored on boards."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func, JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+from ..db.session import Base
+
+if TYPE_CHECKING:
+    from .board import Board
+
+
+class Shape(Base):
+    """Represents a shape persisted in the local database."""
+
+    __tablename__ = "shapes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    board_id: Mapped[str] = mapped_column(
+        ForeignKey("boards.board_id", ondelete="CASCADE"), index=True
+    )
+    shape_id: Mapped[str] = mapped_column(String, unique=True, index=True)
+    payload: Mapped[dict[str, object]] = mapped_column(JSON)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+    board: Mapped["Board"] = relationship("Board", back_populates="shapes")

--- a/tests/integration/test_tags.py
+++ b/tests/integration/test_tags.py
@@ -24,17 +24,17 @@ async def test_list_tags_sorted(
     client, _queue = client_queue
     Base.metadata.create_all(bind=engine)
     session = SessionLocal()
-    board = Board(name="test-board")
+    board = Board(board_id="b1", owner_id="user-1", name="test-board")
     session.add(board)
     session.commit()
-    board_id = int(board.id)
+    board_pk = int(board.id)
     session.add_all(
-        [Tag(board_id=board_id, name="beta"), Tag(board_id=board_id, name="alpha")]
+        [Tag(board_id=board_pk, name="beta"), Tag(board_id=board_pk, name="alpha")]
     )
     session.commit()
     session.close()
 
-    response = await client.get(f"/api/boards/{board_id}/tags")
+    response = await client.get(f"/api/boards/{board_pk}/tags")
     Base.metadata.drop_all(bind=engine)
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_db_shape_store.py
+++ b/tests/test_db_shape_store.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from miro_backend.db.session import Base, SessionLocal, engine
+from miro_backend.schemas.shape import Shape
+from miro_backend.services.shape_store import DbShapeStore
+
+
+def setup_module() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_module() -> None:
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_db_shape_store_crud() -> None:
+    store = DbShapeStore(SessionLocal())
+    store.add_board("b1", "u1")
+    assert store.board_owner("b1") == "u1"
+
+    store.create("b1", Shape(id="s1", content="c"))
+    assert store.get("b1", "s1") == Shape(id="s1", content="c")
+    assert store.list("b1") == [Shape(id="s1", content="c")]
+
+    store.update("b1", Shape(id="s1", content="n"))
+    assert store.get("b1", "s1") == Shape(id="s1", content="n")
+
+    store.delete("b1", "s1")
+    assert store.get("b1", "s1") is None

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -8,7 +8,8 @@ from fastapi.testclient import TestClient
 
 from miro_backend.db.session import Base, engine
 from miro_backend.queue import ChangeQueue
-from miro_backend.services.shape_store import get_shape_store
+from miro_backend.services.shape_store import DbShapeStore
+from miro_backend.db.session import SessionLocal
 
 
 def setup_module() -> None:
@@ -38,7 +39,7 @@ def test_not_found_error_returns_typed_response() -> None:
 def test_forbidden_error_returns_typed_response() -> None:
     """Unauthorized access should return structured 403 responses."""
 
-    store = get_shape_store()
+    store = DbShapeStore(SessionLocal())
     store.add_board("board1", "owner1")
     app_module = importlib.import_module("miro_backend.main")
     app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]

--- a/tests/test_tags_controller.py
+++ b/tests/test_tags_controller.py
@@ -25,19 +25,19 @@ def teardown_module() -> None:
 
 def _create_board_with_tags() -> int:
     session = SessionLocal()
-    board = Board(name="test-board")
+    board = Board(board_id="b1", owner_id="user-1", name="test-board")
     session.add(board)
     session.commit()
-    board_id = int(board.id)
+    board_pk = int(board.id)
     session.add_all(
         [
-            Tag(board_id=board_id, name="beta"),
-            Tag(board_id=board_id, name="alpha"),
+            Tag(board_id=board_pk, name="beta"),
+            Tag(board_id=board_pk, name="alpha"),
         ]
     )
     session.commit()
     session.close()
-    return board_id
+    return board_pk
 
 
 def test_list_tags_sorted_by_name() -> None:


### PR DESCRIPTION
## Summary
- add Board and Shape ORM models for persisted shapes
- implement DbShapeStore and wire it through dependency injection
- test shape persistence across restart and add unit tests for DbShapeStore

## Testing
- `poetry run pre-commit run --files src/miro_backend/models/__init__.py src/miro_backend/models/board.py src/miro_backend/models/shape.py src/miro_backend/services/shape_store.py tests/integration/test_shapes.py tests/integration/test_tags.py tests/test_error_handlers.py tests/test_tags_controller.py tests/test_db_shape_store.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a085228680832bbc67a320eb68c286