### PR TITLE
refactor: centralize spacing tokens

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -1,3 +1,4 @@
+@import '../ui/tokens.css';
 @import '@mirohq/design-tokens/tokens.css';
 @import '@mirohq/design-system-themes/base.css';
 @import '@mirohq/design-system-themes/light.css';

--- a/web/client/src/components/DiffDrawer.tsx
+++ b/web/client/src/components/DiffDrawer.tsx
@@ -49,7 +49,7 @@ export function DiffDrawer<T extends { id?: string }>({
       ref={trapRef}
       role='dialog'
       aria-modal='true'>
-      <h2>Pending changes</h2>
+      <h2 className='h2'>Pending changes</h2>
       <ul>
         {diff.creates.map((c, i) => (
           <li key={`c${i}`}>

--- a/web/client/src/ui/components/Checkbox.tsx
+++ b/web/client/src/ui/components/Checkbox.tsx
@@ -20,7 +20,7 @@ export type CheckboxProps = Readonly<
  * It exposes a boolean `value` prop and triggers `onChange` when toggled.
  */
 const StyledGroup = styled(Flex, {
-  marginBottom: '16px',
+  marginBottom: 'var(--space-200)',
   position: 'relative',
 });
 

--- a/web/client/src/ui/components/InputField.tsx
+++ b/web/client/src/ui/components/InputField.tsx
@@ -21,7 +21,7 @@ export type InputFieldProps = Readonly<
 
 /** Single component combining label and input control. */
 const StyledFormField = styled(Form.Field, {
-  marginBottom: '16px',
+  marginBottom: 'var(--space-200)',
   position: 'relative',
 });
 

--- a/web/client/src/ui/components/SelectField.tsx
+++ b/web/client/src/ui/components/SelectField.tsx
@@ -16,7 +16,7 @@ export type SelectFieldProps = Readonly<
 
 /** Single component combining label and select control. */
 const StyledFormField = styled(Form.Field, {
-  marginBottom: '16px',
+  marginBottom: 'var(--space-200)',
   position: 'relative',
 });
 

--- a/web/client/src/ui/tokens.css
+++ b/web/client/src/ui/tokens.css
@@ -1,0 +1,15 @@
+:root {
+  --space-100: 8px; /* base-8 rhythm */
+  --space-200: 16px;
+  --space-300: 24px;
+  --font-200: 14px; /* body */
+  --font-300: 16px; /* large body */
+  --radius-200: 8px;
+}
+
+.h2 {
+  font:
+    600 var(--font-300) / 1.3 system-ui,
+    sans-serif;
+  margin: var(--space-200) 0;
+}


### PR DESCRIPTION
## Summary
- centralize spacing via reusable design token shim
- replace hard-coded margins with spacing variables
- standardize section heading styling

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `npm run test --silent` *(fails: "miro is not defined")*


------
https://chatgpt.com/codex/tasks/task_e_68a1c806f214832bace909938824991f