### PR TITLE
fix(sync-status-bar): use apiFetch for limits and map queue length

### DIFF
--- a/web/client/src/components/SyncStatusBar.tsx
+++ b/web/client/src/components/SyncStatusBar.tsx
@@ -26,13 +26,13 @@ export function SyncStatusBar(): JSX.Element {
       bucket_fill: Record<string, number>;
     }): void => {
       setQueue(data.queue_length);
-      const lowest = Math.min(...Object.values(data.bucket_fill));
       setBackoffSeconds(null);
-      if (lowest <= 0) {
+      const fills = Object.values(data.bucket_fill);
+      if (fills.some(fill => fill <= 0)) {
         setState('rateLimited');
         return;
       }
-      if (lowest <= NEAR_LIMIT_THRESHOLD) {
+      if (fills.some(fill => fill <= NEAR_LIMIT_THRESHOLD)) {
         setState('nearLimit');
         return;
       }

--- a/web/client/tests/sync-status-bar.test.tsx
+++ b/web/client/tests/sync-status-bar.test.tsx
@@ -36,9 +36,8 @@ describe('SyncStatusBar', () => {
   test('shows syncing with remaining items', async () => {
     (apiFetch as unknown as vi.Mock).mockResolvedValue({
       ok: true,
-      json: async () => ({ queue_length: 0, bucket_fill: { user: 100 } }),
+      json: async () => ({ queue_length: 2, bucket_fill: { user: 100 } }),
     } as Response);
-    useSyncStore.getState().setQueue(2);
     render(<SyncStatusBar />);
     expect(await screen.findByText('2 items remaining')).toBeInTheDocument();
   });
@@ -46,7 +45,10 @@ describe('SyncStatusBar', () => {
   test('shows near limit warning', async () => {
     (apiFetch as unknown as vi.Mock).mockResolvedValue({
       ok: true,
-      json: async () => ({ queue_length: 0, bucket_fill: { user: 1 } }),
+      json: async () => ({
+        queue_length: 0,
+        bucket_fill: { primary: 100, secondary: 1 },
+      }),
     } as Response);
     render(<SyncStatusBar />);
     expect(


### PR DESCRIPTION
## Summary
- poll `/api/limits` via `apiFetch`
- derive near limit state when any bucket is low
- test queue length mapping and per-user limit checks

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: miro is not defined)*
- `npm run lint --silent` *(fails: React Hook useEffect has missing dependencies in BoardLoader.tsx)*
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `pre-commit run --files web/client/src/components/SyncStatusBar.tsx web/client/tests/sync-status-bar.test.tsx` *(fails: pytest: error: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a1894ff558832b94a23fdf5d2f3fc3