### PR TITLE
feat: add accessible drawer and button keyboard support

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -145,3 +145,48 @@ body {
   top: var(--space-100);
   right: var(--space-100);
 }
+
+button:focus-visible {
+  outline: 2px solid var(--colors-blue-700);
+  outline-offset: 2px;
+}
+
+.custom-drawer-container {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+
+.custom-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--colors-background-alpha-neutrals-overlay-subtle);
+  border: none;
+}
+
+.custom-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 300px;
+  max-width: 80%;
+  background: var(--colors-background-neutrals);
+  color: var(--primary-text-color);
+  padding: var(--space-medium);
+  box-shadow: var(--shadows-medium);
+  display: flex;
+  flex-direction: column;
+}
+
+.custom-drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-small);
+}
+
+.custom-drawer-content {
+  flex: 1;
+  overflow-y: auto;
+}

--- a/web/client/src/ui/components/Button.tsx
+++ b/web/client/src/ui/components/Button.tsx
@@ -27,7 +27,13 @@ export type ButtonProps = Readonly<
 
 const baseMargin = { margin: '0 var(--space-small) var(--space-small) 0' };
 
-const StyledDSButton = styled(DSButton, baseMargin);
+const StyledDSButton = styled(DSButton, {
+  ...baseMargin,
+  '&:focus-visible': {
+    outline: '2px solid var(--colors-blue-700)',
+    outlineOffset: '2px',
+  },
+});
 
 function getIconSlots(
   icon: React.ReactNode,
@@ -60,6 +66,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       iconPosition = 'start',
       css,
       children,
+      onKeyDown,
+      onClick,
       ...props
     },
     ref,
@@ -68,12 +76,25 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     const { start, end } = getIconSlots(icon, iconPosition);
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick?.(e as unknown as React.MouseEvent<HTMLButtonElement>);
+      }
+    };
+
     return (
       <StyledDSButton
         ref={ref}
         variant={variant}
         size={finalSize}
         css={css}
+        onKeyDown={handleKeyDown}
+        onClick={onClick}
         {...props}>
         {start}
         <DSButton.Label>{children}</DSButton.Label>

--- a/web/client/src/ui/components/Drawer.tsx
+++ b/web/client/src/ui/components/Drawer.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Button } from './Button';
+
+export interface DrawerProps {
+  /** Drawer title displayed in the header. */
+  readonly title: string;
+  /** Whether the drawer is visible. */
+  readonly isOpen: boolean;
+  /** Callback when the drawer should close. */
+  readonly onClose: () => void;
+  /** Drawer content. */
+  readonly children: React.ReactNode;
+}
+
+const FOCUS_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function getFocusables(root: HTMLElement | null): HTMLElement[] {
+  if (!root) {
+    return [];
+  }
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUS_SELECTOR));
+}
+
+export function Drawer({
+  title,
+  isOpen,
+  onClose,
+  children,
+}: DrawerProps): React.JSX.Element | null {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const focusable = ref.current?.querySelector<HTMLElement>(FOCUS_SELECTOR);
+    focusable?.focus();
+  }, [isOpen]);
+
+  const trapTab = React.useCallback((e: KeyboardEvent): boolean => {
+    if (e.key !== 'Tab') {
+      return false;
+    }
+    const nodes = getFocusables(ref.current);
+    if (nodes.length === 0) {
+      return false;
+    }
+    const first = nodes[0];
+    const last = nodes[nodes.length - 1];
+    const active = document.activeElement as HTMLElement;
+    if (e.shiftKey && active === first) {
+      last.focus();
+      return true;
+    }
+    if (!e.shiftKey && active === last) {
+      first.focus();
+      return true;
+    }
+    return false;
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (trapTab(e)) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose, trapTab]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className='custom-drawer-container'>
+      <button
+        type='button'
+        aria-label='Close drawer'
+        data-testid='drawer-backdrop'
+        className='custom-drawer-backdrop'
+        onClick={e => {
+          if (e.target === e.currentTarget) {
+            onClose();
+          }
+        }}
+        onKeyDown={e => {
+          if (
+            e.target === e.currentTarget &&
+            (e.key === 'Enter' || e.key === ' ')
+          ) {
+            e.preventDefault();
+            onClose();
+          }
+        }}
+      />
+      <div
+        role='dialog'
+        aria-modal='true'
+        aria-label={title}
+        className='custom-drawer'
+        ref={ref}>
+        <header className='custom-drawer-header'>
+          <h3>{title}</h3>
+          <Button
+            variant='secondary'
+            aria-label='Close'
+            onClick={onClose}>
+            ×
+          </Button>
+        </header>
+        <div className='custom-drawer-content'>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/client/src/ui/components/JobDrawer.tsx
+++ b/web/client/src/ui/components/JobDrawer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Drawer, DrawerProps } from './Drawer';
+
+export interface JobDrawerProps extends Omit<DrawerProps, 'children'> {
+  /** Status message announced to assistive tech. */
+  readonly statusMessage: string;
+}
+
+export function JobDrawer({
+  statusMessage,
+  ...drawerProps
+}: JobDrawerProps): React.JSX.Element | null {
+  return (
+    <Drawer {...drawerProps}>
+      <div
+        aria-live='polite'
+        data-testid='job-status'>
+        {statusMessage}
+      </div>
+    </Drawer>
+  );
+}

