### PR TITLE
fix(client): use VITE_BACKEND_URL for API requests

### DIFF
--- a/web/client/src/core/utils/api-fetch.ts
+++ b/web/client/src/core/utils/api-fetch.ts
@@ -1,7 +1,7 @@
 import { context, propagation } from '@opentelemetry/api';
 import { span } from 'logfire';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? '';
 
 /**
  * Augment fetch calls with the current user's identifier.
@@ -21,7 +21,7 @@ export async function apiFetch(
     propagation.inject(context.active(), headers, {
       set: (key, value) => headers.set(key, value),
     });
-    const url = typeof input === 'string' ? `${API_BASE_URL}${input}` : input;
+    const url = typeof input === 'string' ? `${BACKEND_URL}${input}` : input;
     return fetch(url, { ...init, headers });
   });
 }

--- a/web/client/vite.config.ts
+++ b/web/client/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.VITE_PORT),
       proxy: {
         '/api': {
-          target: env.VITE_API_BASE_URL,
+          target: env.VITE_BACKEND_URL,
           changeOrigin: true,
           secure: false,
         },


### PR DESCRIPTION
## Summary
- use VITE_BACKEND_URL for apiFetch base URL
- update Vite proxy to read VITE_BACKEND_URL

## Testing
- `npm --prefix web/client install`
- `npm --prefix web/client run typecheck`
- `npm --prefix web/client run lint`
- `npm --prefix web/client run stylelint`
- `npm --prefix web/client run prettier`
- `CI=1 npm --prefix web/client test` *(fails: missing templates and unsupported APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68a08788ef5c832bb1c97fceb795e451