### PR TITLE
feat(core): add optimistic ops hook

### DIFF
--- a/web/client/src/core/hooks/useOptimisticOps.ts
+++ b/web/client/src/core/hooks/useOptimisticOps.ts
@@ -1,0 +1,51 @@
+import React from 'react';
+
+/**
+ * Definition of an optimistic operation applied to the board.
+ *
+ * The {@link apply} callback should immediately update local state while
+ * {@link commit} persists the change remotely. If the commit fails, the
+ * {@link rollback} function restores the previous state.
+ */
+export interface OptimisticOp {
+  /** Apply the change locally. */
+  apply: () => void;
+  /** Persist the change to the server or board. */
+  commit: () => Promise<void>;
+  /** Revert the local change if committing fails. */
+  rollback: () => void | Promise<void>;
+}
+
+const wait = (ms: number): Promise<void> =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * React hook executing operations optimistically with automatic rollback on
+ * failure. When an operation fails a toast is shown offering the user a chance
+ * to retry the single failed action.
+ *
+ * @returns Function that enqueues an optimistic operation.
+ */
+export function useOptimisticOps(): (op: OptimisticOp) => Promise<void> {
+  const enqueue = React.useCallback(async (op: OptimisticOp): Promise<void> => {
+    op.apply();
+    try {
+      await op.commit();
+    } catch {
+      await wait(150);
+      await op.rollback();
+      await miro.board.notifications.showError('Operation failed', {
+        action: {
+          label: 'Try again',
+          callback: () => {
+            void enqueue(op);
+          },
+        },
+      });
+    }
+  }, []);
+
+  return enqueue;
+}

--- a/web/client/src/ui/hooks/use-excel-sync.ts
+++ b/web/client/src/ui/hooks/use-excel-sync.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ExcelSyncService } from '../../core/excel-sync-service';
+import { useOptimisticOps } from '../../core/hooks/useOptimisticOps';
 import type { ExcelRow } from '../../core/utils/excel-loader';
 import { useExcelData } from './excel-data-context';
 
@@ -12,18 +13,31 @@ export function useExcelSync(): (
 ) => Promise<void> {
   const ctx = useExcelData();
   const serviceRef = React.useRef<ExcelSyncService>(new ExcelSyncService());
+  const enqueue = useOptimisticOps();
+
   return React.useCallback(
     async (index: number, updated: ExcelRow): Promise<void> => {
       if (!ctx) {
         return;
       }
-      ctx.setRows(prev => prev.map((r, i) => (i === index ? updated : r)));
-      await serviceRef.current.updateShapesFromExcel([updated], {
-        idColumn: ctx.idColumn,
-        labelColumn: ctx.labelColumn,
-        templateColumn: ctx.templateColumn,
+      const prev = ctx.rows[index];
+      await enqueue({
+        apply: () =>
+          ctx.setRows(prevRows =>
+            prevRows.map((r, i) => (i === index ? updated : r)),
+          ),
+        rollback: () =>
+          ctx.setRows(prevRows =>
+            prevRows.map((r, i) => (i === index ? prev : r)),
+          ),
+        commit: () =>
+          serviceRef.current.updateShapesFromExcel([updated], {
+            idColumn: ctx.idColumn,
+            labelColumn: ctx.labelColumn,
+            templateColumn: ctx.templateColumn,
+          }),
       });
     },
-    [ctx],
+    [ctx, enqueue],
   );
 }

--- a/web/client/tests/use-excel-sync.test.tsx
+++ b/web/client/tests/use-excel-sync.test.tsx
@@ -27,11 +27,16 @@ function wrapper({ children }: { children: React.ReactNode }) {
 }
 
 describe('useExcelSync', () => {
-  beforeEach(() =>
+  beforeEach(() => {
     (ExcelSyncService as unknown as vi.Mock).mockImplementation(() => ({
       updateShapesFromExcel: vi.fn().mockResolvedValue(undefined),
-    })),
-  );
+    }));
+    (
+      globalThis as unknown as {
+        miro: { board: { notifications: { showError: vi.Mock } } };
+      }
+    ).miro = { board: { notifications: { showError: vi.fn() } } };
+  });
 
   test('updates rows and widgets', async () => {
     const { result } = renderHook(() => useExcelSync(), { wrapper });

--- a/web/client/tests/use-optimistic-ops.test.ts
+++ b/web/client/tests/use-optimistic-ops.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react';
+import { useOptimisticOps } from '../src/core/hooks/useOptimisticOps';
+
+vi.useFakeTimers();
+
+describe('useOptimisticOps', () => {
+  test('rolls back on failure and retries', async () => {
+    const showError = vi.fn();
+    (
+      globalThis as unknown as {
+        miro: { board: { notifications: { showError: vi.Mock } } };
+      }
+    ).miro = { board: { notifications: { showError } } };
+
+    const { result } = renderHook(() => useOptimisticOps());
+    const apply = vi.fn();
+    const rollback = vi.fn();
+    const commit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(undefined);
+
+    await act(async () => {
+      const promise = result.current({ apply, rollback, commit });
+      await vi.advanceTimersByTimeAsync(150);
+      await promise;
+    });
+
+    expect(apply).toHaveBeenCalled();
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(rollback).toHaveBeenCalled();
+    expect(showError).toHaveBeenCalled();
+    const retry = showError.mock.calls[0][1].action.callback as () => void;
+    await act(async () => retry());
+    expect(commit).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not rollback on success', async () => {
+    const showError = vi.fn();
+    (
+      globalThis as unknown as {
+        miro: { board: { notifications: { showError: vi.Mock } } };
+      }
+    ).miro = { board: { notifications: { showError } } };
+
+    const { result } = renderHook(() => useOptimisticOps());
+    const rollback = vi.fn();
+    const commit = vi.fn().mockResolvedValue(undefined);
+    await act(async () => {
+      await result.current({ apply: vi.fn(), rollback, commit });
+    });
+    await vi.advanceTimersByTimeAsync(200);
+    expect(rollback).not.toHaveBeenCalled();
+    expect(showError).not.toHaveBeenCalled();
+  });
+});

--- a/web/client/vitest.config.ts
+++ b/web/client/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['tests/setupTests.ts'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- add `useOptimisticOps` hook for optimistic board operations with rollback and retry toast
- use the hook in Excel sync to revert failed row updates without losing successes
- load shared test setup in Vitest and cover optimistic rollback logic

## Testing
- `npm --prefix web/client run typecheck`
- `npm --prefix web/client run lint`
- `npm --prefix web/client run stylelint`
- `npm --prefix web/client run prettier`
- `npm --prefix web/client run test` *(fails: createShape sends single payload; createShapes posts all shapes in one request; updateShape sends PUT request; deleteShape sends DELETE request; getShape fetches widget; HttpLogSink posts log entries to backend; HttpLogSink warns on non-2xx responses; HttpLogSink logs network failures; registerCurrentUser posts auth details; registerCurrentUser retries on failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a088476784832b9d3f5bf776abccdf