### PR TITLE
feat(core): expose limiter knobs

### DIFF
--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -86,12 +86,12 @@ class Settings(BaseSettings):
         description="Default timeout in seconds for outbound HTTP requests.",
     )
     bucket_reservoir: int = Field(
-        default=10,
+        default=1,
         alias="MIRO_BUCKET_RESERVOIR",
         description="Maximum number of tokens in the soft rate limiter.",
     )
     bucket_refresh_ms: int = Field(
-        default=1000,
+        default=600,
         alias="MIRO_BUCKET_REFRESH_MS",
         description="Interval in milliseconds for refilling the token bucket.",
     )


### PR DESCRIPTION
## Summary
- add config for token bucket reservoir and refresh interval

## Testing
- `poetry run pre-commit run --files src/miro_backend/core/config.py src/miro_backend/queue/provider.py`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a189647ca0832bad24b831d0c09b55