### PR TITLE
feat: add dev and test helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,10 @@ Copy `web/client/.env.example` to `web/client/.env` and adjust the values as nee
 
 ### Development
 
-Start the FastAPI server:
+Run migrations and start both the FastAPI server and Vite dev server:
 
 ```bash
-poetry run uvicorn src.miro_backend.main:app --reload --port 8000
-```
-
-Start the React client:
-
-```bash
-(cd web/client && npm run dev)
+./scripts/dev.sh
 ```
 
 ## Uploading JSON Content
@@ -263,6 +257,14 @@ scopes:
    https://github.com/horeaporutiu/app-examples-template/assets/10428517/b23d9c4c-e785-43f9-a72e-fa5d82c7b019
 
 ## Testing
+
+Run the backend test suite:
+
+```bash
+./scripts/test.sh
+```
+
+The script creates a temporary SQLite database and runs `pytest -q`.
 
 The root `AGENTS.md` lists the commands to run before committing. Be sure to
 install dependencies first:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+
+# Apply database migrations
+poetry run alembic upgrade head
+
+# Start FastAPI backend
+poetry run uvicorn src.miro_backend.main:app --reload --port 8000 &
+API_PID=$!
+
+# Start Vite development server if frontend exists
+if [ -f web/client/package.json ]; then
+  (cd web/client && npm run dev) &
+  FRONTEND_PID=$!
+fi
+
+cleanup() {
+  kill $API_PID ${FRONTEND_PID-} 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for any process to exit
+wait -n $API_PID ${FRONTEND_PID-}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+
+DB_FILE=$(mktemp)
+trap "rm -f ${DB_FILE}" EXIT
+poetry run pytest -q "$@"


### PR DESCRIPTION
## Summary
- add dev helper to run migrations, API, and Vite concurrently
- add test helper for temporary DB and pytest
- document scripts in README

## Testing
- `poetry run pre-commit run --files README.md scripts/dev.sh scripts/test.sh`
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a085503204832b94413b3ecf02f9fc