### PR TITLE
fix(backend): redirect root to static index

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -9,7 +9,7 @@ from typing import AsyncIterator
 
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from typing import Awaitable, Callable
 from fastapi.staticfiles import StaticFiles
 
@@ -190,14 +190,12 @@ async def metrics() -> Response:
         )
 
 
-@app.get("/", response_class=HTMLResponse)  # type: ignore[misc]
-async def root() -> HTMLResponse:
+@app.get("/", response_class=RedirectResponse)  # type: ignore[misc]
+async def root() -> RedirectResponse:
     """Redirect browsers to the built front-end."""
     with logfire.span("root redirect"):
         logfire.info("redirecting to frontend")  # event for root redirect
-        return HTMLResponse(
-            '<script>window.location.href="/static/index.html"</script>'
-        )
+        return RedirectResponse(url="/static/index.html")
 
 
 @app.get("/health")  # type: ignore[misc]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -34,6 +34,6 @@ def test_root_redirect(tmp_path: Path) -> None:
     app_module = importlib.import_module("miro_backend.main")
     app_module.change_queue = ChangeQueue()  # type: ignore[attr-defined]
     with TestClient(app_module.app) as client:
-        response = client.get("/")
-        assert response.status_code == 200
-        assert "window.location.href" in response.text
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/static/index.html"


### PR DESCRIPTION
## Summary
- redirect root path to static index using FastAPI RedirectResponse
- update health test for redirect semantics

## Testing
- `poetry run pre-commit run black --files src/miro_backend/main.py tests/test_health.py`
- `poetry run pre-commit run ruff --files src/miro_backend/main.py tests/test_health.py`
- `poetry run pre-commit run mypy --files src/miro_backend/main.py tests/test_health.py`
- `poetry run pytest tests/test_health.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a1cf25e958832bb1fbbb9272f5145b