### PR TITLE
feat(web): add microcopy and error messages

### DIFF
--- a/web/client/src/ui/hooks/notifications.ts
+++ b/web/client/src/ui/hooks/notifications.ts
@@ -10,6 +10,7 @@
  * @param message - The text to display.
  */
 import * as log from '../../logger';
+import { getErrorToastMessage } from '../microcopy';
 
 export async function showError(message: string): Promise<void> {
   const trimmed = message.length > 80 ? `${message.slice(0, 77)}...` : message;
@@ -21,4 +22,14 @@ export async function showError(message: string): Promise<void> {
   }
   log.info('Showing error notification');
   await miro.board.notifications.showError(trimmed);
+}
+
+/**
+ * Display a standardised error message for a given HTTP status code.
+ *
+ * @param status - HTTP status returned from an API request.
+ */
+export async function showApiError(status: number): Promise<void> {
+  const message = getErrorToastMessage(status);
+  await showError(message);
 }

--- a/web/client/src/ui/microcopy.ts
+++ b/web/client/src/ui/microcopy.ts
@@ -1,0 +1,47 @@
+/**
+ * Centralised UI microcopy for the plugin.
+ */
+
+/** Text displayed in the sync bar for various states. */
+export const syncBarText = {
+  /** Idle state when all updates are persisted. */
+  idle: 'All changes saved',
+  /** Active state showing the number of queued changes. */
+  syncing: (count: number): string => `Syncing ${count} changes…`,
+  /** Throttled state approaching API limits. */
+  nearLimit: 'Slowing to avoid API limits',
+  /** Rate-limited state with automatic resume countdown. */
+  rateLimited: (seconds: number): string =>
+    `Paused for ${seconds}s (auto-resume)`,
+} as const;
+
+/** Labels for the apply button. */
+export const applyButtonText = {
+  /** Primary action showing pending change count. */
+  primary: (count: number): string => `Apply ${count} change(s)`,
+  /** Disabled state when no changes are pending. */
+  disabled: 'No changes to apply',
+} as const;
+
+/** User-friendly messages for API error toasts. */
+export const errorToastText = {
+  429: 'We\u2019re hitting the API limit. I\u2019ll retry shortly.',
+  401: 'Miro session expired. Please sign in again.',
+  500: 'Miro is having trouble. We\u2019ll retry in a moment.',
+} as const;
+
+/**
+ * Map HTTP status codes to an error toast message.
+ *
+ * @param status - Response status code from the server.
+ * @returns Localised error message.
+ */
+export function getErrorToastMessage(status: number): string {
+  if (status === 429 || status === 401) {
+    return errorToastText[status];
+  }
+  if (status >= 500 && status < 600) {
+    return errorToastText[500];
+  }
+  return 'An unexpected error occurred.';
+}

--- a/web/client/tests/microcopy.test.ts
+++ b/web/client/tests/microcopy.test.ts
@@ -1,0 +1,28 @@
+import {
+  applyButtonText,
+  getErrorToastMessage,
+  syncBarText,
+} from '../src/ui/microcopy';
+
+describe('microcopy', () => {
+  test('sync bar syncing message', () => {
+    expect(syncBarText.syncing(3)).toBe('Syncing 3 changes…');
+  });
+
+  test('apply button primary label', () => {
+    expect(applyButtonText.primary(2)).toBe('Apply 2 change(s)');
+  });
+
+  test('maps status codes to error messages', () => {
+    expect(getErrorToastMessage(429)).toBe(
+      'We\u2019re hitting the API limit. I\u2019ll retry shortly.',
+    );
+    expect(getErrorToastMessage(401)).toBe(
+      'Miro session expired. Please sign in again.',
+    );
+    expect(getErrorToastMessage(503)).toBe(
+      'Miro is having trouble. We\u2019ll retry in a moment.',
+    );
+    expect(getErrorToastMessage(418)).toBe('An unexpected error occurred.');
+  });
+});

--- a/web/client/tests/notifications.test.ts
+++ b/web/client/tests/notifications.test.ts
@@ -1,5 +1,5 @@
 import * as log from '../src/logger';
-import { showError } from '../src/ui/hooks/notifications';
+import { showApiError, showError } from '../src/ui/hooks/notifications';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };
@@ -38,5 +38,20 @@ describe('showError', () => {
       .calls[0][0];
     expect(arg.length).toBeLessThanOrEqual(80);
     expect(arg.endsWith('...')).toBe(true);
+  });
+
+  test('maps status codes to messages', async () => {
+    await showApiError(429);
+    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
+      'We\u2019re hitting the API limit. I\u2019ll retry shortly.',
+    );
+    await showApiError(401);
+    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
+      'Miro session expired. Please sign in again.',
+    );
+    await showApiError(503);
+    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
+      'Miro is having trouble. We\u2019ll retry in a moment.',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- centralize sync bar, apply button and error toast microcopy
- expose `showApiError` for HTTP status handling
- cover new messages with unit tests

## Testing
- `npm --prefix web/client install`
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `npm --prefix web/client run test --silent -- tests/microcopy.test.ts tests/notifications.test.ts`
- `SKIP=pytest poetry run pre-commit run --files web/client/src/ui/microcopy.ts web/client/src/ui/hooks/notifications.ts web/client/tests/microcopy.test.ts web/client/tests/notifications.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a0888592b8832b82af62dae179d75a