### PR TITLE
feat(core): add telemetry events

### DIFF
--- a/web/client/src/core/telemetry.ts
+++ b/web/client/src/core/telemetry.ts
@@ -1,0 +1,137 @@
+import { error as logError, warning as logWarning } from '../logger';
+
+interface BaseEvent {
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+export interface DiffShownEvent extends BaseEvent {
+  type: 'diff_shown';
+  creates: number;
+  updates: number;
+  deletes: number;
+  boardId: string;
+}
+
+export interface BatchSubmittedEvent extends BaseEvent {
+  type: 'batch_submitted';
+  jobId: string;
+  count: number;
+}
+
+export interface JobCompletedEvent extends BaseEvent {
+  type: 'job_completed';
+  jobId: string;
+  durationMs: number;
+  successCount: number;
+  failCount: number;
+}
+
+export interface RateLimitEncounteredEvent extends BaseEvent {
+  type: 'rate_limit_encountered';
+  retryAfterMs: number;
+}
+
+export interface OauthPromptShownEvent extends BaseEvent {
+  type: 'oauth_prompt_shown';
+}
+
+export interface OauthCompletedEvent extends BaseEvent {
+  type: 'oauth_completed';
+}
+
+export type TelemetryEvent =
+  | DiffShownEvent
+  | BatchSubmittedEvent
+  | JobCompletedEvent
+  | RateLimitEncounteredEvent
+  | OauthPromptShownEvent
+  | OauthCompletedEvent;
+
+/**
+ * Sends telemetry events to the backend logging endpoint.
+ *
+ * @param event - event payload without personally identifiable information
+ */
+async function post(event: TelemetryEvent): Promise<void> {
+  if (process.env.NODE_ENV === 'test' || typeof fetch !== 'function') {
+    return;
+  }
+  try {
+    const entry = {
+      timestamp: new Date().toISOString(),
+      level: 'info',
+      message: event.type,
+      context: { ...event },
+    };
+    delete entry.context.type;
+    const response = await fetch('/api/logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([entry]),
+    });
+    if (!response.ok) {
+      logWarning('telemetry post failed', { status: response.status });
+    }
+  } catch (error) {
+    logError('telemetry post threw', { error });
+  }
+}
+
+/**
+ * Records the counts of created, updated and deleted items in a diff view.
+ *
+ * @param params - diff statistics including the owning board identifier
+ */
+export async function diffShown(
+  params: Omit<DiffShownEvent, 'type'>,
+): Promise<void> {
+  await post({ type: 'diff_shown', ...params });
+}
+
+/**
+ * Notes submission of a batch job for processing.
+ *
+ * @param params - identifier and item count for the job
+ */
+export async function batchSubmitted(
+  params: Omit<BatchSubmittedEvent, 'type'>,
+): Promise<void> {
+  await post({ type: 'batch_submitted', ...params });
+}
+
+/**
+ * Captures completion statistics for an asynchronous job.
+ *
+ * @param params - identifiers and outcome counts for the job
+ */
+export async function jobCompleted(
+  params: Omit<JobCompletedEvent, 'type'>,
+): Promise<void> {
+  await post({ type: 'job_completed', ...params });
+}
+
+/**
+ * Registers that the client hit a server rate limit.
+ *
+ * @param params - retry delay reported by the server in milliseconds
+ */
+export async function rateLimitEncountered(
+  params: Omit<RateLimitEncounteredEvent, 'type'>,
+): Promise<void> {
+  await post({ type: 'rate_limit_encountered', ...params });
+}
+
+/**
+ * Tracks display of the OAuth consent prompt.
+ */
+export async function oauthPromptShown(): Promise<void> {
+  await post({ type: 'oauth_prompt_shown' });
+}
+
+/**
+ * Tracks successful completion of OAuth consent.
+ */
+export async function oauthCompleted(): Promise<void> {
+  await post({ type: 'oauth_completed' });
+}

--- a/web/client/tests/telemetry.test.ts
+++ b/web/client/tests/telemetry.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import * as logger from '../src/logger';
+import { diffShown, oauthPromptShown } from '../src/core/telemetry';
+
+vi.stubGlobal('miro', {
+  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env.NODE_ENV = 'test';
+});
+
+test('diffShown posts event payload', async () => {
+  const fetchSpy = vi
+    .spyOn(global, 'fetch')
+    .mockResolvedValue(new Response(null, { status: 202 }));
+  process.env.NODE_ENV = 'development';
+  await diffShown({ creates: 1, updates: 2, deletes: 3, boardId: 'b1' });
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [, init] = fetchSpy.mock.calls[0];
+  const body = JSON.parse(String(init?.body));
+  expect(body[0].message).toBe('diff_shown');
+  expect(body[0].context).toEqual({
+    creates: 1,
+    updates: 2,
+    deletes: 3,
+    boardId: 'b1',
+  });
+});
+
+test('telemetry logs network failures', async () => {
+  const fetchSpy = vi
+    .spyOn(global, 'fetch')
+    .mockRejectedValue(new Error('offline'));
+  const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  process.env.NODE_ENV = 'development';
+  await oauthPromptShown();
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  expect(errorSpy).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add telemetry client to emit UX events to backend logs
- cover telemetry posting and network errors with unit tests

## Testing
- ⚠️ `npm --prefix web/client install` (ENOTEMPTY: directory not empty, rename '/workspace/MiroDiagramming/web/client/node_modules/eslint' -> '/workspace/MiroDiagramming/web/client/node_modules/.eslint-JkheWANP')
- ✅ `npm --prefix web/client run typecheck --silent`
- ⚠️ `npm --prefix web/client run test --silent` (pretest npm install failed with ENOTEMPTY)
- ⚠️ `npm --prefix web/client run lint --silent` (Cannot find module '@typescript-eslint/eslint-plugin')
- ⚠️ `npm --prefix web/client run stylelint --silent` (stylelint: not found)
- ✅ `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a0891b933c832b92cee3d2c7469f11