### PR TITLE
feat: add developer debug query toggles

### DIFF
--- a/src/miro_backend/api/routers/auth.py
+++ b/src/miro_backend/api/routers/auth.py
@@ -18,12 +18,15 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 def get_status(
     user_id: str | None = Header(default=None, alias="X-User-Id"),
     store: UserStore = Depends(get_user_store),
+    debug_auth: str | None = Header(default=None, alias="X-Debug-Auth"),
 ) -> Response:
     """Return 200 when tokens exist for the provided ``X-User-Id`` header."""
     with logfire.span("auth status"):
         if user_id is None or user_id.strip() == "":
             logfire.warning("missing user id header")  # warn about absent user id
             raise BadRequestError("X-User-Id header required")
+        if debug_auth == "expired":
+            raise NotFoundError("User tokens not found")
         if store.retrieve(user_id) is None:
             logfire.warning(
                 "user tokens not found", user_id=user_id

--- a/src/miro_backend/api/routers/limits.py
+++ b/src/miro_backend/api/routers/limits.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Header, status
 import logfire
 
 from ...queue.change_queue import change_queue_length
@@ -12,9 +12,14 @@ router = APIRouter(prefix="/api", tags=["limits"])
 
 
 @router.get("/limits", status_code=status.HTTP_200_OK)  # type: ignore[misc]
-def get_limits(limiter: RateLimiter = Depends(get_rate_limiter)) -> dict[str, object]:
+def get_limits(
+    limiter: RateLimiter = Depends(get_rate_limiter),
+    debug_limits: str | None = Header(default=None, alias="X-Debug-Limits"),
+) -> dict[str, object]:
     """Return queue length and current bucket fill per user."""
     with logfire.span("get limits"):
+        if debug_limits is not None:
+            return {"queue_length": 0, "bucket_fill": {"user": 95}}
         return {
             "queue_length": int(change_queue_length._value.get()),
             "bucket_fill": limiter.bucket_fill(),

--- a/src/miro_backend/services/debug.py
+++ b/src/miro_backend/services/debug.py
@@ -1,0 +1,25 @@
+"""Developer debug toggles for test scenarios."""
+
+from __future__ import annotations
+
+from threading import Lock
+
+_counter = 0
+_lock = Lock()
+
+
+def set_debug_429(count: int) -> None:
+    """Set the number of upcoming requests to fail with HTTP 429."""
+    global _counter
+    with _lock:
+        _counter = count
+
+
+def consume_debug_429() -> bool:
+    """Return ``True`` if a debug 429 should be returned for this request."""
+    global _counter
+    with _lock:
+        if _counter > 0:
+            _counter -= 1
+            return True
+        return False

--- a/tests/test_debug_toggles.py
+++ b/tests/test_debug_toggles.py
@@ -1,0 +1,82 @@
+import asyncio
+import importlib
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from miro_backend.queue import ChangeQueue
+from miro_backend.queue.provider import get_change_queue
+from miro_backend.schemas.user_info import UserInfo
+from miro_backend.services.rate_limiter import get_rate_limiter
+from miro_backend.services.user_store import (
+    InMemoryUserStore,
+    get_user_store,
+)
+
+
+class DummyLimiter:
+    """Stub limiter returning fixed bucket fills."""
+
+    def bucket_fill(self) -> dict[str, int]:
+        return {"user": 1}
+
+
+def setup_app() -> Any:
+    app_module = importlib.import_module("miro_backend.main")
+    queue = ChangeQueue()
+
+    async def _idle_worker(_: Any, __: Any) -> None:
+        await asyncio.Event().wait()
+
+    queue.worker = _idle_worker
+    app_module.change_queue = queue  # type: ignore[attr-defined]
+    app_module.app.dependency_overrides[get_change_queue] = lambda: queue
+    app_module.app.dependency_overrides[get_rate_limiter] = lambda: DummyLimiter()
+    return app_module
+
+
+def test_debug_limits_header_forces_near_state() -> None:
+    app_module = setup_app()
+    with TestClient(app_module.app) as client:
+        response = client.get("/api/limits", headers={"X-Debug-Limits": "1"})
+    app_module.app.dependency_overrides.clear()
+    assert response.status_code == 200
+    assert response.json()["bucket_fill"] == {"user": 95}
+
+
+def test_debug_auth_expired_forces_not_found() -> None:
+    app_module = setup_app()
+    store = InMemoryUserStore()
+    store.store(
+        UserInfo(
+            id="1",
+            name="n",
+            access_token="a",
+            refresh_token="r",
+            expires_at=datetime.now(timezone.utc),
+        )
+    )
+    app_module.app.dependency_overrides[get_user_store] = lambda: store
+    with TestClient(app_module.app) as client:
+        normal = client.get("/api/auth/status", headers={"X-User-Id": "1"})
+        debug = client.get(
+            "/api/auth/status",
+            headers={"X-User-Id": "1", "X-Debug-Auth": "expired"},
+        )
+    app_module.app.dependency_overrides.clear()
+    assert normal.status_code == 200
+    assert debug.status_code == 404
+
+
+def test_debug_429_middleware_returns_for_next_requests() -> None:
+    app_module = setup_app()
+    with TestClient(app_module.app) as client:
+        client.get("/api/limits", headers={"X-Debug-429": "2"})
+        first = client.get("/api/limits")
+        second = client.get("/api/limits")
+        third = client.get("/api/limits")
+    app_module.app.dependency_overrides.clear()
+    assert first.status_code == 429
+    assert second.status_code == 429
+    assert third.status_code == 200

--- a/web/client/src/core/utils/api-fetch.ts
+++ b/web/client/src/core/utils/api-fetch.ts
@@ -1,5 +1,6 @@
 import { context, propagation } from '@opentelemetry/api';
 import { span } from 'logfire';
+import { debugFlags } from './debug-flags';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -21,6 +22,18 @@ export async function apiFetch(
     propagation.inject(context.active(), headers, {
       set: (key, value) => headers.set(key, value),
     });
+    if (import.meta.env.DEV) {
+      if (debugFlags.limits) {
+        headers.set('X-Debug-Limits', debugFlags.limits);
+      }
+      if (debugFlags.auth) {
+        headers.set('X-Debug-Auth', debugFlags.auth);
+      }
+      if (debugFlags.count429 !== undefined) {
+        headers.set('X-Debug-429', String(debugFlags.count429));
+        delete debugFlags.count429;
+      }
+    }
     const url = typeof input === 'string' ? `${API_BASE_URL}${input}` : input;
     return fetch(url, { ...init, headers });
   });

--- a/web/client/src/core/utils/debug-flags.ts
+++ b/web/client/src/core/utils/debug-flags.ts
@@ -1,0 +1,25 @@
+/**
+ * Parse debug toggles from the current URL.
+ *
+ * These flags enable developer-only behaviours when running a dev build.
+ */
+export interface DebugFlags {
+  /** Force the API limits endpoint to return a near limit response. */
+  limits?: string;
+  /** Number of subsequent operations that should return HTTP 429. */
+  count429?: number;
+  /** Force authentication to appear expired. */
+  auth?: string;
+}
+
+const params = new URLSearchParams(window.location.search);
+
+export const debugFlags: DebugFlags = import.meta.env.DEV
+  ? {
+      limits: params.get('debugLimits') ?? undefined,
+      count429: params.get('debug429')
+        ? Number(params.get('debug429'))
+        : undefined,
+      auth: params.get('debugAuth') ?? undefined,
+    }
+  : {};


### PR DESCRIPTION
## Summary
- add URL-based debug flag parser for dev builds
- enable backend headers to trigger auth, limit, and 429 debug behaviors
- cover debug toggles with new tests

## Testing
- `npm --prefix web/client install`
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: Bus error)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `poetry install`
- `poetry run pre-commit run --files web/client/src/core/utils/debug-flags.ts web/client/src/core/utils/api-fetch.ts src/miro_backend/services/debug.py src/miro_backend/main.py src/miro_backend/api/routers/auth.py src/miro_backend/api/routers/limits.py tests/test_debug_toggles.py` *(fails: tests failing)*
- `poetry run pytest tests/test_debug_toggles.py` *(fails: Required test coverage of 96% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a0893ff738832b975e971b9dc1202a