### PR TITLE
refactor(ui): replace custom buttons and toolbars with design system components

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -48,35 +48,11 @@ body {
   padding: var(--space-200);
 }
 
-.scrollable .buttons {
+.scrollable .toolbar {
   position: sticky;
   bottom: 0;
   padding-block: var(--space-200);
   background: #fff;
-}
-
-.buttons {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-100);
-}
-
-@media (width >= 480px) {
-  .buttons {
-    flex-direction: row;
-  }
-  .buttons button {
-    width: auto;
-  }
-}
-
-.buttons button {
-  width: 100%;
-}
-
-button:focus-visible {
-  outline: 2px solid var(--accent-color);
-  outline-offset: 2px;
 }
 
 .custom-dropped-files {
@@ -142,7 +118,7 @@ button:focus-visible {
   background: var(--colors-background-neutrals);
   color: var(--primary-text-color);
   padding: var(--space-medium);
-  max-width: 400px;
+  max-width: 320px;
 }
 
 .custom-modal-small {
@@ -150,7 +126,7 @@ button:focus-visible {
 }
 
 .custom-modal-medium {
-  width: 400px;
+  width: 320px;
 }
 
 .custom-modal-header {

--- a/web/client/src/components/DiffDrawer.tsx
+++ b/web/client/src/components/DiffDrawer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button } from '../ui/components/Button';
+import { ButtonToolbar } from '../ui/components/ButtonToolbar';
 import { ShapeClient } from '../core/utils/shape-client';
 import { useFocusTrap } from '../core/hooks/useFocusTrap';
 import type { DiffResult } from '../board/computeDiff';
@@ -82,7 +83,7 @@ export function DiffDrawer<T extends { id?: string }>({
           </li>
         ))}
       </ul>
-      <div className='buttons'>
+      <ButtonToolbar className='toolbar'>
         <Button
           variant='tertiary'
           onClick={onClose}>
@@ -94,7 +95,7 @@ export function DiffDrawer<T extends { id?: string }>({
           title={total === 0 ? 'No changes' : undefined}>
           {`Apply ${total} changes`}
         </Button>
-      </div>
+      </ButtonToolbar>
     </aside>
   );
 }

--- a/web/client/src/components/JobDrawer.tsx
+++ b/web/client/src/components/JobDrawer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useJob } from '../core/hooks/useJob';
 import { useFocusTrap } from '../core/hooks/useFocusTrap';
-import { Button, Checkbox } from '../ui/components';
+import { Button, ButtonToolbar, Checkbox } from '../ui/components';
 
 interface JobDrawerProps {
   /** Identifier of the job to display. */
@@ -113,13 +113,13 @@ export function JobDrawer({
             </li>
           ))}
       </ul>
-      <div className='buttons'>
+      <ButtonToolbar className='toolbar'>
         <Button
           variant='tertiary'
           onClick={onClose}>
           Close
         </Button>
-      </div>
+      </ButtonToolbar>
     </aside>
   );
 }

--- a/web/client/src/ui/components/Button.tsx
+++ b/web/client/src/ui/components/Button.tsx
@@ -1,4 +1,4 @@
-import { Button as DSButton, styled } from '@mirohq/design-system';
+import { Button as DSButton } from '@mirohq/design-system';
 import { CSS } from '@stitches/react';
 import React from 'react';
 
@@ -24,10 +24,6 @@ export type ButtonProps = Readonly<
     css?: CSS;
   }
 >;
-
-const baseMargin = { margin: '0 var(--space-small) var(--space-small) 0' };
-
-const StyledDSButton = styled(DSButton, baseMargin);
 
 function getIconSlots(
   icon: React.ReactNode,
@@ -69,7 +65,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const { start, end } = getIconSlots(icon, iconPosition);
 
     return (
-      <StyledDSButton
+      <DSButton
         ref={ref}
         variant={variant}
         size={finalSize}
@@ -78,7 +74,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {start}
         <DSButton.Label>{children}</DSButton.Label>
         {end}
-      </StyledDSButton>
+      </DSButton>
     );
   },
 );

