### PR TITLE
feat(web): add auth banner and session repair

### DIFF
--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -2,6 +2,7 @@ import { createTheme, Tabs, themes } from '@mirohq/design-system';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import type { ExcelRow } from '../core/utils/excel-loader';
+import { AuthBanner } from '../components/AuthBanner';
 import { EditMetadataModal, IntroScreen } from '../ui/components';
 import { Paragraph } from '../ui/components/Paragraph';
 import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
@@ -57,6 +58,7 @@ function AppShell(): React.JSX.Element {
           setLabelColumn,
           setTemplateColumn,
         }}>
+        <AuthBanner />
         <Tabs
           value={tab}
           onChange={id => setTab(id as Tab)}

--- a/web/client/src/components/AuthBanner.tsx
+++ b/web/client/src/components/AuthBanner.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { useAuthStatus } from '../core/hooks/useAuthStatus';
+
+/**
+ * Display an authorisation banner with a sign-in button when the user
+ * session is missing or expired.
+ *
+ * The banner becomes hidden automatically once the backend reports a
+ * valid session.
+ */
+export const AuthBanner: React.FC = () => {
+  const { status, signIn } = useAuthStatus();
+  if (status === 'ok') {
+    return null;
+  }
+  const message =
+    status === 'unauthorized' ? 'Sign in to Miro' : 'Session expired';
+  return (
+    <div role='alert'>
+      <span>{message}</span>
+      <button onClick={signIn}>Sign in to Miro</button>
+    </div>
+  );
+};
+
+export default AuthBanner;

--- a/web/client/src/core/hooks/useAuthStatus.ts
+++ b/web/client/src/core/hooks/useAuthStatus.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { apiFetch } from '../utils/api-fetch';
+
+export type AuthState = 'ok' | 'unauthorized' | 'expired';
+
+export interface AuthStatus {
+  status: AuthState;
+  /**
+   * Execute a job and capture 401 responses to trigger re-authentication.
+   */
+  runWithAuth<T>(job: () => Promise<T>): Promise<T | undefined>;
+  /**
+   * Redirect the user to begin the OAuth login flow.
+   */
+  signIn(): void;
+  /**
+   * Query the backend for the current authorisation status.
+   */
+  check(): Promise<void>;
+}
+
+/**
+ * Hook that tracks the user's authentication status and resumes pending jobs
+ * once the session is repaired.
+ */
+export function useAuthStatus(): AuthStatus {
+  const [status, setStatus] = useState<AuthState>('ok');
+  const pending = useRef<(() => Promise<unknown>) | null>(null);
+
+  const check = useCallback(async () => {
+    const res = await apiFetch('/api/auth/status');
+    setStatus(res.ok ? 'ok' : 'unauthorized');
+  }, []);
+
+  useEffect(() => {
+    void check();
+  }, [check]);
+
+  useEffect(() => {
+    if (status === 'ok' && pending.current) {
+      void pending.current();
+      pending.current = null;
+    }
+  }, [status]);
+
+  const runWithAuth = useCallback(
+    async <T,>(job: () => Promise<T>): Promise<T | undefined> => {
+      try {
+        const result = await job();
+        // if job resolves to a Response, check status
+        if (
+          typeof (result as unknown as { status?: number }).status ===
+            'number' &&
+          (result as unknown as { status?: number }).status === 401
+        ) {
+          setStatus('expired');
+          pending.current = job;
+          return undefined;
+        }
+        return result;
+      } catch (err) {
+        if ((err as { status?: number }).status === 401) {
+          setStatus('expired');
+          pending.current = job;
+          return undefined;
+        }
+        throw err;
+      }
+    },
+    [],
+  );
+
+  const signIn = useCallback(() => {
+    window.location.href = '/oauth/login';
+  }, []);
+
+  return { status, runWithAuth, signIn, check };
+}

--- a/web/client/src/index.ts
+++ b/web/client/src/index.ts
@@ -1,16 +1,10 @@
 import { DiagramApp } from './app/diagram-app';
-import { apiFetch } from './core/utils/api-fetch';
 import * as log from './logger';
 import { registerWithCurrentUser } from './user-auth';
 
 async function start(): Promise<void> {
   log.info('Starting application');
   await registerWithCurrentUser();
-  const status = await apiFetch('/api/auth/status');
-  if (status.status === 404) {
-    const user = await miro.board.getUserInfo();
-    await miro.board.ui.openPanel({ url: `/oauth/login?userId=${user.id}` });
-  }
   await DiagramApp.getInstance().init();
 }
 

--- a/web/client/tests/auth-banner.test.tsx
+++ b/web/client/tests/auth-banner.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { expect, test, vi } from 'vitest';
+
+import { AuthBanner } from '../src/components/AuthBanner';
+import { useAuthStatus } from '../src/core/hooks/useAuthStatus';
+
+vi.mock('../src/core/hooks/useAuthStatus');
+
+test('renders sign in button when unauthorised', () => {
+  const signIn = vi.fn();
+  (useAuthStatus as unknown as vi.Mock).mockReturnValue({
+    status: 'unauthorized',
+    signIn,
+  });
+
+  render(<AuthBanner />);
+  const button = screen.getByRole('button', { name: 'Sign in to Miro' });
+  fireEvent.click(button);
+  expect(signIn).toHaveBeenCalled();
+});

--- a/web/client/tests/index-login-redirect.test.ts
+++ b/web/client/tests/index-login-redirect.test.ts
@@ -12,7 +12,7 @@ vi.mock('../src/app/diagram-app', () => ({
   },
 }));
 
-test('opens login panel when not authorised', async () => {
+test('does not open login panel when not authorised', async () => {
   const openPanel = vi.fn();
   vi.stubGlobal('miro', {
     board: {
@@ -23,5 +23,5 @@ test('opens login panel when not authorised', async () => {
 
   await import('../src/index');
 
-  expect(openPanel).toHaveBeenCalledWith({ url: '/oauth/login?userId=7' });
+  expect(openPanel).not.toHaveBeenCalled();
 });

--- a/web/client/tests/use-auth-status.test.ts
+++ b/web/client/tests/use-auth-status.test.ts
@@ -1,0 +1,28 @@
+import { renderHook, act } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+
+import { useAuthStatus } from '../src/core/hooks/useAuthStatus';
+import { apiFetch } from '../src/core/utils/api-fetch';
+
+vi.mock('../src/core/utils/api-fetch');
+
+test('resumes pending job after reauth', async () => {
+  (apiFetch as unknown as vi.Mock).mockResolvedValue({ ok: true });
+  const job = vi
+    .fn()
+    .mockResolvedValueOnce({ status: 401 })
+    .mockResolvedValueOnce('done');
+
+  const { result } = renderHook(() => useAuthStatus());
+  await act(async () => {
+    await result.current.runWithAuth(job);
+  });
+  expect(result.current.status).toBe('expired');
+  expect(job).toHaveBeenCalledTimes(1);
+
+  await act(async () => {
+    await result.current.check();
+  });
+  expect(job).toHaveBeenCalledTimes(2);
+  expect(result.current.status).toBe('ok');
+});


### PR DESCRIPTION
## Summary
- add session-aware AuthBanner with login trigger
- resume pending jobs via `useAuthStatus`
- integrate banner into app shell and remove auto login panel

## Testing
- `npm --prefix web/client run typecheck`
- `npm --prefix web/client run lint`
- `npm --prefix web/client run stylelint`
- `npm --prefix web/client run prettier`
- `npm --prefix web/client run test` *(fails: excessive suite duration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a088525e78832b847123b4d708aadf