### PR TITLE
fix(db): mark foreign keys in jobs tables migration

### DIFF
--- a/src/miro_backend/db/migrations/versions/78b2ba4eb105_add_jobs_boards_shapes_tags.py
+++ b/src/miro_backend/db/migrations/versions/78b2ba4eb105_add_jobs_boards_shapes_tags.py
@@ -44,26 +44,19 @@ def upgrade() -> None:  # pragma: no cover - migration code
     op.create_table(
         "tags",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
-        sa.Column(
-            "board_id",
-            sa.Integer(),
-            sa.ForeignKey("boards.id", ondelete="CASCADE"),
-            nullable=False,
-        ),
+        sa.Column("board_id", sa.Integer(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
     )
     op.create_index(op.f("ix_tags_board_id"), "tags", ["board_id"], unique=False)
     op.create_index(op.f("ix_tags_name"), "tags", ["name"], unique=False)
+    op.create_foreign_key(
+        None, "tags", "boards", ["board_id"], ["id"], ondelete="CASCADE"
+    )
 
     op.create_table(
         "shapes",
-        sa.Column(
-            "board_id",
-            sa.String(),
-            sa.ForeignKey("boards.board_id", ondelete="CASCADE"),
-            primary_key=True,
-        ),
-        sa.Column("shape_id", sa.String(), primary_key=True),
+        sa.Column("board_id", sa.String(), nullable=False),
+        sa.Column("shape_id", sa.String(), nullable=False),
         sa.Column("payload", sa.JSON(), nullable=False),
         sa.Column(
             "updated_at",
@@ -71,6 +64,10 @@ def upgrade() -> None:  # pragma: no cover - migration code
             server_default=sa.func.now(),
             nullable=False,
         ),
+        sa.PrimaryKeyConstraint("board_id", "shape_id"),
+    )
+    op.create_foreign_key(
+        None, "shapes", "boards", ["board_id"], ["board_id"], ondelete="CASCADE"
     )
 
 


### PR DESCRIPTION
## Summary
- explicitly mark board relationships in migration for tags and shapes tables

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/db/migrations/versions/78b2ba4eb105_add_jobs_boards_shapes_tags.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1896fd0e4832b8d840beb6b83a468