### PR TITLE
feat(web): add board loader with cache and refresh

### DIFF
--- a/web/client/src/components/BoardLoader.tsx
+++ b/web/client/src/components/BoardLoader.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ShapeClient, type ShapeSnapshot } from '../core/utils/shape-client';
+
+const SKELETON_MS = 350;
+
+interface BoardLoaderProps {
+  /** Identifier of the board to load. */
+  boardId: string;
+}
+
+/**
+ * Load cached shapes for a board with a brief skeleton placeholder.
+ *
+ * Shapes are retrieved from the server cache so the vendor is never
+ * contacted unless the user explicitly refreshes. A skeleton of grey
+ * boxes is shown for a short period before rendering the cached snapshot.
+ */
+export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
+  const [snapshot, setSnapshot] = useState<ShapeSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const client = useMemo(() => new ShapeClient(boardId), [boardId]);
+
+  const load = useCallback(
+    async (refresh = false) => {
+      const snap = await client.getShapes(snapshot?.version, refresh);
+      setSnapshot(snap);
+    },
+    [client, snapshot?.version],
+  );
+
+  const hydrate = useCallback(
+    async (refresh = false) => {
+      setLoading(true);
+      await load(refresh);
+      setTimeout(() => setLoading(false), SKELETON_MS);
+    },
+    [load],
+  );
+
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
+
+  if (loading) {
+    return (
+      <div data-testid='skeleton'>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            style={{ width: 80, height: 40, background: '#eee', margin: 4 }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const shapes = snapshot?.shapes ?? [];
+
+  return (
+    <div>
+      <button
+        type='button'
+        onClick={() => void hydrate(true)}>
+        Refresh board
+      </button>
+      {shapes.length === 0 ? (
+        <div>No items yet. Create shapes or import.</div>
+      ) : (
+        <ul>
+          {shapes.map((s, i) => (
+            <li key={(s as { id?: string }).id ?? String(i)}>
+              {(s as { text?: string }).text ??
+                (s as { id?: string }).id ??
+                'shape'}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/client/tests/board-loader.test.tsx
+++ b/web/client/tests/board-loader.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { BoardLoader } from '../src/components/BoardLoader';
+
+vi.mock('logfire', () => ({ span: (_n: string, fn: () => unknown) => fn() }));
+
+vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
+
+beforeEach(() => {
+  (fetch as vi.Mock).mockReset();
+});
+
+test('shows empty state when cache is empty', async () => {
+  vi.useFakeTimers();
+  (fetch as vi.Mock).mockImplementation(async () => ({
+    json: async () => ({ version: 1, shapes: [] }),
+  }));
+  render(<BoardLoader boardId='b1' />);
+  await act(async () => {
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+  });
+  await screen.findByText(/No items yet/);
+  expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+});
+
+test('refresh board reloads snapshot', async () => {
+  vi.useFakeTimers();
+  (fetch as vi.Mock)
+    .mockImplementationOnce(async () => ({
+      json: async () => ({ version: 1, shapes: [{ id: 's1', text: 'A' }] }),
+    }))
+    .mockImplementationOnce(async () => ({
+      json: async () => ({ version: 2, shapes: [{ id: 's2', text: 'B' }] }),
+    }));
+  render(<BoardLoader boardId='b2' />);
+  await act(async () => {
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+  });
+  await screen.findByText('A');
+  const btn = screen.getByRole('button', { name: /refresh board/i });
+  fireEvent.click(btn);
+  await act(async () => {
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+  });
+  await screen.findByText('B');
+  expect((fetch as vi.Mock).mock.calls[1][0]).toContain('refresh=true');
+});


### PR DESCRIPTION
## Summary
- add BoardLoader component to render cached board data with skeleton placeholders and manual refresh
- extend ShapeClient with getShapes and ShapeSnapshot
- add unit tests for board loader and shape client

## Testing
- `npm install`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `npm run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json" in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0885f5868832b9c9e2fee22b6bc74