### PR TITLE
fix(web): proxy oauth requests in Vite dev server

### DIFF
--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -41,7 +41,12 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.VITE_PORT),
       proxy: {
         '/api': {
-          target: env.VITE_API_BASE_URL,
+          target: env.VITE_BACKEND_URL,
+          changeOrigin: true,
+          secure: false,
+        },
+        '/oauth': {
+          target: env.VITE_BACKEND_URL,
           changeOrigin: true,
           secure: false,
         },


### PR DESCRIPTION
## Summary
- forward `/oauth` requests to backend in Vite dev proxy
- use shared `VITE_BACKEND_URL` env for both API and OAuth routes

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(failed: s is not a function; expected +0 to be 202)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a086cc7418832b90750b429beb486c