### PR TITLE
feat(ui): integrate board loader into structured tab

### DIFF
--- a/web/client/src/components/BoardLoader.tsx
+++ b/web/client/src/components/BoardLoader.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '../core/utils/api-fetch';
+import { Button } from '../ui/components/Button';
 
 interface BoardLoaderProps {
   readonly boardId: string;
@@ -17,6 +18,14 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
   const [shapes, setShapes] = useState<ShapeSnapshot[]>([]);
   const [version, setVersion] = useState(0);
   const [loading, setLoading] = useState(true);
+
+  const SkeletonRow = (): JSX.Element => (
+    <div
+      data-testid='skeleton'
+      className='skeleton'
+      style={{ height: 20, marginBottom: 8 }}
+    />
+  );
 
   const fetchShapes = useCallback(
     async (since: number): Promise<void> => {
@@ -50,7 +59,6 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
 
   useEffect(() => {
     void load(version);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const refresh = async (): Promise<void> => {
@@ -64,11 +72,7 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
     return (
       <div className='board-loader'>
         {Array.from({ length: 3 }, (_, i) => (
-          <div
-            data-testid='skeleton'
-            key={i}
-            style={{ background: '#ccc', height: 20, marginBottom: 8 }}
-          />
+          <SkeletonRow key={i} />
         ))}
       </div>
     );
@@ -78,11 +82,7 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
     return (
       <div className='board-loader'>
         <div>No items yet. Create shapes or import.</div>
-        <button
-          type='button'
-          onClick={refresh}>
-          Refresh board
-        </button>
+        <Button onClick={refresh}>Refresh board</Button>
       </div>
     );
   }
@@ -94,11 +94,7 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
           <li key={String(s.id)}>{String(s.id)}</li>
         ))}
       </ul>
-      <button
-        type='button'
-        onClick={refresh}>
-        Refresh board
-      </button>
+      <Button onClick={refresh}>Refresh board</Button>
     </div>
   );
 }

--- a/web/client/src/ui/pages/StructuredTab.tsx
+++ b/web/client/src/ui/pages/StructuredTab.tsx
@@ -37,6 +37,7 @@ import {
   useAdvancedToggle,
   useDiagramCreate,
 } from '../hooks/use-diagram-create';
+import { BoardLoader } from '../../components/BoardLoader';
 
 /**
  * Queue the first file from a drop event for import.
@@ -98,6 +99,7 @@ const LAYOUT_DESCRIPTIONS: Record<LayoutChoice, string> = {
 // eslint-disable-next-line complexity
 export const StructuredTab: React.FC = () => {
   const [importQueue, setImportQueue] = React.useState<File[]>([]);
+  const [boardId, setBoardId] = React.useState<string | null>(null);
   const [layoutChoice, setLayoutChoice] =
     React.useState<LayoutChoice>('Layered');
   const [showAdvanced, setShowAdvanced] = React.useState(false);
@@ -117,6 +119,24 @@ export const StructuredTab: React.FC = () => {
   >(undefined);
 
   useAdvancedToggle(setShowAdvanced);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      try {
+        const info = await globalThis.miro?.board?.getInfo?.();
+        if (!cancelled && info?.id) {
+          setBoardId(String(info.id));
+        }
+      } catch {
+        // ignore SDK absence
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleFiles = React.useCallback(
     (droppedFiles: File[]): void =>
@@ -379,6 +399,10 @@ export const StructuredTab: React.FC = () => {
           </Grid.Item>
         </Grid>
       )}
+      <section style={{ marginTop: space[200] }}>
+        <h3>Read cached shapes</h3>
+        {boardId && <BoardLoader boardId={boardId} />}
+      </section>
     </TabPanel>
   );
 };


### PR DESCRIPTION
## Summary
- use design-system button and skeleton row in BoardLoader
- surface BoardLoader in Structured tab under a Read cached shapes section

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json" from "src/board/templates.ts". Does the file exist?)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a1865a1f3c832b8221efbb7d53c106