### PR TITLE
feat(app): add tooltips to tab labels

### DIFF
--- a/web/client/src/app/App.test.tsx
+++ b/web/client/src/app/App.test.tsx
@@ -1,11 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { App } from './App';
 
-describe('App boot', () => {
+describe('App', () => {
   it('renders without crashing', () => {
     const { container } = render(<App />);
     expect(container).toBeTruthy();
+  });
+
+  it('exposes full tab labels via aria-label', async () => {
+    render(<App />);
+    fireEvent.click(screen.getByTestId('start-button'));
+    const tabs = await screen.findAllByRole('tab');
+    const firstTab = tabs[0];
+    const label = firstTab.textContent?.trim();
+    expect(firstTab).toHaveAttribute('aria-label', label);
   });
 });

--- a/web/client/src/app/App.tsx
+++ b/web/client/src/app/App.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { ExcelRow } from '../core/utils/excel-loader';
 import { AuthBanner } from '../components/AuthBanner';
 import { SyncStatusBar } from '../components/SyncStatusBar';
-import { EditMetadataModal, IntroScreen } from '../ui/components';
+import { EditMetadataModal, IntroScreen, Tooltip } from '../ui/components';
 import { Paragraph } from '../ui/components/Paragraph';
 import { ExcelDataProvider } from '../ui/hooks/excel-data-context';
 import { ToastContainer } from '../ui/components/Toast';
@@ -70,9 +70,10 @@ function AppShell(): React.JSX.Element {
               <Tabs.Trigger
                 key={t[1]}
                 value={t[1]}
-                className='truncate'
-                title={t[2]}>
-                {t[2]}
+                aria-label={t[2]}>
+                <Tooltip content={t[2]}>
+                  <span className='truncate'>{t[2]}</span>
+                </Tooltip>
               </Tabs.Trigger>
             ))}
           </Tabs.List>


### PR DESCRIPTION
## Summary
- wrap tab triggers in tooltips and expose full names via aria-label
- verify tab labels remain accessible through new unit test

## Testing
- `npm --prefix web/client run typecheck`
- `npm --prefix web/client run lint`
- `npm --prefix web/client run stylelint`
- `npm --prefix web/client run prettier`
- `npm --prefix web/client run test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d0af2e5c832bb112cf1cf9e63c01