### PR TITLE
refactor: migrate scrollable styles to components

### DIFF
--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -8,6 +8,7 @@ import { Paragraph } from '../ui/components/Paragraph';
 import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
 import { ToastContainer } from '../ui/components/Toast';
 import { PanelShell } from '../ui/PanelShell';
+import { ScrollArea } from '../ui/ScrollArea';
 
 import { type Tab, TAB_DATA } from '../ui/pages/tabs';
 
@@ -46,7 +47,7 @@ function AppShell(): React.JSX.Element {
   const CurrentComp = current[4];
 
   return (
-    <div className='scrollable'>
+    <ScrollArea>
       <ExcelDataProvider
         value={{
           rows,
@@ -85,7 +86,7 @@ function AppShell(): React.JSX.Element {
         />
         <ToastContainer />
       </ExcelDataProvider>
-    </div>
+    </ScrollArea>
   );
 }
 

--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -43,22 +43,8 @@ body {
   overflow: hidden;
 }
 
-.scrollable {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--space-200);
-  position: relative;
-}
-
 .drawer {
   width: 320px;
-}
-
-.scrollable .toolbar {
-  position: sticky;
-  bottom: 0;
-  padding-block: var(--space-200);
-  background: #fff;
 }
 
 .custom-dropped-files {

--- a/web/client/src/components/DiffDrawer.tsx
+++ b/web/client/src/components/DiffDrawer.tsx
@@ -4,6 +4,8 @@ import { ButtonToolbar } from '../ui/components/ButtonToolbar';
 import { ShapeClient } from '../core/utils/shape-client';
 import { useFocusTrap } from '../core/hooks/useFocusTrap';
 import type { DiffResult } from '../board/computeDiff';
+import { ScrollArea } from '../ui/ScrollArea';
+import { StickyActions } from '../ui/StickyActions';
 
 export interface DiffDrawerProps<T extends { id?: string }> {
   /** Identifier of the target board. */
@@ -46,56 +48,60 @@ export function DiffDrawer<T extends { id?: string }>({
 
   return (
     <aside
-      className='drawer diff-drawer scrollable'
+      className='drawer diff-drawer'
       ref={trapRef}
       role='dialog'
       aria-modal='true'>
-      <h2 className='h2'>Pending changes</h2>
-      <ul>
-        {diff.creates.map((c, i) => (
-          <li key={`c${i}`}>
-            <span className='diff-chip diff-create'>Create</span>
-            <span
-              className='truncate'
-              title={String((c as { id?: string }).id ?? i)}>
-              {(c as { id?: string }).id ?? i}
-            </span>
-          </li>
-        ))}
-        {diff.updates.map((u, i) => (
-          <li key={`u${i}`}>
-            <span className='diff-chip diff-update'>Update</span>
-            <span
-              className='truncate'
-              title={String((u as { id?: string }).id ?? i)}>
-              {(u as { id?: string }).id ?? i}
-            </span>
-          </li>
-        ))}
-        {diff.deletes.map((d, i) => (
-          <li key={`d${i}`}>
-            <span className='diff-chip diff-delete'>Delete</span>
-            <span
-              className='truncate'
-              title={String((d as { id?: string }).id ?? i)}>
-              {(d as { id?: string }).id ?? i}
-            </span>
-          </li>
-        ))}
-      </ul>
-      <ButtonToolbar className='toolbar'>
-        <Button
-          variant='tertiary'
-          onClick={onClose}>
-          Cancel
-        </Button>
-        <Button
-          onClick={() => void applyChanges()}
-          disabled={total === 0}
-          title={total === 0 ? 'No changes' : undefined}>
-          {`Apply ${total} changes`}
-        </Button>
-      </ButtonToolbar>
+      <ScrollArea>
+        <h2 className='h2'>Pending changes</h2>
+        <ul>
+          {diff.creates.map((c, i) => (
+            <li key={`c${i}`}>
+              <span className='diff-chip diff-create'>Create</span>
+              <span
+                className='truncate'
+                title={String((c as { id?: string }).id ?? i)}>
+                {(c as { id?: string }).id ?? i}
+              </span>
+            </li>
+          ))}
+          {diff.updates.map((u, i) => (
+            <li key={`u${i}`}>
+              <span className='diff-chip diff-update'>Update</span>
+              <span
+                className='truncate'
+                title={String((u as { id?: string }).id ?? i)}>
+                {(u as { id?: string }).id ?? i}
+              </span>
+            </li>
+          ))}
+          {diff.deletes.map((d, i) => (
+            <li key={`d${i}`}>
+              <span className='diff-chip diff-delete'>Delete</span>
+              <span
+                className='truncate'
+                title={String((d as { id?: string }).id ?? i)}>
+                {(d as { id?: string }).id ?? i}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <StickyActions>
+          <ButtonToolbar>
+            <Button
+              variant='tertiary'
+              onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void applyChanges()}
+              disabled={total === 0}
+              title={total === 0 ? 'No changes' : undefined}>
+              {`Apply ${total} changes`}
+            </Button>
+          </ButtonToolbar>
+        </StickyActions>
+      </ScrollArea>
     </aside>
   );
 }

--- a/web/client/src/components/JobDrawer.tsx
+++ b/web/client/src/components/JobDrawer.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useJob } from '../core/hooks/useJob';
 import { useFocusTrap } from '../core/hooks/useFocusTrap';
 import { Button, ButtonToolbar, Checkbox } from '../ui/components';
+import { ScrollArea } from '../ui/ScrollArea';
+import { StickyActions } from '../ui/StickyActions';
 
 interface JobDrawerProps {
   /** Identifier of the job to display. */
@@ -77,50 +79,54 @@ export function JobDrawer({
   return (
     <aside
       ref={trapRef}
-      className='drawer scrollable'
+      className='drawer'
       role='dialog'
       aria-modal='true'>
-      <div
-        aria-live='polite'
-        role='status'
-        className='custom-visually-hidden'>
-        {announcement}
-      </div>
-      <Checkbox
-        label='Close when done'
-        value={closeOnDone}
-        onChange={setCloseOnDone}
-      />
-      <ul>
-        {job?.operations
-          .filter(op => !hiddenOps.has(op.id))
-          .map(op => (
-            <li
-              key={op.id}
-              id={`job-op-${op.id}`}
-              tabIndex={-1}>
-              <span
-                className='truncate'
-                title={op.id}>
-                {op.id}
-              </span>
-              <span>{op.status}</span>
-              {op.status === 'failed' && (
-                <>
-                  <Button variant='tertiary'>Retry</Button>
-                  <Button variant='ghost'>Details</Button>
-                </>
-              )}
-            </li>
-          ))}
-      </ul>
-      <ButtonToolbar className='toolbar'>
-        <Button
-          variant='tertiary'
-          onClick={onClose}>
-          Close
-        </Button>
-      </ButtonToolbar>
+      <ScrollArea>
+        <div
+          aria-live='polite'
+          role='status'
+          className='custom-visually-hidden'>
+          {announcement}
+        </div>
+        <Checkbox
+          label='Close when done'
+          value={closeOnDone}
+          onChange={setCloseOnDone}
+        />
+        <ul>
+          {job?.operations
+            .filter(op => !hiddenOps.has(op.id))
+            .map(op => (
+              <li
+                key={op.id}
+                id={`job-op-${op.id}`}
+                tabIndex={-1}>
+                <span
+                  className='truncate'
+                  title={op.id}>
+                  {op.id}
+                </span>
+                <span>{op.status}</span>
+                {op.status === 'failed' && (
+                  <>
+                    <Button variant='tertiary'>Retry</Button>
+                    <Button variant='ghost'>Details</Button>
+                  </>
+                )}
+              </li>
+            ))}
+        </ul>
+        <StickyActions>
+          <ButtonToolbar>
+            <Button
+              variant='tertiary'
+              onClick={onClose}>
+              Close
+            </Button>
+          </ButtonToolbar>
+        </StickyActions>
+      </ScrollArea>
     </aside>
   );
 }

--- a/web/client/src/main.tsx
+++ b/web/client/src/main.tsx
@@ -7,8 +7,11 @@ import { App } from './app/App';
 
 const lightThemeClassName = createTheme(themes.light);
 
-const isInMiro = typeof window !== 'undefined' && (window as any).miro;
+const isInMiro =
+  typeof window !== 'undefined' &&
+  Boolean((window as Window & { miro?: unknown }).miro);
 if (!isInMiro) {
+  // eslint-disable-next-line no-console -- Surface configuration issues during development
   console.warn('Miro SDK not found; open inside a Miro board.');
 }
 

--- a/web/client/src/ui/components/InputField.tsx
+++ b/web/client/src/ui/components/InputField.tsx
@@ -19,19 +19,6 @@ export type InputFieldProps = Readonly<
 // Custom class names and inline styles are intentionally excluded so spacing
 // and typography remain consistent across the app.
 
-/** Single component combining label and input control. */
-const StyledFormField = styled(Form.Field, {
-  marginBottom: 'var(--space-200)',
-  position: 'relative',
-});
-
-const StyledLabel = styled(Form.Label, { marginBottom: 'var(--space-xsmall)' });
-
-const StyledInput = styled(Input, {
-  paddingLeft: 'var(--space-small)',
-  paddingRight: 'var(--space-small)',
-});
-
 export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
   function InputField({ label, onValueChange, id, ...props }, ref) {
     const generatedId = React.useId();

--- a/web/client/src/ui/components/IntroScreen.tsx
+++ b/web/client/src/ui/components/IntroScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import introText from '../intro.md?raw';
 import { Button } from './Button';
 import { Markdown } from './Markdown';
+import { ScrollArea } from '../ScrollArea';
 
 export interface IntroScreenProps {
   /** Called when the user chooses to start the app. */
@@ -16,17 +17,19 @@ export interface IntroScreenProps {
  */
 export function IntroScreen({ onStart }: IntroScreenProps): React.JSX.Element {
   return (
-    <div
-      className='intro-screen scrollable'
-      data-testid='intro-screen'>
-      <Markdown source={introText} />
-      <span className='custom-visually-hidden'>Welcome to Quick Tools</span>
-      <Button
-        variant='primary'
-        onClick={onStart}
-        data-testid='start-button'>
-        Start
-      </Button>
-    </div>
+    <ScrollArea>
+      <div
+        className='intro-screen'
+        data-testid='intro-screen'>
+        <Markdown source={introText} />
+        <span className='custom-visually-hidden'>Welcome to Quick Tools</span>
+        <Button
+          variant='primary'
+          onClick={onStart}
+          data-testid='start-button'>
+          Start
+        </Button>
+      </div>
+    </ScrollArea>
   );
 }

--- a/web/client/src/ui/pages/ArrangeTab.tsx
+++ b/web/client/src/ui/pages/ArrangeTab.tsx
@@ -18,6 +18,7 @@ import {
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
+import { StickyActions } from '../StickyActions';
 
 /**
  * Combines grid and spacing tools into a single sidebar tab.
@@ -119,15 +120,17 @@ export const ArrangeTab: React.FC = () => {
           </Grid.Item>
         )}
         <Grid.Item>
-          <ButtonToolbar className='toolbar'>
-            <Button
-              onClick={applyGrid}
-              variant='primary'
-              iconPosition='start'
-              icon={<IconGrid />}>
-              <Text>Arrange Grid</Text>
-            </Button>
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              <Button
+                onClick={applyGrid}
+                variant='primary'
+                iconPosition='start'
+                icon={<IconGrid />}>
+                <Text>Arrange Grid</Text>
+              </Button>
+            </ButtonToolbar>
+          </StickyActions>
         </Grid.Item>
 
         <Grid.Item>
@@ -153,15 +156,17 @@ export const ArrangeTab: React.FC = () => {
               onValueChange={v => updateSpacing(v)}
               placeholder='Distance'
             />
-            <ButtonToolbar className='toolbar'>
-              <Button
-                onClick={applySpacing}
-                variant='primary'
-                iconPosition='start'
-                icon={<IconChevronRightDouble />}>
-                <Text>Distribute</Text>
-              </Button>
-            </ButtonToolbar>
+            <StickyActions>
+              <ButtonToolbar>
+                <Button
+                  onClick={applySpacing}
+                  variant='primary'
+                  iconPosition='start'
+                  icon={<IconChevronRightDouble />}>
+                  <Text>Distribute</Text>
+                </Button>
+              </ButtonToolbar>
+            </StickyActions>
           </div>
         </Grid.Item>
       </Grid>

--- a/web/client/src/ui/pages/CardsTab.tsx
+++ b/web/client/src/ui/pages/CardsTab.tsx
@@ -2,6 +2,7 @@ import { Grid, IconArrowArcLeft, IconPlus, Text } from '@mirohq/design-system';
 import React from 'react';
 import { CardProcessor } from '../../board/card-processor';
 import { Button, ButtonToolbar, Checkbox, InputField } from '../components';
+import { StickyActions } from '../StickyActions';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
@@ -94,35 +95,37 @@ export const CardsTab: React.FC = () => {
             </fieldset>
           </Grid.Item>
           <Grid.Item>
-            <ButtonToolbar className='toolbar'>
-              <Button
-                onClick={handleCreate}
-                variant='primary'
-                icon={<IconPlus />}
-                iconPosition='start'>
-                <Text>Create Cards</Text>
-              </Button>
-              {showUndo && (
+            <StickyActions>
+              <ButtonToolbar>
                 <Button
-                  onClick={() =>
-                    undoLastImport(lastProc, () => setLastProc(undefined))
-                  }
-                  variant='secondary'>
-                  Undo import (⌘Z)
+                  onClick={handleCreate}
+                  variant='primary'
+                  icon={<IconPlus />}
+                  iconPosition='start'>
+                  <Text>Create Cards</Text>
                 </Button>
-              )}
-              {lastProc && (
-                <Button
-                  onClick={() =>
-                    undoLastImport(lastProc, () => setLastProc(undefined))
-                  }
-                  variant='secondary'
-                  iconPosition='start'
-                  icon={<IconArrowArcLeft />}>
-                  <Text>Undo Last Import</Text>
-                </Button>
-              )}
-            </ButtonToolbar>
+                {showUndo && (
+                  <Button
+                    onClick={() =>
+                      undoLastImport(lastProc, () => setLastProc(undefined))
+                    }
+                    variant='secondary'>
+                    Undo import (⌘Z)
+                  </Button>
+                )}
+                {lastProc && (
+                  <Button
+                    onClick={() =>
+                      undoLastImport(lastProc, () => setLastProc(undefined))
+                    }
+                    variant='secondary'
+                    iconPosition='start'
+                    icon={<IconArrowArcLeft />}>
+                    <Text>Undo Last Import</Text>
+                  </Button>
+                )}
+              </ButtonToolbar>
+            </StickyActions>
             {progress > 0 && progress < 100 && (
               <progress
                 value={progress}

--- a/web/client/src/ui/pages/ExcelTab.tsx
+++ b/web/client/src/ui/pages/ExcelTab.tsx
@@ -41,6 +41,7 @@ import {
 } from '../hooks/use-excel-handlers';
 import { useExcelSync } from '../hooks/use-excel-sync';
 import type { TabTuple } from './tab-definitions';
+import { StickyActions } from '../StickyActions';
 
 /**
  * Remote workbook loader with error handling.
@@ -522,20 +523,22 @@ function ExcelTabView({
               </li>
             ))}
           </ul>
-          <ButtonToolbar className='toolbar'>
-            <Button
-              onClick={handleCreate}
-              variant='primary'
-              iconPosition='start'
-              icon={<IconPlus />}>
-              <Text>Create Nodes</Text>
-            </Button>
-            <Button
-              onClick={handleApplyChanges}
-              variant='secondary'>
-              Apply changes
-            </Button>
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              <Button
+                onClick={handleCreate}
+                variant='primary'
+                iconPosition='start'
+                icon={<IconPlus />}>
+                <Text>Create Nodes</Text>
+              </Button>
+              <Button
+                onClick={handleApplyChanges}
+                variant='secondary'>
+                Apply changes
+              </Button>
+            </ButtonToolbar>
+          </StickyActions>
         </>
       )}
       <RowInspector

--- a/web/client/src/ui/pages/FramesTab.tsx
+++ b/web/client/src/ui/pages/FramesTab.tsx
@@ -11,6 +11,7 @@ import {
   renameSelectedFrames,
 } from '../../board/frame-tools';
 import { Button, ButtonToolbar, InputField } from '../components';
+import { StickyActions } from '../StickyActions';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
@@ -38,29 +39,33 @@ export const FramesTab: React.FC = () => {
           />
         </Grid.Item>
         <Grid.Item>
-          <ButtonToolbar className='toolbar'>
-            <Button
-              onClick={rename}
-              variant='primary'
-              iconPosition='start'
-              icon={<IconPen />}>
-              <Text>Rename Frames</Text>
-            </Button>
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              <Button
+                onClick={rename}
+                variant='primary'
+                iconPosition='start'
+                icon={<IconPen />}>
+                <Text>Rename Frames</Text>
+              </Button>
+            </ButtonToolbar>
+          </StickyActions>
         </Grid.Item>
         <Grid.Item>
           <Heading level={2}>Lock Frames</Heading>
         </Grid.Item>
         <Grid.Item>
-          <ButtonToolbar className='toolbar'>
-            <Button
-              onClick={lock}
-              variant='secondary'
-              iconPosition='start'
-              icon={<IconLockClosed />}>
-              <Text>Lock Selected</Text>
-            </Button>
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              <Button
+                onClick={lock}
+                variant='secondary'
+                iconPosition='start'
+                icon={<IconLockClosed />}>
+                <Text>Lock Selected</Text>
+              </Button>
+            </ButtonToolbar>
+          </StickyActions>
         </Grid.Item>
       </Grid>
     </TabPanel>

--- a/web/client/src/ui/pages/ResizeTab.tsx
+++ b/web/client/src/ui/pages/ResizeTab.tsx
@@ -35,6 +35,7 @@ import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import { useSelection } from '../hooks/use-selection';
 import type { TabTuple } from './tab-definitions';
+import { StickyActions } from '../StickyActions';
 
 /** Predefined button sizes used by the quick presets. */
 const PRESET_SIZES: Record<'S' | 'M' | 'L', Size> = {
@@ -211,22 +212,26 @@ export const ResizeTab: React.FC = () => {
           </div>
         </Grid.Item>
       </Grid>
-      <ButtonToolbar className='toolbar'>
-        <Button
-          onClick={apply}
-          variant='primary'
-          iconPosition='start'
-          icon={<IconChevronRightDouble />}>
-          <Text>Apply Size</Text>
-        </Button>
-        <Button
-          onClick={copiedSize ? resetCopy : copy}
-          variant='secondary'
-          iconPosition='start'
-          icon={copiedSize ? <IconArrowArcLeft /> : <IconSquaresTwoOverlap />}>
-          <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
-        </Button>
-      </ButtonToolbar>
+      <StickyActions>
+        <ButtonToolbar>
+          <Button
+            onClick={apply}
+            variant='primary'
+            iconPosition='start'
+            icon={<IconChevronRightDouble />}>
+            <Text>Apply Size</Text>
+          </Button>
+          <Button
+            onClick={copiedSize ? resetCopy : copy}
+            variant='secondary'
+            iconPosition='start'
+            icon={
+              copiedSize ? <IconArrowArcLeft /> : <IconSquaresTwoOverlap />
+            }>
+            <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
+          </Button>
+        </ButtonToolbar>
+      </StickyActions>
     </TabPanel>
   );
 };

--- a/web/client/src/ui/pages/SearchTab.tsx
+++ b/web/client/src/ui/pages/SearchTab.tsx
@@ -24,6 +24,7 @@ import {
   useReplaceCurrent,
 } from '../hooks/use-search-handlers';
 import type { TabTuple } from './tab-definitions';
+import { StickyActions } from '../StickyActions';
 
 /**
  * Sidebar tab providing board wide search and replace.
@@ -179,31 +180,33 @@ export const SearchTab: React.FC = () => {
           </Paragraph>
         </Grid.Item>
         <Grid.Item>
-          <ButtonToolbar className='toolbar'>
-            <Button
-              onClick={nextMatch}
-              disabled={!results.length}
-              variant='secondary'
-              icon={<IconChevronRight />}
-              iconPosition='start'>
-              <Text>Next</Text>
-            </Button>
-            <Button
-              onClick={replaceCurrent}
-              disabled={!results.length}
-              variant='secondary'
-              icon={<IconPen />}
-              iconPosition='start'>
-              <Text>Replace</Text>
-            </Button>
-            <Button
-              onClick={replaceAll}
-              variant='primary'
-              icon={<IconArrowRight />}
-              iconPosition='start'>
-              <Text>Replace All</Text>
-            </Button>
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              <Button
+                onClick={nextMatch}
+                disabled={!results.length}
+                variant='secondary'
+                icon={<IconChevronRight />}
+                iconPosition='start'>
+                <Text>Next</Text>
+              </Button>
+              <Button
+                onClick={replaceCurrent}
+                disabled={!results.length}
+                variant='secondary'
+                icon={<IconPen />}
+                iconPosition='start'>
+                <Text>Replace</Text>
+              </Button>
+              <Button
+                onClick={replaceAll}
+                variant='primary'
+                icon={<IconArrowRight />}
+                iconPosition='start'>
+                <Text>Replace All</Text>
+              </Button>
+            </ButtonToolbar>
+          </StickyActions>
         </Grid.Item>
       </Grid>
     </TabPanel>

--- a/web/client/src/ui/pages/StructuredTab.tsx
+++ b/web/client/src/ui/pages/StructuredTab.tsx
@@ -29,6 +29,7 @@ import {
   SelectField,
   SelectOption,
 } from '../components';
+import { StickyActions } from '../StickyActions';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
@@ -370,26 +371,28 @@ export const StructuredTab: React.FC = () => {
             </fieldset>
           </Grid.Item>
           <Grid.Item>
-            <ButtonToolbar className='toolbar'>
-              <Button
-                onClick={handleCreate}
-                variant='primary'
-                iconPosition='start'
-                icon={<IconPlus />}>
-                <Text>Create Diagram</Text>
-              </Button>
-              {lastProc && (
+            <StickyActions>
+              <ButtonToolbar>
                 <Button
-                  onClick={() =>
-                    undoLastImport(lastProc, () => setLastProc(undefined))
-                  }
-                  variant='secondary'
+                  onClick={handleCreate}
+                  variant='primary'
                   iconPosition='start'
-                  icon={<IconArrowArcLeft />}>
-                  <Text>Undo Last Import</Text>
+                  icon={<IconPlus />}>
+                  <Text>Create Diagram</Text>
                 </Button>
-              )}
-            </ButtonToolbar>
+                {lastProc && (
+                  <Button
+                    onClick={() =>
+                      undoLastImport(lastProc, () => setLastProc(undefined))
+                    }
+                    variant='secondary'
+                    iconPosition='start'
+                    icon={<IconArrowArcLeft />}>
+                    <Text>Undo Last Import</Text>
+                  </Button>
+                )}
+              </ButtonToolbar>
+            </StickyActions>
             {progress > 0 && progress < 100 && (
               <progress
                 value={progress}

--- a/web/client/src/ui/pages/StyleTab.tsx
+++ b/web/client/src/ui/pages/StyleTab.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../board/style-tools';
 import { adjustColor } from '../../core/utils/color-utils';
 import { Button, ButtonToolbar, InputField } from '../components';
+import { StickyActions } from '../StickyActions';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import { useSelection } from '../hooks/use-selection';
@@ -129,63 +130,67 @@ export const StyleTab: React.FC = () => {
           />
         </Grid.Item>
         <Grid.Item>
-          <ButtonToolbar className='toolbar'>
-            <Button
-              onClick={apply}
-              type='button'
-              variant='primary'
-              icon={<IconSlidersX />}
-              iconPosition='start'>
-              <Text>Apply</Text>
-            </Button>
-            <Button
-              onClick={applyOpacity}
-              type='button'
-              variant='secondary'>
-              <Text>Opacity</Text>
-            </Button>
-            <Button
-              onClick={applyBorder}
-              type='button'
-              variant='secondary'>
-              <Text>Border</Text>
-            </Button>
-            <Button
-              onClick={copyFill}
-              type='button'
-              variant='ghost'>
-              <Text>Copy Fill</Text>
-            </Button>
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              <Button
+                onClick={apply}
+                type='button'
+                variant='primary'
+                icon={<IconSlidersX />}
+                iconPosition='start'>
+                <Text>Apply</Text>
+              </Button>
+              <Button
+                onClick={applyOpacity}
+                type='button'
+                variant='secondary'>
+                <Text>Opacity</Text>
+              </Button>
+              <Button
+                onClick={applyBorder}
+                type='button'
+                variant='secondary'>
+                <Text>Border</Text>
+              </Button>
+              <Button
+                onClick={copyFill}
+                type='button'
+                variant='ghost'>
+                <Text>Copy Fill</Text>
+              </Button>
+            </ButtonToolbar>
+          </StickyActions>
         </Grid.Item>
         <Grid.Item>
           <Heading level={2}>Style presets</Heading>
         </Grid.Item>
         <Grid.Item>
-          <ButtonToolbar className='toolbar'>
-            {STYLE_PRESET_NAMES.map(name => {
-              const preset = stylePresets[name];
-              const style = presetStyle(preset);
-              return (
-                <Button
-                  key={name}
-                  onClick={() => applyStylePreset(preset)}
-                  type='button'
-                  variant='secondary'
-                  css={{
-                    color: style.color,
-                    backgroundColor: style.fillColor,
-                    borderColor: style.borderColor,
-                    borderWidth: style.borderWidth,
-                    borderStyle: 'solid',
-                    display: 'inline-block',
-                    padding: '0 4px',
-                  }}>
-                  {preset.label}
-                </Button>
-              );
-            })}
-          </ButtonToolbar>
+          <StickyActions>
+            <ButtonToolbar>
+              {STYLE_PRESET_NAMES.map(name => {
+                const preset = stylePresets[name];
+                const style = presetStyle(preset);
+                return (
+                  <Button
+                    key={name}
+                    onClick={() => applyStylePreset(preset)}
+                    type='button'
+                    variant='secondary'
+                    css={{
+                      color: style.color,
+                      backgroundColor: style.fillColor,
+                      borderColor: style.borderColor,
+                      borderWidth: style.borderWidth,
+                      borderStyle: 'solid',
+                      display: 'inline-block',
+                      padding: '0 4px',
+                    }}>
+                    {preset.label}
+                  </Button>
+                );
+              })}
+            </ButtonToolbar>
+          </StickyActions>
         </Grid.Item>
       </Grid>
     </TabPanel>


### PR DESCRIPTION
## Summary
- replace div.scrollable wrappers with ScrollArea
- migrate sticky toolbars to StickyActions across client pages
- drop obsolete scrollable CSS rules

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `npm run test --silent` *(fails: Error: Failed to resolve import "../../../templates/connectorTemplates.json" from "src/board/templates.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cd1d9f48832ba9960a91c0e256c1