### PR TITLE
fix(client): warn when Miro SDK missing

### DIFF
--- a/web/client/src/app/diagram-app.ts
+++ b/web/client/src/app/diagram-app.ts
@@ -19,7 +19,18 @@ export class DiagramApp {
   /** Register UI handlers with the Miro board. */
   public async init(): Promise<void> {
     log.info('Initialising Miro UI handlers');
-    if (typeof miro === 'undefined' || !miro?.board?.ui) {
+    if (
+      typeof window === 'undefined' ||
+      typeof (window as Window & { miro?: unknown }).miro === 'undefined'
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Miro SDK not loaded; are you opening index.html outside Miro?',
+      );
+      return;
+    }
+    if (!miro?.board?.ui) {
+      log.error('Miro board UI not available');
       throw new Error('Miro SDK not available');
     }
     miro.board.ui.on('icon:click', async () => {

--- a/web/client/src/user-auth.ts
+++ b/web/client/src/user-auth.ts
@@ -70,7 +70,19 @@ export class AuthClient {
 export async function registerWithCurrentUser(
   client = new AuthClient(),
 ): Promise<void> {
-  if (typeof miro === 'undefined' || !miro.board) {
+  if (
+    typeof window === 'undefined' ||
+    typeof (window as Window & { miro?: unknown }).miro === 'undefined'
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Miro SDK not loaded; are you opening index.html outside Miro?',
+    );
+    return;
+  }
+  if (!miro.board) {
+    // eslint-disable-next-line no-console
+    console.error('Miro board API not available');
     throw new Error('Miro SDK not available');
   }
   const token = await miro.board.getIdToken();

--- a/web/client/tests/diagram-app.test.ts
+++ b/web/client/tests/diagram-app.test.ts
@@ -41,8 +41,11 @@ describe('DiagramApp', () => {
     });
   });
 
-  test('init throws when miro is undefined', async () =>
-    await expect(DiagramApp.getInstance().init()).rejects.toThrow(
-      'Miro SDK not available',
-    ));
+  test('init warns and returns when miro is undefined', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(DiagramApp.getInstance().init()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      'Miro SDK not loaded; are you opening index.html outside Miro?',
+    );
+  });
 });

--- a/web/client/tests/user-auth.test.ts
+++ b/web/client/tests/user-auth.test.ts
@@ -40,3 +40,11 @@ test('registerCurrentUser retries on failure', async () => {
   expect(fetchMock).toHaveBeenCalledTimes(2);
   vi.useRealTimers();
 });
+
+test('registerCurrentUser warns and returns when Miro SDK missing', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  await expect(registerWithCurrentUser()).resolves.toBeUndefined();
+  expect(warn).toHaveBeenCalledWith(
+    'Miro SDK not loaded; are you opening index.html outside Miro?',
+  );
+});


### PR DESCRIPTION
## Summary
- warn and return when Miro SDK not loaded
- log before throwing when board API missing
- test warnings for missing Miro SDK

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `npm --prefix web/client run test --silent` *(fails: Failed to resolve import ../../../templates/connectorTemplates.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a087a13e74832b836a1605457a4556