### PR TITLE
feat(sync): add compact progress skeleton and status copy

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -46,6 +46,7 @@ body {
   flex: 1;
   overflow-y: auto;
   padding: var(--space-200);
+  position: relative;
 }
 
 .scrollable .buttons {
@@ -230,7 +231,7 @@ button:focus-visible {
 }
 
 .sync-status-bar {
-  position: fixed;
+  position: absolute;
   bottom: var(--space-100);
   right: var(--space-100);
   padding: var(--space-100) var(--space-150);
@@ -239,4 +240,11 @@ button:focus-visible {
   border-radius: var(--radii-100);
   box-shadow: var(--shadows-100);
   font-size: var(--fontSize-200);
+}
+
+.sync-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radii-100);
+  margin-bottom: var(--space-100);
 }

--- a/web/client/src/components/SyncStatusBar.tsx
+++ b/web/client/src/components/SyncStatusBar.tsx
@@ -85,24 +85,22 @@ export function SyncStatusBar(): JSX.Element {
 
   const remaining = queue + activeJobs;
   let content: JSX.Element | string;
+  let progress: JSX.Element | null = null;
 
   if (state === 'disconnected') {
     content = 'Disconnected';
   } else if (state === 'rateLimited') {
-    content = `Pausing (auto-resume in ${backoffSeconds ?? 0}s)`;
+    content = `Paused for ${backoffSeconds ?? 0}s (auto-resume)`;
   } else if (state === 'nearLimit') {
     content = 'Slowing to avoid limits';
   } else if (remaining > 0) {
-    content = (
-      <span>
-        <span
-          role='img'
-          aria-label='loading'>
-          ⏳
-        </span>{' '}
-        {remaining} items remaining
-      </span>
+    progress = (
+      <div
+        data-testid='sync-progress'
+        className='skeleton sync-progress'
+      />
     );
+    content = `Syncing ${remaining} changes…`;
   } else {
     content = 'All changes saved';
   }
@@ -111,6 +109,7 @@ export function SyncStatusBar(): JSX.Element {
     <div
       className='sync-status-bar'
       role='status'>
+      {progress}
       {content}
     </div>
   );

--- a/web/client/tests/sync-status-bar.test.tsx
+++ b/web/client/tests/sync-status-bar.test.tsx
@@ -39,7 +39,8 @@ describe('SyncStatusBar', () => {
       json: async () => ({ queue_length: 2, bucket_fill: { user: 100 } }),
     } as Response);
     render(<SyncStatusBar />);
-    expect(await screen.findByText('2 items remaining')).toBeInTheDocument();
+    expect(await screen.findByText('Syncing 2 changes…')).toBeInTheDocument();
+    expect(screen.getByTestId('sync-progress')).toBeInTheDocument();
   });
 
   test('shows near limit warning', async () => {
@@ -64,13 +65,13 @@ describe('SyncStatusBar', () => {
     } as Response);
     render(<SyncStatusBar />);
     expect(
-      await screen.findByText('Pausing (auto-resume in 12s)'),
+      await screen.findByText('Paused for 12s (auto-resume)'),
     ).toBeInTheDocument();
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });
     expect(
-      await screen.findByText('Pausing (auto-resume in 11s)'),
+      await screen.findByText('Paused for 11s (auto-resume)'),
     ).toBeInTheDocument();
     vi.useRealTimers();
   });
@@ -90,7 +91,7 @@ describe('SyncStatusBar', () => {
     await act(async () => {
       useSyncStore.getState().setQueue(1);
     });
-    expect(await screen.findByText('1 items remaining')).toBeInTheDocument();
+    expect(await screen.findByText('Syncing 1 changes…')).toBeInTheDocument();
     await act(async () => {
       useSyncStore.getState().setQueue(0);
     });


### PR DESCRIPTION
## Summary
- add progress skeleton and updated copy for sync statuses
- anchor sync bar within panel bounds
- test sync status messages and progress indicator

## Testing
- `npm --prefix web/client install`
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `npm --prefix web/client run test --silent` *(failed: Tag client and toast tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c82059f0832bb93880ebf40debdd