### PR TITLE
feat(ui): add toast notifications and diff chips

### DIFF
--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -6,6 +6,7 @@ import { AuthBanner } from '../components/AuthBanner';
 import { EditMetadataModal, IntroScreen } from '../ui/components';
 import { Paragraph } from '../ui/components/Paragraph';
 import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
+import { ToastContainer } from '../ui/components/Toast';
 
 import { type Tab, TAB_DATA } from '../ui/pages/tabs';
 
@@ -80,6 +81,7 @@ function AppShell(): React.JSX.Element {
           isOpen={showMeta}
           onClose={() => setShowMeta(false)}
         />
+        <ToastContainer />
       </ExcelDataProvider>
     </div>
   );

--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -11,7 +11,7 @@
   --space-large: var(--space-400);
   --space-xlarge: var(--space-500);
   --indigoAlpha40: var(--colors-alpha-gray-400);
-  --indigo700: var(--colors-blue-700);
+  --accent-color: var(--colors-blue-700);
   --green700: var(--colors-green-700);
   --red700: var(--colors-red-700);
   --red600: var(--colors-red-600);
@@ -56,7 +56,7 @@ body {
 }
 
 button:focus-visible {
-  outline: 2px solid var(--indigo700);
+  outline: 2px solid var(--accent-color);
   outline-offset: 2px;
 }
 
@@ -149,4 +149,57 @@ button:focus-visible {
   position: absolute;
   top: var(--space-100);
   right: var(--space-100);
+}
+
+.skeleton {
+  background-color: var(--colors-gray-200);
+  color: transparent;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: var(--space-100);
+  right: var(--space-100);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-50);
+  z-index: 1000;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: var(--space-100);
+  background: var(--colors-background-neutrals);
+  color: var(--primary-text-color);
+  border-radius: var(--radii-100);
+  padding: var(--space-xsmall) var(--space-small);
+}
+
+.toast-thumb {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+  border-radius: var(--radii-50);
+}
+
+.diff-chip {
+  display: inline-block;
+  padding: 0 var(--space-50);
+  border-radius: var(--radii-100);
+  font-size: var(--font-size-200);
+  color: var(--white);
+  margin-right: var(--space-50);
+}
+
+.diff-create {
+  background: var(--colors-green-700);
+}
+
+.diff-update {
+  background: var(--colors-blue-700);
+}
+
+.diff-delete {
+  background: var(--colors-red-700);
 }

