### PR TITLE
fix: guard against missing Miro SDK

### DIFF
--- a/web/client/src/main.tsx
+++ b/web/client/src/main.tsx
@@ -7,13 +7,15 @@ import { App } from './app/App';
 
 const lightThemeClassName = createTheme(themes.light);
 
+const isInMiro = typeof window !== 'undefined' && (window as any).miro;
+if (!isInMiro) {
+  console.warn('Miro SDK not found; open inside a Miro board.');
+}
+
 const container = document.getElementById('root');
 if (container) {
   container.classList += lightThemeClassName;
   const root = createRoot(container);
-  root.render(
-    <MiroProvider>
-      <App />
-    </MiroProvider>,
-  );
+  const app = <App />;
+  root.render(isInMiro ? <MiroProvider>{app}</MiroProvider> : app);
 }

--- a/web/client/tests/main-runtime-guard.test.tsx
+++ b/web/client/tests/main-runtime-guard.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+vi.mock('../src/app/App', () => ({ App: () => <div data-testid='app' /> }));
+
+vi.mock('@mirohq/websdk-react-hooks', () => ({
+  MiroProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='miro-provider'>{children}</div>
+  ),
+}));
+
+describe('main entrypoint', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+    // ensure no Miro SDK
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).miro;
+  });
+
+  test('warns and skips provider when Miro SDK absent', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await import('../src/main');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Miro SDK not found; open inside a Miro board.',
+    );
+    expect(document.querySelector('[data-testid="miro-provider"]')).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  test('uses provider when Miro SDK present', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).miro = {};
+    await import('../src/main');
+    expect(
+      document.querySelector('[data-testid="miro-provider"]'),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- wrap application rendering with a runtime check for the Miro SDK
- warn and skip MiroProvider when loaded outside a board
- add unit tests for main entrypoint guard

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` (fails: Failed to resolve import "../../../templates/connectorTemplates.json" from "src/board/templates.ts", etc.)
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`
- `poetry run pre-commit run --files web/client/src/main.tsx web/client/tests/main-runtime-guard.test.tsx` (fails: Command not found: pre-commit)


------
https://chatgpt.com/codex/tasks/task_e_68a1c82ec8fc832bba269e84b95254f9