--- a/web/client/src/ui/components/ButtonToolbar.tsx
+++ b/web/client/src/ui/components/ButtonToolbar.tsx
@@ -1,0 +1,31 @@
+import { Toolbar } from '@mirohq/design-system';
+import React from 'react';
+
+export interface ButtonToolbarProps {
+  /** Optional className for container styling. */
+  className?: string;
+  /** Buttons to display inside the toolbar. */
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps design-system Toolbar to arrange buttons consistently.
+ */
+export function ButtonToolbar({
+  className,
+  children,
+}: ButtonToolbarProps): React.JSX.Element {
+  return (
+    <Toolbar
+      className={className}
+      orientation='vertical'>
+      {React.Children.map(children, (child, index) => (
+        <Toolbar.Item
+          asChild
+          key={index}>
+          {child as React.ReactElement}
+        </Toolbar.Item>
+      ))}
+    </Toolbar>
+  );
+}

--- a/web/client/src/ui/components/InputField.tsx
+++ b/web/client/src/ui/components/InputField.tsx
@@ -1,4 +1,4 @@
-import { Form, Input, styled } from '@mirohq/design-system';
+import { Form, Input } from '@mirohq/design-system';
 import React from 'react';
 
 export type InputFieldProps = Readonly<
@@ -20,17 +20,6 @@ export type InputFieldProps = Readonly<
 // and typography remain consistent across the app.
 
 /** Single component combining label and input control. */
-const StyledFormField = styled(Form.Field, {
-  marginBottom: '16px',
-  position: 'relative',
-});
-
-const StyledLabel = styled(Form.Label, { marginBottom: 'var(--space-xsmall)' });
-
-const StyledInput = styled(Input, {
-  paddingLeft: 'var(--space-small)',
-  paddingRight: 'var(--space-small)',
-});
 
 export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
   function InputField({ label, onValueChange, id, ...props }, ref) {
@@ -44,15 +33,15 @@ export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
     };
 
     return (
-      <StyledFormField>
-        <StyledLabel htmlFor={inputId}>{label}</StyledLabel>
-        <StyledInput
+      <Form.Field>
+        <Form.Label htmlFor={inputId}>{label}</Form.Label>
+        <Input
           id={inputId}
           ref={ref}
           onChange={handleChange}
           {...restProps}
         />
-      </StyledFormField>
+      </Form.Field>
     );
   },
 );

--- a/web/client/src/ui/components/index.ts
+++ b/web/client/src/ui/components/index.ts
@@ -17,3 +17,4 @@ export { FilterDropdown } from './FilterDropdown';
 export { FormGroup } from './FormGroup';
 export { Tooltip } from './Tooltip';
 export { PageHelp } from './PageHelp';
+export { ButtonToolbar } from './ButtonToolbar';

--- a/web/client/src/ui/pages/ArrangeTab.tsx
+++ b/web/client/src/ui/pages/ArrangeTab.tsx
@@ -9,6 +9,7 @@ import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
 import {
   Button,
+  ButtonToolbar,
   Checkbox,
   InputField,
   SelectField,
@@ -118,7 +119,7 @@ export const ArrangeTab: React.FC = () => {
           </Grid.Item>
         )}
         <Grid.Item>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             <Button
               onClick={applyGrid}
               variant='primary'
