### PR TITLE
fix(sync): poll new limits endpoint

### DIFF
--- a/web/client/tests/sync-status-bar.test.tsx
+++ b/web/client/tests/sync-status-bar.test.tsx
@@ -5,6 +5,9 @@ import React from 'react';
 import { vi } from 'vitest';
 import { SyncStatusBar } from '../src/components/SyncStatusBar';
 import { useSyncStore } from '../src/core/state/sync-store';
+import { apiFetch } from '../src/core/utils/api-fetch';
+
+vi.mock('../src/core/utils/api-fetch');
 
 describe('SyncStatusBar', () => {
   beforeEach(() => {
@@ -22,67 +25,57 @@ describe('SyncStatusBar', () => {
   });
 
   test('shows idle when queue empty', async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({ remaining: 100 }),
-      } as Response);
+    (apiFetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ queue_length: 0, bucket_fill: { user: 100 } }),
+    } as Response);
     render(<SyncStatusBar />);
     expect(await screen.findByText('All changes saved')).toBeInTheDocument();
   });
 
   test('shows syncing with remaining items', async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({ remaining: 100 }),
-      } as Response);
+    (apiFetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ queue_length: 0, bucket_fill: { user: 100 } }),
+    } as Response);
     useSyncStore.getState().setQueue(2);
     render(<SyncStatusBar />);
     expect(await screen.findByText('2 items remaining')).toBeInTheDocument();
   });
 
   test('shows near limit warning', async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({ remaining: 1 }),
-      } as Response);
+    (apiFetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ queue_length: 0, bucket_fill: { user: 1 } }),
+    } as Response);
     render(<SyncStatusBar />);
     expect(
       await screen.findByText('Slowing to avoid limits'),
     ).toBeInTheDocument();
   });
 
-  test('shows rate limited message', async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({ remaining: 0, retryAfter: 12 }),
-      } as Response);
+  test('shows rate limited when bucket empty', async () => {
+    (apiFetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ queue_length: 0, bucket_fill: { user: 0 } }),
+    } as Response);
     render(<SyncStatusBar />);
     expect(
-      await screen.findByText('Pausing for 12s (auto-resume)'),
+      await screen.findByText('Pausing for 0s (auto-resume)'),
     ).toBeInTheDocument();
   });
 
   test('shows disconnected on fetch error', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    (apiFetch as unknown as vi.Mock).mockRejectedValue(new Error('network'));
     render(<SyncStatusBar />);
     expect(await screen.findByText('Disconnected')).toBeInTheDocument();
   });
 
   test('returns to idle when queue clears', async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({ remaining: 100 }),
-      } as Response);
+    (apiFetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ queue_length: 0, bucket_fill: { user: 100 } }),
+    } as Response);
     render(<SyncStatusBar />);
     await act(async () => {
       useSyncStore.getState().setQueue(1);


### PR DESCRIPTION
## Summary
- query `/api/limits` using `apiFetch` and map `queue_length`/`bucket_fill`
- update SyncStatusBar tests for new limits payload

## Testing
- `npm install`
- `npm run typecheck --silent` *(no output)*
- `npm run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json")*
- `npm run lint --silent` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a160a34c44832bbefea23dc77d1305