### PR TITLE
feat(ui): align drawers and status bar with design system

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -51,8 +51,27 @@ body {
 .scrollable .buttons {
   position: sticky;
   bottom: 0;
-  padding-block: var(--space-300);
+  padding-block: var(--space-200);
   background: #fff;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-100);
+}
+
+@media (width >= 480px) {
+  .buttons {
+    flex-direction: row;
+  }
+  .buttons button {
+    width: auto;
+  }
+}
+
+.buttons button {
+  width: 100%;
 }
 
 button:focus-visible {
@@ -202,4 +221,22 @@ button:focus-visible {
 
 .diff-delete {
   background: var(--colors-red-700);
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sync-status-bar {
+  position: fixed;
+  bottom: var(--space-100);
+  right: var(--space-100);
+  padding: var(--space-100) var(--space-150);
+  background: var(--colors-gray-900);
+  color: var(--colors-white);
+  border-radius: var(--radii-100);
+  box-shadow: var(--shadows-100);
+  font-size: var(--fontSize-200);
 }

--- a/web/client/src/components/BoardLoader.tsx
+++ b/web/client/src/components/BoardLoader.tsx
@@ -59,7 +59,7 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
 
   useEffect(() => {
     void load(version);
-  }, []);
+  }, [load, version]);
 
   const refresh = async (): Promise<void> => {
     await apiFetch(`/api/boards/${boardId}/shapes/refresh`, { method: 'POST' });

--- a/web/client/src/components/DiffDrawer.tsx
+++ b/web/client/src/components/DiffDrawer.tsx
@@ -45,7 +45,7 @@ export function DiffDrawer<T extends { id?: string }>({
 
   return (
     <aside
-      className='diff-drawer'
+      className='diff-drawer scrollable'
       ref={trapRef}
       role='dialog'
       aria-modal='true'>
@@ -54,25 +54,37 @@ export function DiffDrawer<T extends { id?: string }>({
         {diff.creates.map((c, i) => (
           <li key={`c${i}`}>
             <span className='diff-chip diff-create'>Create</span>
-            {(c as { id?: string }).id ?? i}
+            <span
+              className='truncate'
+              title={String((c as { id?: string }).id ?? i)}>
+              {(c as { id?: string }).id ?? i}
+            </span>
           </li>
         ))}
         {diff.updates.map((u, i) => (
           <li key={`u${i}`}>
             <span className='diff-chip diff-update'>Update</span>
-            {(u as { id?: string }).id ?? i}
+            <span
+              className='truncate'
+              title={String((u as { id?: string }).id ?? i)}>
+              {(u as { id?: string }).id ?? i}
+            </span>
           </li>
         ))}
         {diff.deletes.map((d, i) => (
           <li key={`d${i}`}>
             <span className='diff-chip diff-delete'>Delete</span>
-            {(d as { id?: string }).id ?? i}
+            <span
+              className='truncate'
+              title={String((d as { id?: string }).id ?? i)}>
+              {(d as { id?: string }).id ?? i}
+            </span>
           </li>
         ))}
       </ul>
-      <div className='drawer-actions'>
+      <div className='buttons'>
         <Button
-          variant='secondary'
+          variant='tertiary'
           onClick={onClose}>
           Cancel
         </Button>

--- a/web/client/src/components/JobDrawer.tsx
+++ b/web/client/src/components/JobDrawer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useJob } from '../core/hooks/useJob';
 import { useFocusTrap } from '../core/hooks/useFocusTrap';
+import { Button } from '../ui/components/Button';
 
 interface JobDrawerProps {
   /** Identifier of the job to display. */
@@ -74,8 +75,9 @@ export function JobDrawer({
   }
 
   return (
-    <div
+    <aside
       ref={trapRef}
+      className='scrollable'
       role='dialog'
       aria-modal='true'>
       <div
@@ -99,17 +101,28 @@ export function JobDrawer({
               key={op.id}
               id={`job-op-${op.id}`}
               tabIndex={-1}>
-              <span>{op.id}</span>
+              <span
+                className='truncate'
+                title={op.id}>
+                {op.id}
+              </span>
               <span>{op.status}</span>
               {op.status === 'failed' && (
                 <>
-                  <button>Retry</button>
-                  <button>Details</button>
+                  <Button variant='tertiary'>Retry</Button>
+                  <Button variant='ghost'>Details</Button>
                 </>
               )}
             </li>
           ))}
       </ul>
-    </div>
+      <div className='buttons'>
+        <Button
+          variant='tertiary'
+          onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </aside>
   );
 }

--- a/web/client/src/components/SyncStatusBar.tsx
+++ b/web/client/src/components/SyncStatusBar.tsx
@@ -27,11 +27,11 @@ export function SyncStatusBar(): JSX.Element {
     }): void => {
       setQueue(data.queue_length);
       const lowest = Math.min(...Object.values(data.bucket_fill));
-      setBackoffSeconds(null);
       if (lowest <= 0) {
         setState('rateLimited');
         return;
       }
+      setBackoffSeconds(null);
       if (lowest <= NEAR_LIMIT_THRESHOLD) {
         setState('nearLimit');
         return;
@@ -67,13 +67,29 @@ export function SyncStatusBar(): JSX.Element {
     };
   }, [setBackoffSeconds, setQueue, setState]);
 
+  useEffect(() => {
+    if (state === 'rateLimited' && backoffSeconds === null) {
+      setBackoffSeconds(12);
+    } else if (state !== 'rateLimited') {
+      setBackoffSeconds(null);
+    }
+  }, [state, backoffSeconds, setBackoffSeconds]);
+
+  useEffect(() => {
+    if (backoffSeconds === null || backoffSeconds <= 0) {
+      return;
+    }
+    const id = setTimeout(() => setBackoffSeconds(backoffSeconds - 1), 1000);
+    return () => clearTimeout(id);
+  }, [backoffSeconds, setBackoffSeconds]);
+
   const remaining = queue + activeJobs;
   let content: JSX.Element | string;
 
   if (state === 'disconnected') {
     content = 'Disconnected';
   } else if (state === 'rateLimited') {
-    content = `Pausing for ${backoffSeconds ?? 0}s (auto-resume)`;
+    content = `Pausing (auto-resume in ${backoffSeconds ?? 0}s)`;
   } else if (state === 'nearLimit') {
     content = 'Slowing to avoid limits';
   } else if (remaining > 0) {

--- a/web/client/src/ui/components/Modal.tsx
+++ b/web/client/src/ui/components/Modal.tsx
@@ -102,8 +102,9 @@ export function Modal({
   // Close the modal when the backdrop is activated via mouse or keyboard
   return (
     <div className='custom-modal-container'>
-      <button
-        type='button'
+      <div
+        role='button'
+        tabIndex={0}
         aria-label='Close modal'
         data-testid='modal-backdrop'
         className='custom-modal-backdrop'

--- a/web/client/src/ui/components/Toast.tsx
+++ b/web/client/src/ui/components/Toast.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from './Button';
 
 /** A single toast notification. */
 export interface ToastOptions {
@@ -61,13 +62,14 @@ export const ToastContainer: React.FC = () => {
           )}
           <span>{t.message}</span>
           {t.action && (
-            <button
+            <Button
+              variant='tertiary'
               onClick={() => {
                 t.action?.callback();
                 remove(t.id);
               }}>
               {t.action.label}
-            </button>
+            </Button>
           )}
         </div>
       ))}

--- a/web/client/tests/sync-status-bar.test.tsx
+++ b/web/client/tests/sync-status-bar.test.tsx
@@ -55,14 +55,22 @@ describe('SyncStatusBar', () => {
   });
 
   test('shows rate limited when bucket empty', async () => {
+    vi.useFakeTimers();
     (apiFetch as unknown as vi.Mock).mockResolvedValue({
       ok: true,
       json: async () => ({ queue_length: 0, bucket_fill: { user: 0 } }),
     } as Response);
     render(<SyncStatusBar />);
     expect(
-      await screen.findByText('Pausing for 0s (auto-resume)'),
+      await screen.findByText('Pausing (auto-resume in 12s)'),
     ).toBeInTheDocument();
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(
+      await screen.findByText('Pausing (auto-resume in 11s)'),
+    ).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   test('shows disconnected on fetch error', async () => {


### PR DESCRIPTION
## Summary
- streamline diff and job drawers into scrollable single-column layout with sticky actions
- replace ad-hoc buttons and add truncation and responsive full-width behavior
- style sync status bar and show countdown when rate limited

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `npm run test --silent` *(fails: "miro is not defined", diffdrawer test warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1893bb678832b9e549b18e948161b