### PR TITLE
fix(web): render sync status bar

### DIFF
--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import type { ExcelRow } from '../core/utils/excel-loader';
 import { AuthBanner } from '../components/AuthBanner';
+import { SyncStatusBar } from '../components/SyncStatusBar';
 import { EditMetadataModal, IntroScreen } from '../ui/components';
 import { Paragraph } from '../ui/components/Paragraph';
 import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
@@ -75,6 +76,7 @@ function AppShell(): React.JSX.Element {
             ))}
           </Tabs.List>
         </Tabs>
+        <SyncStatusBar />
         <Paragraph>{current[3]}</Paragraph>
         <CurrentComp />
         <EditMetadataModal


### PR DESCRIPTION
## Summary
- render SyncStatusBar within AppShell so users see sync state

## Testing
- `npm --prefix web/client install`
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` (fails: "miro is not defined")
- `npm --prefix web/client run lint --silent` (fails: "Definition for rule 'react-hooks/exhaustive-deps' was not found")
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a160b4b040832bbab6152142a15fd8