### PR TITLE
fix: ensure job hook hits API routes

### DIFF
--- a/web/client/src/core/hooks/useJob.ts
+++ b/web/client/src/core/hooks/useJob.ts
@@ -49,7 +49,7 @@ export function useJob(jobId: string): Job | undefined {
 
     async function poll(): Promise<void> {
       try {
-        const res = await apiFetch(`/jobs/${jobId}`);
+        const res = await apiFetch(`/api/jobs/${jobId}`);
         const data = (await res.json()) as Job;
         jobCache.set(jobId, data);
         if (!cancelled) {

--- a/web/client/tests/useJob.test.ts
+++ b/web/client/tests/useJob.test.ts
@@ -24,6 +24,8 @@ test('polls until job completes', async () => {
   await Promise.resolve();
   await vi.advanceTimersByTimeAsync(1000);
   await Promise.resolve();
+  expect(spy).toHaveBeenNthCalledWith(1, '/api/jobs/1');
+  expect(spy).toHaveBeenNthCalledWith(2, '/api/jobs/1');
   expect(spy).toHaveBeenCalledTimes(2);
   expect(result.current?.status).toBe('done');
 });
@@ -37,6 +39,7 @@ test('returns cached result for duplicate job id', async () => {
   const { result, unmount } = renderHook(() => useJob('1'));
   await Promise.resolve();
   await vi.runAllTimersAsync();
+  expect(spy).toHaveBeenCalledWith('/api/jobs/1');
   expect(spy).toHaveBeenCalledTimes(1);
   expect(result.current?.status).toBe('done');
   unmount();


### PR DESCRIPTION
## Summary
- prefix job status polling with `/api` so Vite proxy or backend URL works
- test hook expectations updated to verify API path

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json"...)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `poetry run pre-commit run --files web/client/src/core/hooks/useJob.ts web/client/tests/useJob.test.ts` *(fails: Interrupted (KeyboardInterrupt))*
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a13e668d40832b9fe663dd54aef246