### PR TITLE
feat: persist shapes to database

### DIFF
--- a/src/miro_backend/models/__init__.py
+++ b/src/miro_backend/models/__init__.py
@@ -3,6 +3,7 @@
 from .board import Board
 from .cache import CacheEntry
 from .log_entry import LogEntry
+from .shape import Shape
 from .tag import Tag
 from .user import User
 from .idempotency import Idempotency
@@ -14,6 +15,7 @@ __all__ = [
     "Idempotency",
     "Job",
     "LogEntry",
+    "Shape",
     "Tag",
     "User",
 ]

--- a/src/miro_backend/models/board.py
+++ b/src/miro_backend/models/board.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..db.session import Base
 
 if TYPE_CHECKING:
+    from .shape import Shape
     from .tag import Tag
 
 
@@ -19,8 +20,17 @@ class Board(Base):
     __tablename__ = "boards"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String, unique=True, index=True)
+    name: Mapped[str | None] = mapped_column(
+        String, unique=True, index=True, nullable=True
+    )
+    board_id: Mapped[str | None] = mapped_column(
+        String, unique=True, index=True, nullable=True
+    )
+    owner_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
     tags: Mapped[list["Tag"]] = relationship(
         "Tag", back_populates="board", cascade="all, delete-orphan"
+    )
+    shapes: Mapped[list["Shape"]] = relationship(
+        "Shape", back_populates="board", cascade="all, delete-orphan"
     )

--- a/src/miro_backend/models/shape.py
+++ b/src/miro_backend/models/shape.py
@@ -1,0 +1,31 @@
+"""Database model for shapes."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import DateTime, ForeignKey, String, JSON, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..db.session import Base
+
+if TYPE_CHECKING:
+    from .board import Board
+
+
+class Shape(Base):
+    """Represents a shape stored on a board."""
+
+    __tablename__ = "shapes"
+
+    board_id: Mapped[str] = mapped_column(
+        String, ForeignKey("boards.board_id", ondelete="CASCADE"), primary_key=True
+    )
+    shape_id: Mapped[str] = mapped_column(String, primary_key=True)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    board: Mapped["Board"] = relationship("Board", back_populates="shapes")

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -6,7 +6,7 @@ import importlib
 
 from fastapi.testclient import TestClient
 
-from miro_backend.db.session import Base, engine
+from miro_backend.db.session import Base, SessionLocal, engine
 from miro_backend.queue import ChangeQueue
 from miro_backend.services.shape_store import get_shape_store
 
@@ -38,8 +38,10 @@ def test_not_found_error_returns_typed_response() -> None:
 def test_forbidden_error_returns_typed_response() -> None:
     """Unauthorized access should return structured 403 responses."""
 
-    store = get_shape_store()
+    session = SessionLocal()
+    store = get_shape_store(session)
     store.add_board("board1", "owner1")
+    session.close()
     app_module = importlib.import_module("miro_backend.main")
     app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
     with TestClient(app_module.app) as client:


### PR DESCRIPTION
## Summary
- store boards and shapes in database
- add database-backed shape store and provider
- verify shape persistence across process restart

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/models/board.py src/miro_backend/models/shape.py src/miro_backend/models/__init__.py src/miro_backend/services/shape_store.py tests/integration/test_shapes.py tests/test_error_handlers.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a12978679c832b93f22d9c5ba8aca6