### PR TITLE
fix(queue): enable soft token bucket limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### Bug Fixes
+
+* enable soft token-bucket limiter for production queue
+
 ## [1.18.1](https://github.com/fenrick/MiroDiagramming/compare/v1.18.0...v1.18.1) (2025-07-19)
 
 

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -85,6 +85,16 @@ class Settings(BaseSettings):
         alias="MIRO_HTTP_TIMEOUT_SECONDS",
         description="Default timeout in seconds for outbound HTTP requests.",
     )
+    bucket_reservoir: int = Field(
+        default=10,
+        alias="MIRO_BUCKET_RESERVOIR",
+        description="Maximum number of tokens in the soft rate limiter.",
+    )
+    bucket_refresh_ms: int = Field(
+        default=1000,
+        alias="MIRO_BUCKET_REFRESH_MS",
+        description="Interval in milliseconds for refilling the token bucket.",
+    )
 
     model_config = SettingsConfigDict(
         env_file="config/.env", extra="ignore", populate_by_name=True

--- a/src/miro_backend/queue/provider.py
+++ b/src/miro_backend/queue/provider.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from .change_queue import ChangeQueue
 from .persistence import SqlAlchemyQueuePersistence
+from ..core.config import settings
 
-_change_queue = ChangeQueue(persistence=SqlAlchemyQueuePersistence())
+_change_queue = ChangeQueue(
+    persistence=SqlAlchemyQueuePersistence(),
+    bucket_reservoir=settings.bucket_reservoir,
+    bucket_refresh_interval_ms=settings.bucket_refresh_ms,
+)
 
 
 def get_change_queue() -> ChangeQueue:

--- a/tests/test_config_bucket_settings.py
+++ b/tests/test_config_bucket_settings.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from miro_backend.core.config import Settings
+
+
+def test_bucket_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIRO_BUCKET_RESERVOIR", "3")
+    monkeypatch.setenv("MIRO_BUCKET_REFRESH_MS", "50")
+
+    settings = Settings()
+
+    assert settings.bucket_reservoir == 3
+    assert settings.bucket_refresh_ms == 50


### PR DESCRIPTION
## Summary
- add config options for token bucket reservoir and refresh interval
- wire production change queue to apply soft token bucket limiter
- test env var loading for bucket settings

## Testing
- `poetry run pre-commit run black --files CHANGELOG.md src/miro_backend/core/config.py src/miro_backend/queue/provider.py tests/test_config_bucket_settings.py`
- `poetry run pre-commit run ruff --files CHANGELOG.md src/miro_backend/core/config.py src/miro_backend/queue/provider.py tests/test_config_bucket_settings.py`
- `poetry run pre-commit run mypy --files CHANGELOG.md src/miro_backend/core/config.py src/miro_backend/queue/provider.py tests/test_config_bucket_settings.py`
- `poetry run pre-commit run --files CHANGELOG.md src/miro_backend/core/config.py src/miro_backend/queue/provider.py tests/test_config_bucket_settings.py` *(failed: Interrupted (KeyboardInterrupt))*
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a169ba8eb8832b8a02ef4ca99e8870