### PR TITLE
refactor(ui): replace custom toast with design system callout

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -185,16 +185,6 @@ button:focus-visible {
   z-index: 1000;
 }
 
-.toast {
-  display: flex;
-  align-items: center;
-  gap: var(--space-100);
-  background: var(--colors-background-neutrals);
-  color: var(--primary-text-color);
-  border-radius: var(--radii-100);
-  padding: var(--space-xsmall) var(--space-small);
-}
-
 .toast-thumb {
   width: 24px;
   height: 24px;

--- a/web/client/src/ui/components/Toast.tsx
+++ b/web/client/src/ui/components/Toast.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Callout } from '@mirohq/design-system';
 import { Button } from './Button';
 
 /** A single toast notification. */
@@ -49,29 +50,33 @@ export const ToastContainer: React.FC = () => {
   return (
     <div className='toast-container'>
       {toasts.map(t => (
-        <div
+        <Callout
           key={t.id}
-          className='toast'
-          role='alert'>
-          {t.thumbnailUrl && (
-            <img
-              className='toast-thumb'
-              src={t.thumbnailUrl}
-              alt=''
-            />
-          )}
-          <span>{t.message}</span>
+          role='alert'
+          dismissible={false}>
+          <Callout.Content>
+            {t.thumbnailUrl && (
+              <img
+                className='toast-thumb'
+                src={t.thumbnailUrl}
+                alt=''
+              />
+            )}
+            <Callout.Description>{t.message}</Callout.Description>
+          </Callout.Content>
           {t.action && (
-            <Button
-              variant='tertiary'
-              onClick={() => {
-                t.action?.callback();
-                remove(t.id);
-              }}>
-              {t.action.label}
-            </Button>
+            <Callout.Actions>
+              <Button
+                variant='tertiary'
+                onClick={() => {
+                  t.action?.callback();
+                  remove(t.id);
+                }}>
+                {t.action.label}
+              </Button>
+            </Callout.Actions>
           )}
-        </div>
+        </Callout>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- use design-system Callout for toast notifications
- remove legacy toast styles

## Testing
- `npm run stylelint --silent`
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm run test --silent` *(fails: "miro is not defined")*
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a1c7ce0b80832b8995ff55ce072dfd