--- a/web/client/src/components/DiffDrawer.tsx
+++ b/web/client/src/components/DiffDrawer.tsx
@@ -52,13 +52,22 @@ export function DiffDrawer<T extends { id?: string }>({
       <h2>Pending changes</h2>
       <ul>
         {diff.creates.map((c, i) => (
-          <li key={`c${i}`}>Create {(c as { id?: string }).id ?? i}</li>
+          <li key={`c${i}`}>
+            <span className='diff-chip diff-create'>Create</span>
+            {(c as { id?: string }).id ?? i}
+          </li>
         ))}
         {diff.updates.map((u, i) => (
-          <li key={`u${i}`}>Update {(u as { id?: string }).id ?? i}</li>
+          <li key={`u${i}`}>
+            <span className='diff-chip diff-update'>Update</span>
+            {(u as { id?: string }).id ?? i}
+          </li>
         ))}
         {diff.deletes.map((d, i) => (
-          <li key={`d${i}`}>Delete {(d as { id?: string }).id ?? i}</li>
+          <li key={`d${i}`}>
+            <span className='diff-chip diff-delete'>Delete</span>
+            {(d as { id?: string }).id ?? i}
+          </li>
         ))}
       </ul>
       <div className='drawer-actions'>

--- a/web/client/src/core/hooks/useOptimisticOps.ts
+++ b/web/client/src/core/hooks/useOptimisticOps.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { pushToast } from '../../ui/components/Toast';
 
 /**
  * Definition of an optimistic operation applied to the board.
@@ -14,6 +15,8 @@ export interface OptimisticOp {
   commit: () => Promise<void>;
   /** Revert the local change if committing fails. */
   rollback: () => void | Promise<void>;
+  /** Optional thumbnail used in failure toasts. */
+  thumbnailUrl?: string;
 }
 
 const wait = (ms: number): Promise<void> =>
@@ -36,7 +39,9 @@ export function useOptimisticOps(): (op: OptimisticOp) => Promise<void> {
     } catch {
       await wait(150);
       await op.rollback();
-      await miro.board.notifications.showError('Operation failed', {
+      pushToast({
+        message: 'Operation failed',
+        thumbnailUrl: op.thumbnailUrl,
         action: {
           label: 'Try again',
           callback: () => {

--- a/web/client/src/ui/hooks/notifications.ts
+++ b/web/client/src/ui/hooks/notifications.ts
@@ -11,6 +11,7 @@
  */
 import * as log from '../../logger';
 import { getErrorToastMessage } from '../microcopy';
+import { pushToast } from '../components/Toast';
 
 export async function showError(message: string): Promise<void> {
   const trimmed = message.length > 80 ? `${message.slice(0, 77)}...` : message;
@@ -21,7 +22,7 @@ export async function showError(message: string): Promise<void> {
     log.debug('Trimmed long error message');
   }
   log.info('Showing error notification');
-  await miro.board.notifications.showError(trimmed);
+  pushToast({ message: trimmed });
 }
 
 /**

--- a/web/client/tests/app-ui.test.ts
+++ b/web/client/tests/app-ui.test.ts
@@ -6,25 +6,21 @@ import React from 'react';
 import { App } from '../src/app/App';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
 import { getDropzoneStyle, undoLastImport } from '../src/ui/hooks/ui-utils';
+import { pushToast } from '../src/ui/components/Toast';
 
-interface GlobalWithMiro {
-  miro?: { board?: Record<string, unknown> };
-}
-
-declare const global: GlobalWithMiro;
+vi.mock('../src/ui/components/Toast', () => ({ pushToast: vi.fn() }));
 
 describe('App UI integration', () => {
   beforeEach(() => {
-    global.miro = {
-      board: {
-        notifications: { showError: vi.fn().mockResolvedValue(undefined) },
-      },
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).miro = { board: {} };
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete global.miro;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).miro;
   });
 
   function selectFile(): File {
@@ -70,9 +66,7 @@ describe('App UI integration', () => {
     const button = screen.getByRole('button', { name: /create diagram/i });
     await act(async () => fireEvent.click(button));
     expect(spy).toHaveBeenCalled();
-    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
-      'Error: fail',
-    );
+    expect(pushToast).toHaveBeenCalledWith({ message: 'Error: fail' });
   });
 
   test('withFrame option forwards frame title', async () => {

--- a/web/client/tests/cards-tab-branches.test.tsx
+++ b/web/client/tests/cards-tab-branches.test.tsx
@@ -4,6 +4,9 @@ import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { CardProcessor } from '../src/board/card-processor';
 import { CardsTab } from '../src/ui/pages/CardsTab';
+import { pushToast } from '../src/ui/components/Toast';
+
+vi.mock('../src/ui/components/Toast', () => ({ pushToast: vi.fn() }));
 
 vi.mock('../src/board/card-processor');
 
@@ -11,12 +14,7 @@ describe('CardsTab extra paths', () => {
   // TODO extend to test server-backed card lookups once card cache is persistent
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (globalThis as any).miro = {
-      board: {
-        ui: { on: vi.fn() },
-        notifications: { showError: vi.fn().mockResolvedValue(undefined) },
-      },
-    };
+    (globalThis as any).miro = { board: { ui: { on: vi.fn() } } };
   });
 
   afterEach(() => {
@@ -63,9 +61,6 @@ describe('CardsTab extra paths', () => {
     await act(async () =>
       fireEvent.click(screen.getByRole('button', { name: /create cards/i })),
     );
-    expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (globalThis as any).miro.board.notifications.showError,
-    ).toHaveBeenCalledWith('Error: fail');
+    expect(pushToast).toHaveBeenCalledWith({ message: 'Error: fail' });
   });
 });

--- a/web/client/tests/cards-tab-undo.test.tsx
+++ b/web/client/tests/cards-tab-undo.test.tsx
@@ -11,9 +11,7 @@ vi.mock('../src/board/card-processor');
 describe('CardsTab undo paths', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (globalThis as any).miro = {
-      board: { ui: { on: vi.fn() }, notifications: { showError: vi.fn() } },
-    };
+    (globalThis as any).miro = { board: { ui: { on: vi.fn() } } };
     vi.useFakeTimers();
     vi.clearAllMocks();
   });

--- a/web/client/tests/diffdrawer.test.tsx
+++ b/web/client/tests/diffdrawer.test.tsx
@@ -73,4 +73,21 @@ describe('DiffDrawer', () => {
     await userEvent.tab();
     expect(cancel).toHaveFocus();
   });
+
+  test('renders chips for each change type', () => {
+    render(
+      <DiffDrawer
+        boardId='b1'
+        diff={{
+          creates: [{ id: 'c1' }],
+          updates: [{ id: 'u1' }],
+          deletes: [{ id: 'd1' }],
+        }}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText('Create')).toHaveClass('diff-chip', 'diff-create');
+    expect(screen.getByText('Update')).toHaveClass('diff-chip', 'diff-update');
+    expect(screen.getByText('Delete')).toHaveClass('diff-chip', 'diff-delete');
+  });
 });

--- a/web/client/tests/notifications.test.ts
+++ b/web/client/tests/notifications.test.ts
@@ -1,57 +1,46 @@
 import * as log from '../src/logger';
 import { showApiError, showError } from '../src/ui/hooks/notifications';
+import { pushToast } from '../src/ui/components/Toast';
 
-interface GlobalWithMiro {
-  miro?: { board?: Record<string, unknown> };
-}
-
-declare const global: GlobalWithMiro;
+vi.mock('../src/ui/components/Toast', () => ({ pushToast: vi.fn() }));
 
 describe('showError', () => {
   beforeEach(() => {
-    global.miro = {
-      board: {
-        notifications: { showError: vi.fn().mockResolvedValue(undefined) },
-      },
-    };
+    vi.clearAllMocks();
     vi.spyOn(log, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete global.miro;
   });
 
   test('passes through short messages', async () => {
     await showError('fail');
     expect(log.error).toHaveBeenCalledWith('fail');
-    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
-      'fail',
-    );
+    expect(pushToast).toHaveBeenCalledWith({ message: 'fail' });
   });
 
   test('truncates long messages', async () => {
     const long = 'a'.repeat(90);
     await showError(long);
     expect(log.error).toHaveBeenCalledWith(long);
-    const arg = (global.miro.board.notifications.showError as vi.Mock).mock
-      .calls[0][0];
+    const arg = (pushToast as vi.Mock).mock.calls[0][0].message as string;
     expect(arg.length).toBeLessThanOrEqual(80);
     expect(arg.endsWith('...')).toBe(true);
   });
 
   test('maps status codes to messages', async () => {
     await showApiError(429);
-    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
-      'We\u2019re hitting the API limit. I\u2019ll retry shortly.',
-    );
+    expect(pushToast).toHaveBeenCalledWith({
+      message: 'We\u2019re hitting the API limit. I\u2019ll retry shortly.',
+    });
     await showApiError(401);
-    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
-      'Miro session expired. Please sign in again.',
-    );
+    expect(pushToast).toHaveBeenCalledWith({
+      message: 'Miro session expired. Please sign in again.',
+    });
     await showApiError(503);
-    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
-      'Miro is having trouble. We\u2019ll retry in a moment.',
-    );
+    expect(pushToast).toHaveBeenCalledWith({
+      message: 'Miro is having trouble. We\u2019ll retry in a moment.',
+    });
   });
 });

--- a/web/client/tests/toast.test.tsx
+++ b/web/client/tests/toast.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { ToastContainer, pushToast } from '../src/ui/components/Toast';
+import { expect, test, vi } from 'vitest';
+
+vi.useFakeTimers();
+
+test('caps to three concurrent toasts', async () => {
+  render(<ToastContainer />);
+  pushToast({ message: '1' });
+  pushToast({ message: '2' });
+  pushToast({ message: '3' });
+  pushToast({ message: '4' });
+  await screen.findByText('4');
+  const alerts = screen.getAllByRole('alert');
+  expect(alerts).toHaveLength(3);
+  expect(screen.queryByText('1')).toBeNull();
+});

--- a/web/client/tests/use-excel-sync.test.tsx
+++ b/web/client/tests/use-excel-sync.test.tsx
@@ -31,11 +31,6 @@ describe('useExcelSync', () => {
     (ExcelSyncService as unknown as vi.Mock).mockImplementation(() => ({
       updateShapesFromExcel: vi.fn().mockResolvedValue(undefined),
     }));
-    (
-      globalThis as unknown as {
-        miro: { board: { notifications: { showError: vi.Mock } } };
-      }
-    ).miro = { board: { notifications: { showError: vi.fn() } } };
   });
 
   test('updates rows and widgets', async () => {


### PR DESCRIPTION
## Summary
- add toast system limited to three concurrent messages
- show color-coded chips in diff drawer and wire notifications to toasts
- standardize accent color and skeleton/notification styles

## Testing
- `npm run typecheck --silent`
- `npm run test --silent tests/shape-client.test.ts` *(fails: ReferenceError: miro is not defined)*
- `npm run lint --silent` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a149ebc7f8832b8564e49e62cb8f27