### PR TITLE
feat(openapi): add server metadata and examples

### DIFF
--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
         alias="MIRO_CORS_ORIGINS",
         description="List of allowed CORS origins.",
     )
+    api_url: str = Field(
+        default="",
+        alias="MIRO_API_URL",
+        description="Server URL advertised in the OpenAPI document.",
+    )
     client_id: str = Field(
         alias="MIRO_CLIENT_ID",
         description="OAuth client identifier issued by Miro.",

--- a/tests/test_open_api_configuration.py
+++ b/tests/test_open_api_configuration.py
@@ -10,7 +10,7 @@ from miro_backend.queue import ChangeQueue
 
 
 def test_openapi_document_includes_health_path() -> None:
-    """The generated OpenAPI document should expose the health endpoint."""
+    """The generated OpenAPI document should expose examples and metadata."""
 
     app_module = importlib.import_module("miro_backend.main")
     app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
@@ -19,3 +19,9 @@ def test_openapi_document_includes_health_path() -> None:
         assert response.status_code == 200
         data = response.json()
         assert "/health" in data["paths"]
+        assert data["servers"] == [{"url": ""}]
+        tags = {tag["name"]: tag for tag in data["tags"]}
+        assert "batch" in tags
+        assert "Idempotency-Key" in tags["batch"]["description"]
+        assert "jobs" in tags
+        assert "/api/jobs" in tags["jobs"]["description"]


### PR DESCRIPTION
## Summary
- configure OpenAPI with explicit server URL and descriptive tags
- document batch idempotency and job queries with inline examples
- expose API URL via new `MIRO_API_URL` setting

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/core/config.py src/miro_backend/main.py tests/test_open_api_configuration.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a13a2ad680832b80f9da29c8da08c0