### PR TITLE
feat: add daily idempotency cleanup task

### DIFF
--- a/src/miro_backend/services/idempotency.py
+++ b/src/miro_backend/services/idempotency.py
@@ -1,0 +1,54 @@
+"""Idempotency utilities."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import logfire
+from sqlalchemy import delete
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session, sessionmaker
+
+from ..db.session import SessionLocal
+from ..models import Idempotency
+
+
+def purge_expired_idempotency(
+    session_factory: sessionmaker[Session] = SessionLocal,
+    ttl: timedelta = timedelta(hours=48),
+) -> int:
+    """Delete idempotency rows older than ``ttl``.
+
+    Args:
+        session_factory: Factory for database sessions.
+        ttl: Maximum age for idempotency records.
+
+    Returns:
+        Number of rows removed.
+    """
+
+    cutoff = datetime.now(tz=UTC) - ttl
+    with session_factory() as session:
+        try:
+            result = session.execute(
+                delete(Idempotency).where(Idempotency.created_at < cutoff)
+            )
+            session.commit()
+        except OperationalError:
+            return 0
+        return result.rowcount or 0
+
+
+async def cleanup_idempotency() -> None:
+    """Periodically purge expired idempotency rows."""
+
+    try:
+        while True:
+            deleted = await asyncio.to_thread(purge_expired_idempotency)
+            if deleted:
+                logfire.info("removed stale idempotency rows", extra={"count": deleted})
+            await asyncio.sleep(60 * 60 * 24)
+    except asyncio.CancelledError:
+        logfire.info("idempotency cleanup stopped")
+        raise

--- a/tests/test_idempotency_cleanup.py
+++ b/tests/test_idempotency_cleanup.py
@@ -1,0 +1,37 @@
+"""Verify expired idempotency records are purged."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from miro_backend.db.session import Base
+from miro_backend.models import Idempotency
+from miro_backend.services.idempotency import purge_expired_idempotency
+
+
+def test_purge_expired_idempotency(tmp_path: Path) -> None:
+    """Rows older than the TTL should be deleted."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'idem.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    old_time = datetime.now(tz=UTC) - timedelta(days=3)
+    fresh_time = datetime.now(tz=UTC)
+    with Session() as session:
+        session.add(Idempotency(key="old", response={}, created_at=old_time))
+        session.add(Idempotency(key="new", response={}, created_at=fresh_time))
+        session.commit()
+
+    deleted = purge_expired_idempotency(Session, ttl=timedelta(days=2))
+    assert deleted == 1
+
+    with Session() as session:
+        remaining = {row.key for row in session.query(Idempotency).all()}
+    assert remaining == {"new"}


### PR DESCRIPTION
## Summary
- schedule background job to purge stale idempotency records
- implement purging logic with test coverage

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/idempotency.py src/miro_backend/main.py tests/test_idempotency_cleanup.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a134665c00832b8c6bd6faf22a1bff