### PR TITLE
feat(client): batch apply board changes

### DIFF
--- a/web/client/src/board/computeDiff.ts
+++ b/web/client/src/board/computeDiff.ts
@@ -1,0 +1,58 @@
+/**
+ * Diff calculation between two collections of items. Each item must have an
+ * optional `id` property used to determine identity.
+ */
+export interface DiffResult<T> {
+  /** Items that do not exist in the original set. */
+  readonly creates: T[];
+  /** Items present in both sets but with different content. */
+  readonly updates: T[];
+  /** Items from the original set missing in the modified set. */
+  readonly deletes: T[];
+}
+
+/**
+ * Compute additions, updates and deletions between two arrays.
+ *
+ * @param original - Baseline items.
+ * @param modified - New items to compare against the baseline.
+ * @returns A {@link DiffResult} categorising changes.
+ */
+export function computeDiff<T extends { id?: string }>(
+  original: readonly T[],
+  modified: readonly T[],
+): DiffResult<T> {
+  const originalMap = new Map(
+    original.map(item => [item.id ?? crypto.randomUUID(), item]),
+  );
+  const modifiedMap = new Map(
+    modified.map(item => [item.id ?? crypto.randomUUID(), item]),
+  );
+
+  const creates = modified.filter(item => {
+    if (!item.id) {
+      return true;
+    }
+    return !originalMap.has(item.id);
+  });
+
+  const deletes = original.filter(item => {
+    if (!item.id) {
+      return true;
+    }
+    return !modifiedMap.has(item.id);
+  });
+
+  const updates = modified.filter(item => {
+    if (!item.id) {
+      return false;
+    }
+    const orig = originalMap.get(item.id);
+    if (!orig) {
+      return false;
+    }
+    return JSON.stringify(orig) !== JSON.stringify(item);
+  });
+
+  return { creates, updates, deletes };
+}

--- a/web/client/src/core/utils/shape-client.ts
+++ b/web/client/src/core/utils/shape-client.ts
@@ -97,4 +97,29 @@ export class ShapeClient {
     }
     return (await res.json()) as Record<string, unknown>;
   }
+
+  /**
+   * Submit a batch of board operations.
+   *
+   * @param ops - Operations to apply.
+   * @param idempotencyKey - Unique key to enforce idempotent retries.
+   * @returns Server job information.
+   */
+  public async applyOperations(
+    ops: ReadonlyArray<unknown>,
+    idempotencyKey: string,
+  ): Promise<{ jobId: string }> {
+    if (typeof fetch !== 'function') {
+      return { jobId: '' };
+    }
+    const res = await apiFetch(`${this.baseUrl}/${this.boardId}/ops`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': idempotencyKey,
+      },
+      body: JSON.stringify(ops),
+    });
+    return (await res.json()) as { jobId: string };
+  }
 }

--- a/web/client/tests/computeDiff.test.ts
+++ b/web/client/tests/computeDiff.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { computeDiff } from '../src/board/computeDiff';
+
+test('computes creates updates deletes', () => {
+  const original = [
+    { id: '1', v: 1 },
+    { id: '2', v: 2 },
+  ];
+  const modified = [
+    { id: '2', v: 3 },
+    { id: '3', v: 4 },
+  ];
+  const diff = computeDiff(original, modified);
+  expect(diff.creates).toEqual([{ id: '3', v: 4 }]);
+  expect(diff.updates).toEqual([{ id: '2', v: 3 }]);
+  expect(diff.deletes).toEqual([{ id: '1', v: 1 }]);
+});

--- a/web/client/tests/diffdrawer.test.tsx
+++ b/web/client/tests/diffdrawer.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { DiffDrawer } from '../src/components/DiffDrawer';
+
+describe('DiffDrawer', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('disables apply when no changes', () => {
+    render(
+      <DiffDrawer
+        boardId='b1'
+        diff={{ creates: [], updates: [], deletes: [] }}
+        onClose={() => {}}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: /Apply 0 changes/ });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'No changes');
+  });
+
+  test('applies changes and returns job id', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({
+        json: () => Promise.resolve({ jobId: 'j1' }),
+      } as Response);
+    const onApplied = vi.fn();
+    render(
+      <DiffDrawer
+        boardId='b1'
+        diff={{ creates: [{ shape: 'r' }], updates: [], deletes: [] }}
+        onClose={() => {}}
+        onApplied={onApplied}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /Apply 1 changes/ }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onApplied).toHaveBeenCalledWith('j1');
+  });
+
+  test('Escape closes drawer', async () => {
+    const onClose = vi.fn();
+    render(
+      <DiffDrawer
+        boardId='b1'
+        diff={{ creates: [], updates: [], deletes: [{ id: '1' }] }}
+        onClose={onClose}
+      />,
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/client/tests/shape-client.test.ts
+++ b/web/client/tests/shape-client.test.ts
@@ -71,3 +71,16 @@ test('getShape fetches widget', async () => {
   expect(call[0]).toBe('/api/b4/shapes/s9');
   expect(result).toEqual({ id: 's9' });
 });
+
+test('applyOperations posts batch ops', async () => {
+  const api = new ShapeClient('b5', '/api');
+  (fetch as vi.Mock).mockResolvedValueOnce({
+    json: vi.fn().mockResolvedValue({ jobId: 'j1' }),
+  });
+  const res = await api.applyOperations([{ op: 'create' }], 'key');
+  expect((fetch as vi.Mock).mock.calls[0][0]).toBe('/api/b5/ops');
+  expect((fetch as vi.Mock).mock.calls[0][1].headers['Idempotency-Key']).toBe(
+    'key',
+  );
+  expect(res).toEqual({ jobId: 'j1' });
+});


### PR DESCRIPTION
## Summary
- compute diff between item sets
- add drawer to review and submit batched ops
- support /boards/:id/ops in shape client

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json" from "src/board/templates.ts". Does the file exist?)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a088307e70832bb1abd7016ce23eb1