--- a/web/client/src/ui/components/index.ts
+++ b/web/client/src/ui/components/index.ts
@@ -17,3 +17,5 @@ export { FilterDropdown } from './FilterDropdown';
 export { FormGroup } from './FormGroup';
 export { Tooltip } from './Tooltip';
 export { PageHelp } from './PageHelp';
+export { Drawer } from './Drawer';
+export { JobDrawer } from './JobDrawer';

--- a/web/client/tests/button-accessibility.test.tsx
+++ b/web/client/tests/button-accessibility.test.tsx
@@ -1,0 +1,19 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { Button } from '../src/ui/components/Button';
+
+describe('Button accessibility', () => {
+  test('activates on Enter and Space', async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    render(<Button onClick={spy}>Do</Button>);
+    const btn = screen.getByRole('button', { name: 'Do' });
+    btn.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/client/tests/drawer.test.tsx
+++ b/web/client/tests/drawer.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { Drawer } from '../src/ui/components/Drawer';
+
+describe('Drawer', () => {
+  test('traps focus and closes with Escape', async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    render(
+      <Drawer
+        title='Jobs'
+        isOpen
+        onClose={spy}>
+        <button>First</button>
+        <button>Second</button>
+      </Drawer>,
+    );
+    const closeBtn = screen.getByLabelText('Close');
+    expect(closeBtn).toHaveFocus();
+    await user.tab();
+    const first = screen.getByRole('button', { name: 'First' });
+    expect(first).toHaveFocus();
+    await user.tab();
+    const second = screen.getByRole('button', { name: 'Second' });
+    expect(second).toHaveFocus();
+    await user.tab();
+    expect(closeBtn).toHaveFocus();
+    await user.keyboard('{Escape}');
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/web/client/tests/job-drawer.test.tsx
+++ b/web/client/tests/job-drawer.test.tsx
@@ -1,0 +1,21 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { JobDrawer } from '../src/ui/components/JobDrawer';
+
+describe('JobDrawer', () => {
+  test('announces status changes', () => {
+    render(
+      <JobDrawer
+        title='Jobs'
+        isOpen
+        onClose={() => {}}
+        statusMessage='Syncing 5 changes…'
+      />,
+    );
+    const region = screen.getByTestId('job-status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveTextContent('Syncing 5 changes…');
+  });
+});


### PR DESCRIPTION
## Summary
- add focus trapped Drawer with escape handling
- ensure Button shows focus ring and reacts to Enter/Space
- expose JobDrawer announcing status via aria-live

## Testing
- `npm run typecheck`
- `npx vitest run tests/button-accessibility.test.tsx tests/drawer.test.tsx tests/job-drawer.test.tsx`
- `npm run lint`
- `npm run stylelint`
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_68a0890c357c832b833e31e251d3b9f8