### PR TITLE
fix(client): add idempotency keys to batch writes

### DIFF
--- a/web/client/src/core/utils/card-client.ts
+++ b/web/client/src/core/utils/card-client.ts
@@ -18,9 +18,10 @@ export class CardClient {
     if (typeof fetch !== 'function') {
       return;
     }
+    const key = crypto.randomUUID?.() ?? String(Date.now()) + Math.random();
     await apiFetch(this.url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': key },
       body: JSON.stringify(cards),
     });
   }

--- a/web/client/src/core/utils/shape-client.ts
+++ b/web/client/src/core/utils/shape-client.ts
@@ -55,9 +55,10 @@ export class ShapeClient {
     if (typeof fetch !== 'function') {
       return [];
     }
+    const key = crypto.randomUUID?.() ?? String(Date.now()) + Math.random();
     const res = await apiFetch(this.url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': key },
       body: JSON.stringify(shapes),
     });
     const data = (await res.json()) as Array<{ body: string }>;

--- a/web/client/tests/card-client.test.ts
+++ b/web/client/tests/card-client.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 import { CardClient } from '../src/core/utils/card-client';
 import type { CardData } from '../src/core/utils/cards';
+vi.mock('logfire', () => ({
+  span: (_: string, fn: () => unknown) => fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
 
 vi.stubGlobal('fetch', vi.fn());
 vi.stubGlobal('miro', {
@@ -13,14 +18,18 @@ test('createCard posts single card', async () => {
   const api = new CardClient('/api');
   const card: CardData = { title: 't' };
   await api.createCard(card);
+  const call = (fetch as vi.Mock).mock.calls[0];
   expect((fetch as vi.Mock).mock.calls).toHaveLength(1);
-  expect(JSON.parse((fetch as vi.Mock).mock.calls[0][1].body)).toHaveLength(1);
+  expect(JSON.parse(call[1].body)).toHaveLength(1);
+  expect(call[1].headers.get('Idempotency-Key')).toBeDefined();
 });
 
 test('createCards posts all cards in one request', async () => {
   const api = new CardClient('/api');
   const cards = Array.from({ length: 21 }, () => ({ title: 't' }));
   await api.createCards(cards);
+  const call = (fetch as vi.Mock).mock.calls[0];
   expect((fetch as vi.Mock).mock.calls).toHaveLength(1);
-  expect(JSON.parse((fetch as vi.Mock).mock.calls[0][1].body)).toHaveLength(21);
+  expect(JSON.parse(call[1].body)).toHaveLength(21);
+  expect(call[1].headers.get('Idempotency-Key')).toBeDefined();
 });


### PR DESCRIPTION
## Summary
- include an Idempotency-Key header when creating cards and shapes
- add tests asserting keys are sent

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `npm --prefix web/client run test --silent` *(fails: Cannot spy on export "warning" in http-log-sink.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a08776e9a0832b8e6484b005f605f7