### PR TITLE
feat: polish OpenAPI metadata and examples

### DIFF
--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -21,7 +21,12 @@ async def post_batch(
     request: BatchRequest,
     queue: ChangeQueue = Depends(get_change_queue),
     user_id: str = Header(alias="X-User-Id"),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = Header(
+        default=None,
+        alias="Idempotency-Key",
+        description="Unique key to ensure idempotent requests.",
+        example="req-123",
+    ),
 ) -> BatchResponse:
     """Validate ``request`` and enqueue its operations.
 

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
         alias="MIRO_CORS_ORIGINS",
         description="List of allowed CORS origins.",
     )
+    server_url: str = Field(
+        default="http://localhost:8000",
+        alias="MIRO_SERVER_URL",
+        description="Base URL for this service exposed in OpenAPI docs.",
+    )
     client_id: str = Field(
         alias="MIRO_CLIENT_ID",
         description="OAuth client identifier issued by Miro.",

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -69,8 +69,29 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         logfire.info("change worker stopped")  # event for worker shutdown
 
 
+TAGS_METADATA = [
+    {"name": "auth", "description": "Authentication operations"},
+    {
+        "name": "batch",
+        "description": "Submit operations in bulk; supports idempotency and job tracking.",
+    },
+    {"name": "cache", "description": "Cache management endpoints"},
+    {"name": "cards", "description": "Card operations"},
+    {"name": "logs", "description": "Application log streaming"},
+    {"name": "oauth", "description": "OAuth utilities"},
+    {"name": "shapes", "description": "Shape operations"},
+    {"name": "tags", "description": "Board tag management"},
+    {"name": "users", "description": "User operations"},
+    {"name": "webhook", "description": "Webhook handlers"},
+    {"name": "jobs", "description": "Background job status endpoints"},
+]
+
 BASE_DIR = Path(__file__).resolve().parents[2]
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(
+    lifespan=lifespan,
+    servers=[{"url": settings.server_url}],
+    openapi_tags=TAGS_METADATA,
+)
 
 # Instrument FastAPI and register middleware and handlers
 setup_fastapi(app)

--- a/src/miro_backend/schemas/batch.py
+++ b/src/miro_backend/schemas/batch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CreateNodeOperation(BaseModel):
@@ -37,8 +37,29 @@ class BatchRequest(BaseModel):
 
     operations: list[Operation]
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "operations": [
+                    {
+                        "type": "create_node",
+                        "node_id": "n1",
+                        "data": {"x": 0, "y": 0},
+                    },
+                    {
+                        "type": "update_card",
+                        "card_id": "c1",
+                        "payload": {"title": "Updated"},
+                    },
+                ]
+            }
+        }
+    )
+
 
 class BatchResponse(BaseModel):
     """Summary of enqueued operations."""
 
     enqueued: int
+
+    model_config = ConfigDict(json_schema_extra={"example": {"enqueued": 2}})


### PR DESCRIPTION
## Summary
- document API server URL via `MIRO_SERVER_URL` and expose server list and tag metadata in FastAPI
- add OpenAPI examples for batch requests, responses and idempotency header
- extend OpenAPI tests to assert server, tag and example configuration

## Testing
- `poetry run pre-commit run --files src/miro_backend/core/config.py src/miro_backend/main.py src/miro_backend/schemas/batch.py src/miro_backend/api/routers/batch.py tests/test_open_api_configuration.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a085409f90832b8339655dce2a7863