@@ -126,7 +127,7 @@ export const ArrangeTab: React.FC = () => {
               icon={<IconGrid />}>
               <Text>Arrange Grid</Text>
             </Button>
-          </div>
+          </ButtonToolbar>
         </Grid.Item>
 
         <Grid.Item>
@@ -152,7 +153,7 @@ export const ArrangeTab: React.FC = () => {
               onValueChange={v => updateSpacing(v)}
               placeholder='Distance'
             />
-            <div className='buttons'>
+            <ButtonToolbar className='toolbar'>
               <Button
                 onClick={applySpacing}
                 variant='primary'
@@ -160,7 +161,7 @@ export const ArrangeTab: React.FC = () => {
                 icon={<IconChevronRightDouble />}>
                 <Text>Distribute</Text>
               </Button>
-            </div>
+            </ButtonToolbar>
           </div>
         </Grid.Item>
       </Grid>

--- a/web/client/src/ui/pages/CardsTab.tsx
+++ b/web/client/src/ui/pages/CardsTab.tsx
@@ -1,7 +1,7 @@
 import { Grid, IconArrowArcLeft, IconPlus, Text } from '@mirohq/design-system';
 import React from 'react';
 import { CardProcessor } from '../../board/card-processor';
-import { Button, Checkbox, InputField } from '../components';
+import { Button, ButtonToolbar, Checkbox, InputField } from '../components';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
@@ -94,7 +94,7 @@ export const CardsTab: React.FC = () => {
             </fieldset>
           </Grid.Item>
           <Grid.Item>
-            <div className='buttons'>
+            <ButtonToolbar className='toolbar'>
               <Button
                 onClick={handleCreate}
                 variant='primary'
@@ -102,13 +102,6 @@ export const CardsTab: React.FC = () => {
                 iconPosition='start'>
                 <Text>Create Cards</Text>
               </Button>
-              {progress > 0 && progress < 100 && (
-                <progress
-                  value={progress}
-                  max={100}
-                />
-              )}
-              {error && <p className='error'>{error}</p>}
               {showUndo && (
                 <Button
                   onClick={() =>
@@ -129,7 +122,14 @@ export const CardsTab: React.FC = () => {
                   <Text>Undo Last Import</Text>
                 </Button>
               )}
-            </div>
+            </ButtonToolbar>
+            {progress > 0 && progress < 100 && (
+              <progress
+                value={progress}
+                max={100}
+              />
+            )}
+            {error && <p className='error'>{error}</p>}
           </Grid.Item>
         </Grid>
       )}

--- a/web/client/src/ui/pages/ExcelTab.tsx
+++ b/web/client/src/ui/pages/ExcelTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../core/utils/excel-loader';
 import {
   Button,
+  ButtonToolbar,
   Checkbox,
   InputField,
   Paragraph,
@@ -521,7 +522,7 @@ function ExcelTabView({
               </li>
             ))}
           </ul>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             <Button
               onClick={handleCreate}
               variant='primary'
@@ -534,7 +535,7 @@ function ExcelTabView({
               variant='secondary'>
               Apply changes
             </Button>
-          </div>
+          </ButtonToolbar>
         </>
       )}
       <RowInspector

--- a/web/client/src/ui/pages/FramesTab.tsx
+++ b/web/client/src/ui/pages/FramesTab.tsx
@@ -10,7 +10,7 @@ import {
   lockSelectedFrames,
   renameSelectedFrames,
 } from '../../board/frame-tools';
-import { Button, InputField } from '../components';
+import { Button, ButtonToolbar, InputField } from '../components';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
@@ -38,7 +38,7 @@ export const FramesTab: React.FC = () => {
           />
         </Grid.Item>
         <Grid.Item>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             <Button
               onClick={rename}
               variant='primary'
@@ -46,13 +46,13 @@ export const FramesTab: React.FC = () => {
               icon={<IconPen />}>
               <Text>Rename Frames</Text>
             </Button>
-          </div>
+          </ButtonToolbar>
         </Grid.Item>
         <Grid.Item>
           <Heading level={2}>Lock Frames</Heading>
         </Grid.Item>
         <Grid.Item>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             <Button
               onClick={lock}
               variant='secondary'
@@ -60,7 +60,7 @@ export const FramesTab: React.FC = () => {
               icon={<IconLockClosed />}>
               <Text>Lock Selected</Text>
             </Button>
-          </div>
+          </ButtonToolbar>
         </Grid.Item>
       </Grid>
     </TabPanel>

--- a/web/client/src/ui/pages/ResizeTab.tsx
+++ b/web/client/src/ui/pages/ResizeTab.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../core/utils/unit-utils';
 import {
   Button,
+  ButtonToolbar,
   InputField,
   Paragraph,
   SelectField,
@@ -210,7 +211,7 @@ export const ResizeTab: React.FC = () => {
           </div>
         </Grid.Item>
       </Grid>
-      <div className='buttons'>
+      <ButtonToolbar className='toolbar'>
         <Button
           onClick={apply}
           variant='primary'
@@ -225,7 +226,7 @@ export const ResizeTab: React.FC = () => {
           icon={copiedSize ? <IconArrowArcLeft /> : <IconSquaresTwoOverlap />}>
           <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
         </Button>
-      </div>
+      </ButtonToolbar>
     </TabPanel>
   );
 };

--- a/web/client/src/ui/pages/SearchTab.tsx
+++ b/web/client/src/ui/pages/SearchTab.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { SearchOptions } from '../../board/search-tools';
 import {
   Button,
+  ButtonToolbar,
   FilterDropdown,
   InputField,
   Paragraph,
@@ -178,7 +179,7 @@ export const SearchTab: React.FC = () => {
           </Paragraph>
         </Grid.Item>
         <Grid.Item>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             <Button
               onClick={nextMatch}
               disabled={!results.length}
@@ -202,7 +203,7 @@ export const SearchTab: React.FC = () => {
               iconPosition='start'>
               <Text>Replace All</Text>
             </Button>
-          </div>
+          </ButtonToolbar>
         </Grid.Item>
       </Grid>
     </TabPanel>

--- a/web/client/src/ui/pages/StructuredTab.tsx
+++ b/web/client/src/ui/pages/StructuredTab.tsx
@@ -23,6 +23,7 @@ import {
 import { ASPECT_RATIOS, AspectRatioId } from '../../core/utils/aspect-ratio';
 import {
   Button,
+  ButtonToolbar,
   Checkbox,
   InputField,
   SelectField,
@@ -369,7 +370,7 @@ export const StructuredTab: React.FC = () => {
             </fieldset>
           </Grid.Item>
           <Grid.Item>
-            <div className='buttons'>
+            <ButtonToolbar className='toolbar'>
               <Button
                 onClick={handleCreate}
                 variant='primary'
@@ -377,13 +378,6 @@ export const StructuredTab: React.FC = () => {
                 icon={<IconPlus />}>
                 <Text>Create Diagram</Text>
               </Button>
-              {progress > 0 && progress < 100 && (
-                <progress
-                  value={progress}
-                  max={100}
-                />
-              )}
-              {error && <p className='error'>{error}</p>}
               {lastProc && (
                 <Button
                   onClick={() =>
@@ -395,7 +389,14 @@ export const StructuredTab: React.FC = () => {
                   <Text>Undo Last Import</Text>
                 </Button>
               )}
-            </div>
+            </ButtonToolbar>
+            {progress > 0 && progress < 100 && (
+              <progress
+                value={progress}
+                max={100}
+              />
+            )}
+            {error && <p className='error'>{error}</p>}
           </Grid.Item>
         </Grid>
       )}

--- a/web/client/src/ui/pages/StyleTab.tsx
+++ b/web/client/src/ui/pages/StyleTab.tsx
@@ -17,7 +17,7 @@ import {
   tweakOpacity,
 } from '../../board/style-tools';
 import { adjustColor } from '../../core/utils/color-utils';
-import { Button, InputField } from '../components';
+import { Button, ButtonToolbar, InputField } from '../components';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import { useSelection } from '../hooks/use-selection';
@@ -129,7 +129,7 @@ export const StyleTab: React.FC = () => {
           />
         </Grid.Item>
         <Grid.Item>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             <Button
               onClick={apply}
               type='button'
@@ -156,13 +156,13 @@ export const StyleTab: React.FC = () => {
               variant='ghost'>
               <Text>Copy Fill</Text>
             </Button>
-          </div>
+          </ButtonToolbar>
         </Grid.Item>
         <Grid.Item>
           <Heading level={2}>Style presets</Heading>
         </Grid.Item>
         <Grid.Item>
-          <div className='buttons'>
+          <ButtonToolbar className='toolbar'>
             {STYLE_PRESET_NAMES.map(name => {
               const preset = stylePresets[name];
               const style = presetStyle(preset);
@@ -185,7 +185,7 @@ export const StyleTab: React.FC = () => {
                 </Button>
               );
             })}
-          </div>
+          </ButtonToolbar>
         </Grid.Item>
       </Grid>
     </TabPanel>


### PR DESCRIPTION
## Summary
- remove bespoke button/input CSS and rely on design system
- consolidate button groups behind new design-system Toolbar wrapper
- drop panel width hacks over 320dp

## Testing
- `npm --prefix web/client run typecheck --silent`
- `npm --prefix web/client run test --silent` *(fails: SyncStatusBar tests timed out)*
- `npm --prefix web/client run lint --silent`
- `npm --prefix web/client run stylelint --silent`
- `npm --prefix web/client run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a1c83d19b4832b9ec647f1da6d6bad