### PR TITLE
fix: enable console logging in dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ MIRO_HTTP_TIMEOUT_SECONDS=10.0
 
 # Optional base64-encoded 32-byte key for encrypting tokens
 MIRO_ENCRYPTION_KEY=
+
+# Logging configuration
+VITE_LOGFIRE_SEND_TO_LOGFIRE=false
+VITE_LOGFIRE_SERVICE_NAME=miro-frontend

--- a/web/client/src/logger.ts
+++ b/web/client/src/logger.ts
@@ -6,7 +6,7 @@ import { configure } from 'logfire';
 configure({
   sendToLogfire: import.meta.env.VITE_LOGFIRE_SEND_TO_LOGFIRE === 'true',
   serviceName: import.meta.env.VITE_LOGFIRE_SERVICE_NAME ?? 'miro-frontend',
-  console: false,
+  console: import.meta.env.DEV ?? true, // enable console in dev
 });
 
 export * from 'logfire';


### PR DESCRIPTION
## Summary
- enable Logfire console output in development
- document VITE_LOGFIRE env vars in `.env.example`

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: TypeError: s is not a function)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `poetry run pre-commit run --files .env.example web/client/src/logger.ts` *(fails: assert 400 == 307)*

------
https://chatgpt.com/codex/tasks/task_e_68a08793aaec832b9437a3cdee5270b1