### PR TITLE
fix(auth): use design-system components in auth banner

### DIFF
--- a/web/client/src/components/AuthBanner.tsx
+++ b/web/client/src/components/AuthBanner.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Button, Callout } from '@mirohq/design-system';
 import { useAuthStatus } from '../core/hooks/useAuthStatus';
 
 /**
@@ -17,10 +18,16 @@ export const AuthBanner: React.FC = () => {
   const message =
     status === 'unauthorized' ? 'Sign in to Miro' : 'Session expired';
   return (
-    <div role='alert'>
-      <span>{message}</span>
-      <button onClick={signIn}>Sign in to Miro</button>
-    </div>
+    <Callout
+      variant='warning'
+      dismissible={false}>
+      <Callout.Content>
+        <Callout.Description>{message}</Callout.Description>
+      </Callout.Content>
+      <Callout.Actions>
+        <Button onClick={signIn}>Sign in to Miro</Button>
+      </Callout.Actions>
+    </Callout>
   );
 };
 


### PR DESCRIPTION
## Summary
- use design-system Callout and Button in AuthBanner for consistent styling

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: miro is not defined in tests/shape-client.test.ts)*
- `npm run lint --silent` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a186448250832bacd3dbe2f73ac8a9