### PR TITLE
feat(board): add cached board loader

### DIFF
--- a/web/client/src/components/BoardLoader.tsx
+++ b/web/client/src/components/BoardLoader.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../core/utils/api-fetch';
+
+interface BoardLoaderProps {
+  readonly boardId: string;
+}
+
+interface ShapeSnapshot {
+  readonly id: string | number;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Loads cached board shapes while displaying placeholder skeletons.
+ */
+export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
+  const [shapes, setShapes] = useState<ShapeSnapshot[]>([]);
+  const [version, setVersion] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const fetchShapes = useCallback(
+    async (since: number): Promise<void> => {
+      const res = await apiFetch(
+        `/api/boards/${boardId}/shapes?since=${since}`,
+      );
+      if (!res.ok) {
+        setShapes([]);
+        return;
+      }
+      const data = (await res.json()) as {
+        shapes: ShapeSnapshot[];
+        version: number;
+      };
+      setShapes(data.shapes);
+      setVersion(data.version);
+    },
+    [boardId],
+  );
+
+  const load = useCallback(
+    async (since: number): Promise<void> => {
+      await Promise.all([
+        fetchShapes(since),
+        new Promise(resolve => setTimeout(resolve, 350)),
+      ]);
+      setLoading(false);
+    },
+    [fetchShapes],
+  );
+
+  useEffect(() => {
+    void load(version);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const refresh = async (): Promise<void> => {
+    await apiFetch(`/api/boards/${boardId}/shapes/refresh`, { method: 'POST' });
+    setLoading(true);
+    setVersion(0);
+    await load(0);
+  };
+
+  if (loading) {
+    return (
+      <div className='board-loader'>
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            data-testid='skeleton'
+            key={i}
+            style={{ background: '#ccc', height: 20, marginBottom: 8 }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (shapes.length === 0) {
+    return (
+      <div className='board-loader'>
+        <div>No items yet. Create shapes or import.</div>
+        <button
+          type='button'
+          onClick={refresh}>
+          Refresh board
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className='board-loader'>
+      <ul>
+        {shapes.map(s => (
+          <li key={String(s.id)}>{String(s.id)}</li>
+        ))}
+      </ul>
+      <button
+        type='button'
+        onClick={refresh}>
+        Refresh board
+      </button>
+    </div>
+  );
+}
+
+export default BoardLoader;

--- a/web/client/tests/board-loader.test.tsx
+++ b/web/client/tests/board-loader.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { expect, test, vi } from 'vitest';
+import { BoardLoader } from '../src/components/BoardLoader';
+
+vi.mock('logfire', () => ({
+  span: (_: string, fn: () => unknown) => fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}));
+
+test('renders cached shapes after skeleton delay', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ shapes: [{ id: 's1' }], version: 1 }),
+      } as Response),
+  );
+  vi.stubGlobal('miro', {
+    board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+  });
+  render(<BoardLoader boardId='b1' />);
+  expect(screen.getAllByTestId('skeleton')).toHaveLength(3);
+  await screen.findByText('s1');
+  const call = (fetch as unknown as vi.Mock).mock.calls[0];
+  expect(call[0]).toBe('/api/boards/b1/shapes?since=0');
+});
+
+test('shows empty state when no cache', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ shapes: [], version: 1 }),
+      } as Response),
+  );
+  vi.stubGlobal('miro', {
+    board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+  });
+  render(<BoardLoader boardId='b2' />);
+  await screen.findByText('No items yet. Create shapes or import.');
+});
+
+test('refresh button reloads shapes', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ shapes: [{ id: 's1' }], version: 1 }),
+    } as Response)
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ shapes: [{ id: 's2' }], version: 2 }),
+    } as Response);
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('miro', {
+    board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+  });
+  render(<BoardLoader boardId='b3' />);
+  await screen.findByText('s1');
+  await userEvent.click(screen.getByRole('button', { name: 'Refresh board' }));
+  await screen.findByText('s2');
+  expect(fetchMock.mock.calls[1][0]).toBe('/api/boards/b3/shapes/refresh');
+});


### PR DESCRIPTION
## Summary
- add BoardLoader component to display cached shapes with skeleton placeholders
- support manual cache refresh to rehydrate board data
- cover BoardLoader with unit tests

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `npm --prefix web/client run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json" from "src/board/templates.ts")*
- `npm --prefix web/client run test --silent tests/board-loader.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a142c511e8832bb4dd6739aed78850