### PR TITLE
feat(ui): standardize drawer sizing and labels

### DIFF
--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -68,7 +68,9 @@ function AppShell(): React.JSX.Element {
             {TAB_DATA.map(t => (
               <Tabs.Trigger
                 key={t[1]}
-                value={t[1]}>
+                value={t[1]}
+                className='truncate'
+                title={t[2]}>
                 {t[2]}
               </Tabs.Trigger>
             ))}

--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -48,6 +48,10 @@ body {
   padding: var(--space-200);
 }
 
+.drawer {
+  width: 320px;
+}
+
 .scrollable .buttons {
   position: sticky;
   bottom: 0;

--- a/web/client/src/components/DiffDrawer.tsx
+++ b/web/client/src/components/DiffDrawer.tsx
@@ -45,7 +45,7 @@ export function DiffDrawer<T extends { id?: string }>({
 
   return (
     <aside
-      className='diff-drawer scrollable'
+      className='drawer diff-drawer scrollable'
       ref={trapRef}
       role='dialog'
       aria-modal='true'>

--- a/web/client/src/components/JobDrawer.tsx
+++ b/web/client/src/components/JobDrawer.tsx
@@ -77,11 +77,12 @@ export function JobDrawer({
   return (
     <aside
       ref={trapRef}
-      className='scrollable'
+      className='drawer scrollable'
       role='dialog'
       aria-modal='true'>
       <div
         aria-live='polite'
+        role='status'
         className='custom-visually-hidden'>
         {announcement}
       </div>

--- a/web/client/src/ui/components/Modal.tsx
+++ b/web/client/src/ui/components/Modal.tsx
@@ -17,8 +17,8 @@ export interface ModalProps {
 /**
  * Accessible modal dialog with focus trap and Escape key handling.
  *
- * Uses the native `<dialog>` element which has an implicit
- * `dialog` role, so no explicit ARIA role is set.
+ * Uses the native `<dialog>` element and sets an explicit
+ * `dialog` role for assistive technologies.
  */
 export function Modal({
   title,
@@ -124,6 +124,7 @@ export function Modal({
         }}
       />
       <dialog
+        role='dialog'
         open
         aria-label={title}
         aria-modal='true'


### PR DESCRIPTION
## Summary
- set drawers to 320dp width and expose polite status updates
- truncate tab labels with tooltips
- declare explicit dialog role for modal dialogs

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `npm run test --silent` *(fails: Failed to resolve import "../../../templates/connectorTemplates.json"; many Vitest failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c8153c88832b8a5f41f7b34a9129