### PR TITLE
fix(client): proxy OAuth endpoints and retain api path

### DIFF
--- a/web/client/default.conf.template
+++ b/web/client/default.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen       ${VITE_PORT};
-    listen  [::]:${VITE_PORT};
+    listen       80;
+    listen  [::]:80;
     server_name  localhost;
 
     access_log  /var/log/nginx/server.access.log  main;
@@ -10,11 +10,19 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Preserve /api prefix: NO rewrite.
     location /api/ {
         proxy_pass ${VITE_BACKEND_URL};
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        rewrite ^/api(/.*)$ $1 break;
+    }
+
+    # Add OAuth endpoints
+    location /oauth/ {
+        proxy_pass ${VITE_BACKEND_URL};
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }


### PR DESCRIPTION
## Summary
- proxy OAuth endpoints through Nginx
- stop stripping `/api` prefix to keep FastAPI routes intact
- default Nginx listen port to 80 for container compatibility

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: ReferenceError: PointerEvent is not defined)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `poetry run pre-commit run --files web/client/default.conf.template` *(fails: tests failed)*
- `poetry run pytest` *(fails: 2 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0875b4610832bb3cf744145939a77