### PR TITLE
feat: add job drawer and job polling hook

### DIFF
--- a/web/client/src/components/JobDrawer.tsx
+++ b/web/client/src/components/JobDrawer.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useJob } from '../core/hooks/useJob';
+
+interface JobDrawerProps {
+  /** Identifier of the job to display. */
+  jobId: string;
+  /** Whether the drawer is visible. */
+  isOpen: boolean;
+  /** Callback invoked when the drawer closes. */
+  onClose: () => void;
+}
+
+/**
+ * Drawer showing live progress for a batch job.
+ */
+export function JobDrawer({
+  jobId,
+  isOpen,
+  onClose,
+}: JobDrawerProps): JSX.Element | null {
+  const job = useJob(jobId);
+  const [closeOnDone, setCloseOnDone] = React.useState(true);
+  const [hiddenOps, setHiddenOps] = React.useState<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    if (!job) {
+      return;
+    }
+    const timers: NodeJS.Timeout[] = [];
+    job.operations.forEach(op => {
+      if (op.status === 'done' && !hiddenOps.has(op.id)) {
+        timers.push(
+          setTimeout(() => {
+            setHiddenOps(prev => new Set(prev).add(op.id));
+          }, 2000),
+        );
+      }
+    });
+    return () => timers.forEach(clearTimeout);
+  }, [job, hiddenOps]);
+
+  React.useEffect(() => {
+    if (!job) {
+      return;
+    }
+    const done = job.status === 'done';
+    const failed = job.status === 'failed' || job.status === 'partial';
+    if (failed) {
+      const first = job.operations.find(op => op.status === 'failed');
+      const el = first ? document.getElementById(`job-op-${first.id}`) : null;
+      el?.focus();
+    } else if (done && closeOnDone) {
+      onClose();
+    }
+  }, [job, closeOnDone, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div role='dialog'>
+      <label>
+        <input
+          type='checkbox'
+          checked={closeOnDone}
+          onChange={e => setCloseOnDone(e.target.checked)}
+        />
+        Close when done
+      </label>
+      <ul>
+        {job?.operations
+          .filter(op => !hiddenOps.has(op.id))
+          .map(op => (
+            <li
+              key={op.id}
+              id={`job-op-${op.id}`}
+              tabIndex={-1}>
+              <span>{op.id}</span>
+              <span>{op.status}</span>
+              {op.status === 'failed' && (
+                <>
+                  <button>Retry</button>
+                  <button>Details</button>
+                </>
+              )}
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/client/src/core/hooks/useJob.ts
+++ b/web/client/src/core/hooks/useJob.ts
@@ -1,0 +1,76 @@
+import React from 'react';
+import { apiFetch } from '../utils/api-fetch';
+
+export type JobOpStatus = 'pending' | 'working' | 'done' | 'failed';
+
+/**
+ * Operation within an asynchronous job.
+ */
+export interface JobOperation {
+  /** Identifier of the operation. */
+  id: string;
+  /** Current status. */
+  status: JobOpStatus;
+  /** Optional human readable message. */
+  message?: string;
+}
+
+export type JobStatus = JobOpStatus | 'partial';
+
+/**
+ * Job containing multiple operations that run asynchronously.
+ */
+export interface Job {
+  /** Server generated job identifier. */
+  id: string;
+  /** Overall status for the job. */
+  status: JobStatus;
+  /** Operations that compose the job. */
+  operations: JobOperation[];
+}
+
+const jobCache = new Map<string, Job>();
+
+/**
+ * Poll the backend for the status of a job.
+ *
+ * Results are cached per job id so duplicate requests return instantly.
+ *
+ * @param jobId - Identifier returned when creating the job.
+ * @returns The latest job information or `undefined` if not yet available.
+ */
+export function useJob(jobId: string): Job | undefined {
+  const [job, setJob] = React.useState<Job | undefined>(() =>
+    jobCache.get(jobId),
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function poll(): Promise<void> {
+      try {
+        const res = await apiFetch(`/jobs/${jobId}`);
+        const data = (await res.json()) as Job;
+        jobCache.set(jobId, data);
+        if (!cancelled) {
+          setJob(data);
+          if (data.status === 'pending' || data.status === 'working') {
+            setTimeout(poll, 1000);
+          }
+        }
+      } catch {
+        /* intentionally ignore network errors */
+      }
+    }
+
+    if (!job || job.status === 'pending' || job.status === 'working') {
+      poll();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId, job]);
+
+  return job;
+}

--- a/web/client/tests/job-drawer.test.tsx
+++ b/web/client/tests/job-drawer.test.tsx
@@ -1,0 +1,98 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { JobDrawer } from '../src/components/JobDrawer';
+import type { Job } from '../src/core/hooks/useJob';
+
+vi.useFakeTimers();
+let job: Job;
+vi.mock('../src/core/hooks/useJob', () => ({ useJob: () => job }));
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+test('hides successful operations after delay', async () => {
+  job = {
+    id: '1',
+    status: 'working',
+    operations: [{ id: 'a', status: 'done' }],
+  };
+  render(
+    <JobDrawer
+      jobId='1'
+      isOpen
+      onClose={() => {}}
+    />,
+  );
+  expect(screen.getByText('a')).toBeInTheDocument();
+  await vi.advanceTimersByTimeAsync(2000);
+  await Promise.resolve();
+  expect(screen.queryByText('a')).toBeNull();
+});
+
+test('failed operations persist with actions', async () => {
+  job = {
+    id: '2',
+    status: 'failed',
+    operations: [{ id: 'b', status: 'failed' }],
+  };
+  render(
+    <JobDrawer
+      jobId='2'
+      isOpen
+      onClose={() => {}}
+    />,
+  );
+  await vi.runAllTimersAsync();
+  expect(screen.getByText('b')).toBeInTheDocument();
+  expect(screen.getByText('Retry')).toBeInTheDocument();
+  expect(screen.getByText('Details')).toBeInTheDocument();
+});
+
+test('toggle defaults to enabled', () => {
+  job = { id: '5', status: 'working', operations: [] };
+  render(
+    <JobDrawer
+      jobId='5'
+      isOpen
+      onClose={() => {}}
+    />,
+  );
+  expect(screen.getByLabelText('Close when done')).toBeChecked();
+});
+
+test('auto closes when job completes', async () => {
+  job = { id: '3', status: 'done', operations: [] };
+  const onClose = vi.fn();
+  render(
+    <JobDrawer
+      jobId='3'
+      isOpen
+      onClose={onClose}
+    />,
+  );
+  await Promise.resolve();
+  expect(onClose).toHaveBeenCalled();
+});
+
+test('focuses first failed operation on failure', async () => {
+  job = {
+    id: '4',
+    status: 'failed',
+    operations: [
+      { id: 'x', status: 'failed' },
+      { id: 'y', status: 'done' },
+    ],
+  };
+  render(
+    <JobDrawer
+      jobId='4'
+      isOpen
+      onClose={() => {}}
+    />,
+  );
+  const item = screen.getByText('x').closest('li');
+  expect(item).toHaveFocus();
+});

--- a/web/client/tests/useJob.test.ts
+++ b/web/client/tests/useJob.test.ts
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { useJob } from '../src/core/hooks/useJob';
+import * as api from '../src/core/utils/api-fetch';
+
+vi.useFakeTimers();
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('polls until job completes', async () => {
+  const spy = vi
+    .spyOn(api, 'apiFetch')
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id: '1', status: 'working', operations: [] }),
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: '1', status: 'done', operations: [] })),
+    );
+  const { result } = renderHook(() => useJob('1'));
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(1000);
+  await Promise.resolve();
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(result.current?.status).toBe('done');
+});
+
+test('returns cached result for duplicate job id', async () => {
+  const spy = vi
+    .spyOn(api, 'apiFetch')
+    .mockResolvedValue(
+      new Response(JSON.stringify({ id: '1', status: 'done', operations: [] })),
+    );
+  const { result, unmount } = renderHook(() => useJob('1'));
+  await Promise.resolve();
+  await vi.runAllTimersAsync();
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(result.current?.status).toBe('done');
+  unmount();
+  const { result: second } = renderHook(() => useJob('1'));
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(second.current?.status).toBe('done');
+});


### PR DESCRIPTION
## Summary
- add `useJob` hook to poll job status and cache results
- display job progress with `JobDrawer` component
- cover behaviour with unit tests

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: Failed to resolve import `../../../templates/connectorTemplates.json` from `src/board/templates.ts`)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a0883bd29c832ba0e92e0dc14256df