### PR TITLE
build: add openapi snapshot fallback

### DIFF
--- a/scripts/generate-client.ts
+++ b/scripts/generate-client.ts
@@ -4,8 +4,14 @@ import path from "node:path";
 async function generate(): Promise<void> {
   const bin = path.resolve(__dirname, "../web/client/node_modules/.bin/openapi-typescript");
   const outPath = path.resolve(__dirname, "../web/client/src/generated/client.ts");
+  const url =
+    process.env.OPENAPI_URL ??
+    path.resolve(__dirname, "../web/client/openapi.json");
+  const args = url.startsWith("http")
+    ? [url, "--output", outPath]
+    : [url, "--output", outPath];
   await new Promise<void>((resolve, reject) => {
-    execFile(bin, ["http://localhost:8000/openapi.json", "--output", outPath], (error) => {
+    execFile(bin, args, (error) => {
       if (error) {
         reject(error);
         return;

--- a/web/client/openapi.json
+++ b/web/client/openapi.json
@@ -1,0 +1,854 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "FastAPI", "version": "0.1.0" },
+  "paths": {
+    "/api/auth/status": {
+      "get": {
+        "tags": ["auth"],
+        "summary": "Get Status",
+        "description": "Return 200 when tokens exist for the provided ``X-User-Id`` header.",
+        "operationId": "get_status_api_auth_status_get",
+        "parameters": [
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "X-User-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhook": {
+      "post": {
+        "tags": ["webhook"],
+        "summary": "Post Webhook",
+        "description": "Validate ``signature`` and enqueue the webhook payload.",
+        "operationId": "post_webhook_api_webhook_post",
+        "parameters": [
+          {
+            "name": "X-Miro-Signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "X-Miro-Signature"
+            }
+          }
+        ],
+        "responses": {
+          "202": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users": {
+      "post": {
+        "tags": ["users"],
+        "summary": "Create User",
+        "description": "Persist ``info`` and return it, rejecting duplicates.",
+        "operationId": "create_user_api_users_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserInfo" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserInfo" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/boards/{board_id}/tags": {
+      "get": {
+        "tags": ["tags"],
+        "summary": "List Tags",
+        "description": "Return all tags for ``board_id`` sorted by name.",
+        "operationId": "list_tags_api_boards__board_id__tags_get",
+        "parameters": [
+          {
+            "name": "board_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "title": "Board Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Tag" },
+                  "title": "Response List Tags Api Boards  Board Id  Tags Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/boards/{board_id}/shapes/{shape_id}": {
+      "get": {
+        "tags": ["shapes"],
+        "summary": "Get Shape",
+        "description": "Return the specified shape if the requester owns the board.",
+        "operationId": "get_shape_api_boards__board_id__shapes__shape_id__get",
+        "parameters": [
+          {
+            "name": "board_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Board Id" }
+          },
+          {
+            "name": "shape_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Shape Id" }
+          },
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "X-User-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Shape" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["shapes"],
+        "summary": "Update Shape",
+        "description": "Update an existing shape and queue the change.",
+        "operationId": "update_shape_api_boards__board_id__shapes__shape_id__put",
+        "parameters": [
+          {
+            "name": "board_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Board Id" }
+          },
+          {
+            "name": "shape_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Shape Id" }
+          },
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "X-User-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ShapeUpdate" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Shape" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["shapes"],
+        "summary": "Delete Shape",
+        "description": "Delete a shape and queue the removal.",
+        "operationId": "delete_shape_api_boards__board_id__shapes__shape_id__delete",
+        "parameters": [
+          {
+            "name": "board_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Board Id" }
+          },
+          {
+            "name": "shape_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Shape Id" }
+          },
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "X-User-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/boards/{board_id}/shapes/": {
+      "post": {
+        "tags": ["shapes"],
+        "summary": "Create Shape",
+        "description": "Create a new shape and queue the change.",
+        "operationId": "create_shape_api_boards__board_id__shapes__post",
+        "parameters": [
+          {
+            "name": "board_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Board Id" }
+          },
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "X-User-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ShapeCreate" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Shape" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth/login": {
+      "get": {
+        "tags": ["oauth"],
+        "summary": "Login",
+        "description": "Redirect the user to Miro's OAuth consent screen.",
+        "operationId": "login_oauth_login_get",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "title": "Userid" }
+          },
+          {
+            "name": "returnUrl",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Returnurl"
+            }
+          }
+        ],
+        "responses": {
+          "307": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth/callback": {
+      "get": {
+        "tags": ["oauth"],
+        "summary": "Callback",
+        "description": "Exchange the code for tokens and store them.",
+        "operationId": "callback_oauth_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "title": "Code" }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "title": "State" }
+          }
+        ],
+        "responses": {
+          "307": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logs/": {
+      "post": {
+        "tags": ["logs"],
+        "summary": "Capture Logs",
+        "description": "Persist a batch of log entries.\n\nParameters\n----------\nentries:\n    Collection of log entries supplied by the client.\nrepo:\n    Repository used to store entries.",
+        "operationId": "capture_logs_api_logs__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": { "$ref": "#/components/schemas/LogEntryIn" },
+                "type": "array",
+                "title": "Entries"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/cards": {
+      "post": {
+        "tags": ["cards"],
+        "summary": "Create Cards",
+        "description": "Queue tasks that create the supplied ``cards``.",
+        "operationId": "create_cards_api_cards_post",
+        "parameters": [
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string", "title": "X-User-Id" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/CardCreate" },
+                "title": "Cards"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": { "type": "integer" },
+                  "title": "Response Create Cards Api Cards Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/cache/{board_id}": {
+      "get": {
+        "tags": ["cache"],
+        "summary": "Get Board Cache",
+        "description": "Return cached board state for ``board_id``.",
+        "operationId": "get_board_cache_api_cache__board_id__get",
+        "parameters": [
+          {
+            "name": "board_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Board Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Board Cache Api Cache  Board Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/batch": {
+      "post": {
+        "tags": ["batch"],
+        "summary": "Post Batch",
+        "description": "Validate ``request`` and enqueue its operations.\n\nIf ``idempotency_key`` is provided and the request was previously processed,\nreturn the cached response without enqueuing tasks again.",
+        "operationId": "post_batch_api_batch_post",
+        "parameters": [
+          {
+            "name": "X-User-Id",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string", "title": "X-User-Id" }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BatchRequest" }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BatchResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "description": "Expose Prometheus metrics.",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "description": "Redirect browsers to the built front-end.",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "text/html": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Basic health check endpoint.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": { "type": "string" },
+                  "type": "object",
+                  "title": "Response Health Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BatchRequest": {
+        "properties": {
+          "operations": {
+            "items": {
+              "oneOf": [
+                { "$ref": "#/components/schemas/CreateNodeOperation" },
+                { "$ref": "#/components/schemas/UpdateCardOperation" }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "create_node": "#/components/schemas/CreateNodeOperation",
+                  "update_card": "#/components/schemas/UpdateCardOperation"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Operations"
+          }
+        },
+        "type": "object",
+        "required": ["operations"],
+        "title": "BatchRequest",
+        "description": "Incoming batch of operations to process."
+      },
+      "BatchResponse": {
+        "properties": {
+          "enqueued": { "type": "integer", "title": "Enqueued" }
+        },
+        "type": "object",
+        "required": ["enqueued"],
+        "title": "BatchResponse",
+        "description": "Summary of enqueued operations."
+      },
+      "CardCreate": {
+        "properties": {
+          "id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Id"
+          },
+          "title": { "type": "string", "title": "Title" },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "tags": {
+            "anyOf": [
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
+            ],
+            "title": "Tags"
+          },
+          "style": {
+            "anyOf": [
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
+            ],
+            "title": "Style"
+          },
+          "fields": {
+            "anyOf": [
+              {
+                "items": { "additionalProperties": true, "type": "object" },
+                "type": "array"
+              },
+              { "type": "null" }
+            ],
+            "title": "Fields"
+          },
+          "taskStatus": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Taskstatus"
+          }
+        },
+        "type": "object",
+        "required": ["title"],
+        "title": "CardCreate",
+        "description": "Data describing a card to be created on the board."
+      },
+      "CreateNodeOperation": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "create_node",
+            "title": "Type",
+            "description": "Discriminator for the operation type"
+          },
+          "node_id": { "type": "string", "title": "Node Id" },
+          "data": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": ["type", "node_id", "data"],
+        "title": "CreateNodeOperation",
+        "description": "Request to create a new node on the board."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": { "$ref": "#/components/schemas/ValidationError" },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "LogEntryIn": {
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "level": { "type": "string", "maxLength": 16, "title": "Level" },
+          "message": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "Message"
+          },
+          "context": {
+            "anyOf": [
+              {
+                "additionalProperties": { "type": "string" },
+                "type": "object"
+              },
+              { "type": "null" }
+            ],
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": ["timestamp", "level", "message"],
+        "title": "LogEntryIn",
+        "description": "Log entry received from the client application."
+      },
+      "Shape": {
+        "properties": {
+          "content": { "type": "string", "title": "Content" },
+          "id": { "type": "string", "title": "Id" }
+        },
+        "type": "object",
+        "required": ["content", "id"],
+        "title": "Shape",
+        "description": "A shape stored on a board."
+      },
+      "ShapeCreate": {
+        "properties": { "content": { "type": "string", "title": "Content" } },
+        "type": "object",
+        "required": ["content"],
+        "title": "ShapeCreate",
+        "description": "Payload required to create a new shape."
+      },
+      "ShapeUpdate": {
+        "properties": { "content": { "type": "string", "title": "Content" } },
+        "type": "object",
+        "required": ["content"],
+        "title": "ShapeUpdate",
+        "description": "Payload used to update an existing shape."
+      },
+      "Tag": {
+        "properties": {
+          "id": { "type": "integer", "title": "Id" },
+          "board_id": { "type": "integer", "title": "Board Id" },
+          "name": { "type": "string", "title": "Name" }
+        },
+        "type": "object",
+        "required": ["id", "board_id", "name"],
+        "title": "Tag",
+        "description": "Serialised representation of a :class:`~miro_backend.models.tag.Tag`."
+      },
+      "UpdateCardOperation": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "update_card",
+            "title": "Type",
+            "description": "Discriminator for the operation type"
+          },
+          "card_id": { "type": "string", "title": "Card Id" },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          }
+        },
+        "type": "object",
+        "required": ["type", "card_id", "payload"],
+        "title": "UpdateCardOperation",
+        "description": "Request to update an existing card."
+      },
+      "UserInfo": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "access_token": { "type": "string", "title": "Access Token" },
+          "refresh_token": { "type": "string", "title": "Refresh Token" },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expires At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "access_token",
+          "refresh_token",
+          "expires_at"
+        ],
+        "title": "UserInfo",
+        "description": "Authentication and OAuth token details of a Miro user."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -18,7 +18,7 @@
     "dev": "vite",
     "start": "vite",
     "generate-client": "tsx ../../scripts/generate-client.ts",
-    "build": "npm run generate-client && tsc -b && vite build --outDir dist",
+    "build": "npm run generate-client || echo 'using snapshot' && tsc -b && vite build --outDir dist",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "prettier": "prettier '**/*.{js,jsx,ts,tsx,md,json,yml,yaml,html,css}' --write",

--- a/web/client/src/generated/client.ts
+++ b/web/client/src/generated/client.ts
@@ -4,743 +4,1021 @@
  */
 
 export interface paths {
-  '/api/auth/status': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Get Status
-     * @description Return 200 when tokens exist for the provided ``X-User-Id`` header.
-     */
-    get: operations['get_status_api_auth_status_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/webhook': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    get?: never;
-    put?: never;
-    /**
-     * Post Webhook
-     * @description Validate ``signature`` and enqueue the webhook payload.
-     */
-    post: operations['post_webhook_api_webhook_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/users': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    get?: never;
-    put?: never;
-    /**
-     * Create User
-     * @description Persist ``info`` and return it, rejecting duplicates.
-     */
-    post: operations['create_user_api_users_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/boards/{board_id}/tags': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * List Tags
-     * @description Return all tags for ``board_id`` sorted by name.
-     */
-    get: operations['list_tags_api_boards__board_id__tags_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/boards/{board_id}/shapes/{shape_id}': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Get Shape
-     * @description Return the specified shape if the requester owns the board.
-     */
-    get: operations['get_shape_api_boards__board_id__shapes__shape_id__get'];
-    /**
-     * Update Shape
-     * @description Update an existing shape and queue the change.
-     */
-    put: operations['update_shape_api_boards__board_id__shapes__shape_id__put'];
-    post?: never;
-    /**
-     * Delete Shape
-     * @description Delete a shape and queue the removal.
-     */
-    delete: operations['delete_shape_api_boards__board_id__shapes__shape_id__delete'];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/boards/{board_id}/shapes/': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    get?: never;
-    put?: never;
-    /**
-     * Create Shape
-     * @description Create a new shape and queue the change.
-     */
-    post: operations['create_shape_api_boards__board_id__shapes__post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/oauth/login': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Login
-     * @description Redirect the user to Miro's OAuth consent screen.
-     */
-    get: operations['login_oauth_login_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/oauth/callback': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Callback
-     * @description Exchange the code for tokens and store them.
-     */
-    get: operations['callback_oauth_callback_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/logs/': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    get?: never;
-    put?: never;
-    /**
-     * Capture Logs
-     * @description Persist a batch of log entries.
-     *
-     *     Parameters
-     *     ----------
-     *     entries:
-     *         Collection of log entries supplied by the client.
-     *     repo:
-     *         Repository used to store entries.
-     */
-    post: operations['capture_logs_api_logs__post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/cards': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    get?: never;
-    put?: never;
-    /**
-     * Create Cards
-     * @description Queue tasks that create the supplied ``cards``.
-     */
-    post: operations['create_cards_api_cards_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/cache/{board_id}': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Get Board Cache
-     * @description Return cached board state for ``board_id``.
-     */
-    get: operations['get_board_cache_api_cache__board_id__get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/batch': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    get?: never;
-    put?: never;
-    /**
-     * Post Batch
-     * @description Validate ``request`` and enqueue its operations.
-     */
-    post: operations['post_batch_api_batch_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/metrics': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Metrics
-     * @description Expose Prometheus metrics.
-     */
-    get: operations['metrics_metrics_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Root
-     * @description Redirect browsers to the built front-end.
-     */
-    get: operations['root__get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/health': {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    /**
-     * Health
-     * @description Basic health check endpoint.
-     */
-    get: operations['health_health_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/api/auth/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Status
+         * @description Return 200 when tokens exist for the provided ``X-User-Id`` header.
+         */
+        get: operations["get_status_api_auth_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/webhook": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Post Webhook
+         * @description Validate ``signature`` and enqueue the webhook payload.
+         */
+        post: operations["post_webhook_api_webhook_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create User
+         * @description Persist ``info`` and return it, rejecting duplicates.
+         */
+        post: operations["create_user_api_users_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/boards/{board_id}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Tags
+         * @description Return all tags for ``board_id`` sorted by name.
+         */
+        get: operations["list_tags_api_boards__board_id__tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/boards/{board_id}/shapes/{shape_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Shape
+         * @description Return the specified shape if the requester owns the board.
+         */
+        get: operations["get_shape_api_boards__board_id__shapes__shape_id__get"];
+        /**
+         * Update Shape
+         * @description Update an existing shape and queue the change.
+         */
+        put: operations["update_shape_api_boards__board_id__shapes__shape_id__put"];
+        post?: never;
+        /**
+         * Delete Shape
+         * @description Delete a shape and queue the removal.
+         */
+        delete: operations["delete_shape_api_boards__board_id__shapes__shape_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/boards/{board_id}/shapes/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Shape
+         * @description Create a new shape and queue the change.
+         */
+        post: operations["create_shape_api_boards__board_id__shapes__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/oauth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Login
+         * @description Redirect the user to Miro's OAuth consent screen.
+         */
+        get: operations["login_oauth_login_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/oauth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Callback
+         * @description Exchange the code for tokens and store them.
+         */
+        get: operations["callback_oauth_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/logs/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Capture Logs
+         * @description Persist a batch of log entries.
+         *
+         *     Parameters
+         *     ----------
+         *     entries:
+         *         Collection of log entries supplied by the client.
+         *     repo:
+         *         Repository used to store entries.
+         */
+        post: operations["capture_logs_api_logs__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Cards
+         * @description Queue tasks that create the supplied ``cards``.
+         */
+        post: operations["create_cards_api_cards_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cache/{board_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Board Cache
+         * @description Return cached board state for ``board_id``.
+         */
+        get: operations["get_board_cache_api_cache__board_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Post Batch
+         * @description Validate ``request`` and enqueue its operations.
+         *
+         *     If ``idempotency_key`` is provided and the request was previously processed,
+         *     return the cached response without enqueuing tasks again.
+         */
+        post: operations["post_batch_api_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Metrics
+         * @description Expose Prometheus metrics.
+         */
+        get: operations["metrics_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Root
+         * @description Redirect browsers to the built front-end.
+         */
+        get: operations["root__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health
+         * @description Basic health check endpoint.
+         */
+        get: operations["health_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    /**
-     * BatchRequest
-     * @description Incoming batch of operations to process.
-     */
-    BatchRequest: {
-      /** Operations */
-      operations: (
-        | components['schemas']['CreateNodeOperation']
-        | components['schemas']['UpdateCardOperation']
-      )[];
+    schemas: {
+        /**
+         * BatchRequest
+         * @description Incoming batch of operations to process.
+         */
+        BatchRequest: {
+            /** Operations */
+            operations: (components["schemas"]["CreateNodeOperation"] | components["schemas"]["UpdateCardOperation"])[];
+        };
+        /**
+         * BatchResponse
+         * @description Summary of enqueued operations.
+         */
+        BatchResponse: {
+            /** Enqueued */
+            enqueued: number;
+        };
+        /**
+         * CardCreate
+         * @description Data describing a card to be created on the board.
+         */
+        CardCreate: {
+            /** Id */
+            id?: string | null;
+            /** Title */
+            title: string;
+            /** Description */
+            description?: string | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Style */
+            style?: {
+                [key: string]: unknown;
+            } | null;
+            /** Fields */
+            fields?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Taskstatus */
+            taskStatus?: string | null;
+        };
+        /**
+         * CreateNodeOperation
+         * @description Request to create a new node on the board.
+         */
+        CreateNodeOperation: {
+            /**
+             * @description Discriminator for the operation type (enum property replaced by openapi-typescript)
+             * @enum {string}
+             */
+            type: "create_node";
+            /** Node Id */
+            node_id: string;
+            /** Data */
+            data: {
+                [key: string]: unknown;
+            };
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * LogEntryIn
+         * @description Log entry received from the client application.
+         */
+        LogEntryIn: {
+            /**
+             * Timestamp
+             * Format: date-time
+             */
+            timestamp: string;
+            /** Level */
+            level: string;
+            /** Message */
+            message: string;
+            /** Context */
+            context?: {
+                [key: string]: string;
+            } | null;
+        };
+        /**
+         * Shape
+         * @description A shape stored on a board.
+         */
+        Shape: {
+            /** Content */
+            content: string;
+            /** Id */
+            id: string;
+        };
+        /**
+         * ShapeCreate
+         * @description Payload required to create a new shape.
+         */
+        ShapeCreate: {
+            /** Content */
+            content: string;
+        };
+        /**
+         * ShapeUpdate
+         * @description Payload used to update an existing shape.
+         */
+        ShapeUpdate: {
+            /** Content */
+            content: string;
+        };
+        /**
+         * Tag
+         * @description Serialised representation of a :class:`~miro_backend.models.tag.Tag`.
+         */
+        Tag: {
+            /** Id */
+            id: number;
+            /** Board Id */
+            board_id: number;
+            /** Name */
+            name: string;
+        };
+        /**
+         * UpdateCardOperation
+         * @description Request to update an existing card.
+         */
+        UpdateCardOperation: {
+            /**
+             * @description Discriminator for the operation type (enum property replaced by openapi-typescript)
+             * @enum {string}
+             */
+            type: "update_card";
+            /** Card Id */
+            card_id: string;
+            /** Payload */
+            payload: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * UserInfo
+         * @description Authentication and OAuth token details of a Miro user.
+         */
+        UserInfo: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Access Token */
+            access_token: string;
+            /** Refresh Token */
+            refresh_token: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
     };
-    /**
-     * BatchResponse
-     * @description Summary of enqueued operations.
-     */
-    BatchResponse: {
-      /** Enqueued */
-      enqueued: number;
-    };
-    /**
-     * CardCreate
-     * @description Data describing a card to be created on the board.
-     */
-    CardCreate: {
-      /** Id */
-      id?: string | null;
-      /** Title */
-      title: string;
-      /** Description */
-      description?: string | null;
-      /** Tags */
-      tags?: string[] | null;
-      /** Style */
-      style?: { [key: string]: unknown } | null;
-      /** Fields */
-      fields?: { [key: string]: unknown }[] | null;
-      /** Taskstatus */
-      taskStatus?: string | null;
-    };
-    /**
-     * CreateNodeOperation
-     * @description Request to create a new node on the board.
-     */
-    CreateNodeOperation: {
-      /**
-       * @description Discriminator for the operation type (enum property replaced by openapi-typescript)
-       * @enum {string}
-       */
-      type: 'create_node';
-      /** Node Id */
-      node_id: string;
-      /** Data */
-      data: { [key: string]: unknown };
-    };
-    /** HTTPValidationError */
-    HTTPValidationError: {
-      /** Detail */
-      detail?: components['schemas']['ValidationError'][];
-    };
-    /**
-     * LogEntryIn
-     * @description Log entry received from the client application.
-     */
-    LogEntryIn: {
-      /**
-       * Timestamp
-       * Format: date-time
-       */
-      timestamp: string;
-      /** Level */
-      level: string;
-      /** Message */
-      message: string;
-      /** Context */
-      context?: { [key: string]: string } | null;
-    };
-    /**
-     * Shape
-     * @description A shape stored on a board.
-     */
-    Shape: {
-      /** Content */
-      content: string;
-      /** Id */
-      id: string;
-    };
-    /**
-     * ShapeCreate
-     * @description Payload required to create a new shape.
-     */
-    ShapeCreate: {
-      /** Content */
-      content: string;
-    };
-    /**
-     * ShapeUpdate
-     * @description Payload used to update an existing shape.
-     */
-    ShapeUpdate: {
-      /** Content */
-      content: string;
-    };
-    /**
-     * Tag
-     * @description Serialised representation of a :class:`~miro_backend.models.tag.Tag`.
-     */
-    Tag: {
-      /** Id */
-      id: number;
-      /** Board Id */
-      board_id: number;
-      /** Name */
-      name: string;
-    };
-    /**
-     * UpdateCardOperation
-     * @description Request to update an existing card.
-     */
-    UpdateCardOperation: {
-      /**
-       * @description Discriminator for the operation type (enum property replaced by openapi-typescript)
-       * @enum {string}
-       */
-      type: 'update_card';
-      /** Card Id */
-      card_id: string;
-      /** Payload */
-      payload: { [key: string]: unknown };
-    };
-    /**
-     * UserInfo
-     * @description Authentication and OAuth token details of a Miro user.
-     */
-    UserInfo: {
-      /** Id */
-      id: string;
-      /** Name */
-      name: string;
-      /** Access Token */
-      access_token: string;
-      /** Refresh Token */
-      refresh_token: string;
-      /**
-       * Expires At
-       * Format: date-time
-       */
-      expires_at: string;
-    };
-    /** ValidationError */
-    ValidationError: {
-      /** Location */
-      loc: (string | number)[];
-      /** Message */
-      msg: string;
-      /** Error Type */
-      type: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  get_status_api_auth_status_get: {
-    parameters: {
-      query?: never;
-      header?: { 'X-User-Id'?: string | null };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: { headers: { [name: string]: unknown }; content?: never };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+    get_status_api_auth_status_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User-Id"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  post_webhook_api_webhook_post: {
-    parameters: {
-      query?: never;
-      header?: { 'X-Miro-Signature'?: string | null };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      202: { headers: { [name: string]: unknown }; content?: never };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
-      };
     };
-  };
-  create_user_api_users_post: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody: {
-      content: { 'application/json': components['schemas']['UserInfo'] };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': components['schemas']['UserInfo'] };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+    post_webhook_api_webhook_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Miro-Signature"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  list_tags_api_boards__board_id__tags_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: { board_id: number };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': components['schemas']['Tag'][] };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
-      };
     };
-  };
-  get_shape_api_boards__board_id__shapes__shape_id__get: {
-    parameters: {
-      query?: never;
-      header?: { 'X-User-Id'?: string | null };
-      path: { board_id: string; shape_id: string };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': components['schemas']['Shape'] };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+    create_user_api_users_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  update_shape_api_boards__board_id__shapes__shape_id__put: {
-    parameters: {
-      query?: never;
-      header?: { 'X-User-Id'?: string | null };
-      path: { board_id: string; shape_id: string };
-      cookie?: never;
-    };
-    requestBody: {
-      content: { 'application/json': components['schemas']['ShapeUpdate'] };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': components['schemas']['Shape'] };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserInfo"];
+            };
         };
-      };
-    };
-  };
-  delete_shape_api_boards__board_id__shapes__shape_id__delete: {
-    parameters: {
-      query?: never;
-      header?: { 'X-User-Id'?: string | null };
-      path: { board_id: string; shape_id: string };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      204: { headers: { [name: string]: unknown }; content?: never };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserInfo"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
-      };
     };
-  };
-  create_shape_api_boards__board_id__shapes__post: {
-    parameters: {
-      query?: never;
-      header?: { 'X-User-Id'?: string | null };
-      path: { board_id: string };
-      cookie?: never;
-    };
-    requestBody: {
-      content: { 'application/json': components['schemas']['ShapeCreate'] };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': components['schemas']['Shape'] };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+    list_tags_api_boards__board_id__tags_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                board_id: number;
+            };
+            cookie?: never;
         };
-      };
-    };
-  };
-  login_oauth_login_get: {
-    parameters: {
-      query: { userId: string; returnUrl?: string | null };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      307: { headers: { [name: string]: unknown }; content?: never };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Tag"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
-      };
     };
-  };
-  callback_oauth_callback_get: {
-    parameters: {
-      query: { code: string; state: string };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      307: { headers: { [name: string]: unknown }; content?: never };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+    get_shape_api_boards__board_id__shapes__shape_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User-Id"?: string | null;
+            };
+            path: {
+                board_id: string;
+                shape_id: string;
+            };
+            cookie?: never;
         };
-      };
-    };
-  };
-  capture_logs_api_logs__post: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody: {
-      content: { 'application/json': components['schemas']['LogEntryIn'][] };
-    };
-    responses: {
-      /** @description Successful Response */
-      202: { headers: { [name: string]: unknown }; content?: never };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Shape"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
-      };
     };
-  };
-  create_cards_api_cards_post: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody: {
-      content: { 'application/json': components['schemas']['CardCreate'][] };
-    };
-    responses: {
-      /** @description Successful Response */
-      202: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': { [key: string]: number } };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+    update_shape_api_boards__board_id__shapes__shape_id__put: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User-Id"?: string | null;
+            };
+            path: {
+                board_id: string;
+                shape_id: string;
+            };
+            cookie?: never;
         };
-      };
-    };
-  };
-  get_board_cache_api_cache__board_id__get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: { board_id: string };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': { [key: string]: unknown } };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ShapeUpdate"];
+            };
         };
-      };
-    };
-  };
-  post_batch_api_batch_post: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody: {
-      content: { 'application/json': components['schemas']['BatchRequest'] };
-    };
-    responses: {
-      /** @description Successful Response */
-      202: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': components['schemas']['BatchResponse'] };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: { [name: string]: unknown };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Shape"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
         };
-      };
     };
-  };
-  metrics_metrics_get: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': unknown };
-      };
+    delete_shape_api_boards__board_id__shapes__shape_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User-Id"?: string | null;
+            };
+            path: {
+                board_id: string;
+                shape_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-  };
-  root__get: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'text/html': string };
-      };
+    create_shape_api_boards__board_id__shapes__post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User-Id"?: string | null;
+            };
+            path: {
+                board_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ShapeCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Shape"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-  };
-  health_health_get: {
-    parameters: { query?: never; header?: never; path?: never; cookie?: never };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: { [name: string]: unknown };
-        content: { 'application/json': { [key: string]: string } };
-      };
+    login_oauth_login_get: {
+        parameters: {
+            query: {
+                userId: string;
+                returnUrl?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            307: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
     };
-  };
+    callback_oauth_callback_get: {
+        parameters: {
+            query: {
+                code: string;
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            307: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    capture_logs_api_logs__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogEntryIn"][];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_cards_api_cards_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-User-Id": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CardCreate"][];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: number;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_board_cache_api_cache__board_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                board_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_batch_api_batch_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-User-Id": string;
+                "Idempotency-Key"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    metrics_metrics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    root__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+        };
+    };
+    health_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+    };
 }


### PR DESCRIPTION
## Summary
- allow generate-client script to read OPENAPI_URL or local snapshot
- fall back to snapshot during build when API is unavailable
- check in OpenAPI spec and regenerate TypeScript client

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: ReferenceError PointerEvent is not defined)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `poetry run pre-commit run --files scripts/generate-client.ts web/client/package.json web/client/openapi.json` *(fails: tests failing)*
- `poetry run pytest` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0876a6d7c832b9a5f524b9c5529ff