### PR TITLE
feat: add sync status bar

### DIFF
--- a/web/client/package-lock.json
+++ b/web/client/package-lock.json
@@ -19,7 +19,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.8",
-        "safe-regex": "^2.1.1"
+        "safe-regex": "^2.1.1",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -25885,6 +25886,34 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -44,7 +44,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.8",
-    "safe-regex": "^2.1.1"
+    "safe-regex": "^2.1.1",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/web/client/src/components/SyncStatusBar.tsx
+++ b/web/client/src/components/SyncStatusBar.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect } from 'react';
+import { useSyncStore } from '../core/state/sync-store';
+
+const POLL_INTERVAL_MS = 5000;
+const NEAR_LIMIT_THRESHOLD = 10;
+
+/**
+ * Displays global synchronisation and rate limit status.
+ */
+export function SyncStatusBar(): JSX.Element {
+  const {
+    queue,
+    activeJobs,
+    state,
+    setState,
+    setRemainingCredits,
+    backoffSeconds,
+    setBackoffSeconds,
+  } = useSyncStore();
+
+  useEffect(() => {
+    let cancelled = false;
+    const applyLimits = (data: {
+      remaining: number;
+      retryAfter?: number;
+    }): void => {
+      setRemainingCredits(data.remaining);
+      setBackoffSeconds(data.retryAfter ?? null);
+      if (data.retryAfter && data.retryAfter > 0) {
+        setState('rateLimited');
+        return;
+      }
+      if (data.remaining <= NEAR_LIMIT_THRESHOLD) {
+        setState('nearLimit');
+        return;
+      }
+      setState('ok');
+    };
+
+    const poll = async (): Promise<void> => {
+      try {
+        const res = await fetch('/limits');
+        if (!res.ok) {
+          throw new Error('status ' + res.status);
+        }
+        const data = (await res.json()) as {
+          remaining: number;
+          retryAfter?: number;
+        };
+        if (!cancelled) {
+          applyLimits(data);
+        }
+      } catch {
+        if (!cancelled) {
+          setState('disconnected');
+          setBackoffSeconds(null);
+        }
+      }
+    };
+    poll();
+    const id = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [setBackoffSeconds, setRemainingCredits, setState]);
+
+  const remaining = queue + activeJobs;
+  let content: JSX.Element | string;
+
+  if (state === 'disconnected') {
+    content = 'Disconnected';
+  } else if (state === 'rateLimited') {
+    content = `Pausing for ${backoffSeconds ?? 0}s (auto-resume)`;
+  } else if (state === 'nearLimit') {
+    content = 'Slowing to avoid limits';
+  } else if (remaining > 0) {
+    content = (
+      <span>
+        <span
+          role='img'
+          aria-label='loading'>
+          ⏳
+        </span>{' '}
+        {remaining} items remaining
+      </span>
+    );
+  } else {
+    content = 'All changes saved';
+  }
+
+  return (
+    <div
+      className='sync-status-bar'
+      role='status'>
+      {content}
+    </div>
+  );
+}

--- a/web/client/src/core/state/sync-store.ts
+++ b/web/client/src/core/state/sync-store.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+
+/**
+ * State describing the current synchronisation and rate limit status.
+ */
+export type SyncState = 'ok' | 'nearLimit' | 'rateLimited' | 'disconnected';
+
+/**
+ * Store for tracking synchronisation progress and API limits.
+ */
+export interface SyncStore {
+  /** Number of queued sync operations. */
+  queue: number;
+  /** Number of active sync jobs. */
+  activeJobs: number;
+  /** Remaining API credits; null when unknown. */
+  remainingCredits: number | null;
+  /** Current state of synchronisation and rate limiting. */
+  state: SyncState;
+  /** Seconds to wait before retrying when rate limited. */
+  backoffSeconds: number | null;
+  /** Update the queue length. */
+  setQueue: (queue: number) => void;
+  /** Update the number of active jobs. */
+  setActiveJobs: (jobs: number) => void;
+  /** Update remaining API credits. */
+  setRemainingCredits: (credits: number | null) => void;
+  /** Update the synchronisation state. */
+  setState: (state: SyncState) => void;
+  /** Update the rate limit backoff timer. */
+  setBackoffSeconds: (seconds: number | null) => void;
+}
+
+/**
+ * Hook exposing the global synchronisation store.
+ */
+export const useSyncStore = create<SyncStore>(set => ({
+  queue: 0,
+  activeJobs: 0,
+  remainingCredits: null,
+  state: 'ok',
+  backoffSeconds: null,
+  setQueue: queue => set({ queue }),
+  setActiveJobs: activeJobs => set({ activeJobs }),
+  setRemainingCredits: remainingCredits => set({ remainingCredits }),
+  setState: state => set({ state }),
+  setBackoffSeconds: backoffSeconds => set({ backoffSeconds }),
+}));

--- a/web/client/tests/sync-status-bar.test.tsx
+++ b/web/client/tests/sync-status-bar.test.tsx
@@ -1,0 +1,96 @@
+/** @vitest-environment jsdom */
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { vi } from 'vitest';
+import { SyncStatusBar } from '../src/components/SyncStatusBar';
+import { useSyncStore } from '../src/core/state/sync-store';
+
+describe('SyncStatusBar', () => {
+  beforeEach(() => {
+    useSyncStore.setState({
+      queue: 0,
+      activeJobs: 0,
+      remainingCredits: null,
+      state: 'ok',
+      backoffSeconds: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('shows idle when queue empty', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ remaining: 100 }),
+      } as Response);
+    render(<SyncStatusBar />);
+    expect(await screen.findByText('All changes saved')).toBeInTheDocument();
+  });
+
+  test('shows syncing with remaining items', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ remaining: 100 }),
+      } as Response);
+    useSyncStore.getState().setQueue(2);
+    render(<SyncStatusBar />);
+    expect(await screen.findByText('2 items remaining')).toBeInTheDocument();
+  });
+
+  test('shows near limit warning', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ remaining: 1 }),
+      } as Response);
+    render(<SyncStatusBar />);
+    expect(
+      await screen.findByText('Slowing to avoid limits'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows rate limited message', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ remaining: 0, retryAfter: 12 }),
+      } as Response);
+    render(<SyncStatusBar />);
+    expect(
+      await screen.findByText('Pausing for 12s (auto-resume)'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows disconnected on fetch error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    render(<SyncStatusBar />);
+    expect(await screen.findByText('Disconnected')).toBeInTheDocument();
+  });
+
+  test('returns to idle when queue clears', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ remaining: 100 }),
+      } as Response);
+    render(<SyncStatusBar />);
+    await act(async () => {
+      useSyncStore.getState().setQueue(1);
+    });
+    expect(await screen.findByText('1 items remaining')).toBeInTheDocument();
+    await act(async () => {
+      useSyncStore.getState().setQueue(0);
+    });
+    expect(await screen.findByText('All changes saved')).toBeInTheDocument();
+  });
+});

--- a/web/client/vitest.config.ts
+++ b/web/client/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['tests/setupTests.ts'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- add zustand store for tracking sync queue and rate limits
- show global SyncStatusBar that polls /limits for near-limit or rate-limit states
- configure vitest setup file and tests for sync status bar states

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: SyncStatusBar tests timeout; HttpLogSink tests fail)*
- `npx vitest run tests/sync-status-bar.test.tsx`
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a0881032e4832b871297bd0d7bfe65