### PR TITLE
fix(web): unify backend URL env variable

### DIFF
--- a/web/client/src/core/utils/api-fetch.ts
+++ b/web/client/src/core/utils/api-fetch.ts
@@ -1,7 +1,7 @@
 import { context, propagation } from '@opentelemetry/api';
 import { span } from 'logfire';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL ?? '';
 
 /**
  * Augment fetch calls with the current user's identifier.

--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.VITE_PORT),
       proxy: {
         '/api': {
-          target: env.VITE_API_BASE_URL,
+          target: env.VITE_BACKEND_URL,
           changeOrigin: true,
           secure: false,
         },


### PR DESCRIPTION
## Summary
- ensure frontend API requests and dev server proxy use `VITE_BACKEND_URL`

## Testing
- `poetry run pre-commit run --files web/client/src/core/utils/api-fetch.ts web/client/vite.config.ts` *(fails: Invalid state, tests failing)*
- `poetry run pytest` *(fails: Invalid state, tests failing)*
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: multiple test suites failing)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a086c33510832b813a91846dfcc80c