### PR TITLE
feat(ui): add sticky actions container

### DIFF
--- a/web/client/src/ui/ScrollArea.tsx
+++ b/web/client/src/ui/ScrollArea.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * Provides a vertically scrollable region sized for panel layouts.
+ *
+ * Combine with {@link StickyActions} to keep primary controls visible while
+ * letting longer content flow beneath.
+ *
+ * @param children Elements to render inside the scroll area.
+ * @returns A flex container that scrolls its children vertically.
+ */
+export function ScrollArea({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-200)' }}>
+      {children}
+    </div>
+  );
+}

--- a/web/client/src/ui/StickyActions.tsx
+++ b/web/client/src/ui/StickyActions.tsx
@@ -21,8 +21,8 @@ export function StickyActions({
         position: 'sticky',
         bottom: 0,
         background: 'var(--mds-surface, #fff)',
-        paddingTop: 12,
-        paddingBottom: 12,
+        paddingTop: 'var(--space-200)',
+        paddingBottom: 'var(--space-200)',
       }}>
       {children}
     </div>

--- a/web/client/src/ui/StickyActions.tsx
+++ b/web/client/src/ui/StickyActions.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+/**
+ * Anchors action elements to the bottom of a panel while allowing
+ * surrounding content to scroll beneath.
+ *
+ * Place this inside {@link PanelShell} so primary controls remain visible in
+ * narrow panels.
+ *
+ * @param children React nodes to render inside the sticky container.
+ * @returns A container that keeps its children fixed to the panel bottom.
+ */
+export function StickyActions({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div
+      style={{
+        position: 'sticky',
+        bottom: 0,
+        background: 'var(--mds-surface, #fff)',
+        paddingTop: 12,
+        paddingBottom: 12,
+      }}>
+      {children}
+    </div>
+  );
+}

--- a/web/client/tests/scroll-area.test.tsx
+++ b/web/client/tests/scroll-area.test.tsx
@@ -1,0 +1,21 @@
+/** @vitest-environment jsdom */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { ScrollArea } from '../src/ui/ScrollArea';
+
+describe('ScrollArea', () => {
+  it('enables vertical scrolling with padding', () => {
+    const { container } = render(
+      <ScrollArea>
+        <div>Content</div>
+      </ScrollArea>,
+    );
+    const wrapper = container.firstChild as HTMLDivElement;
+    expect(wrapper).toHaveStyle({
+      flex: '1',
+      overflowY: 'auto',
+      padding: 'var(--space-200)',
+    });
+  });
+});

--- a/web/client/tests/sticky-actions.test.tsx
+++ b/web/client/tests/sticky-actions.test.tsx
@@ -1,0 +1,23 @@
+/** @vitest-environment jsdom */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { StickyActions } from '../src/ui/StickyActions';
+
+describe('StickyActions', () => {
+  it('positions actions at the bottom', () => {
+    const { container } = render(
+      <StickyActions>
+        <div>Save</div>
+      </StickyActions>,
+    );
+    const wrapper = container.firstChild as HTMLDivElement;
+    expect(wrapper).toHaveStyle({
+      position: 'sticky',
+      bottom: '0px',
+      background: 'var(--mds-surface, #fff)',
+      paddingTop: '12px',
+      paddingBottom: '12px',
+    });
+  });
+});

--- a/web/client/tests/sticky-actions.test.tsx
+++ b/web/client/tests/sticky-actions.test.tsx
@@ -16,8 +16,8 @@ describe('StickyActions', () => {
       position: 'sticky',
       bottom: '0px',
       background: 'var(--mds-surface, #fff)',
-      paddingTop: '12px',
-      paddingBottom: '12px',
+      paddingTop: 'var(--space-200)',
+      paddingBottom: 'var(--space-200)',
     });
   });
 });


### PR DESCRIPTION
## Summary
- keep panel action buttons visible with new StickyActions component
- cover sticky action styling with unit test

## Testing
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: `miro is not defined`)*
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a1c7f4b6c4832b81c2dba4dac8e660