### PR TITLE
fix: log idempotency purge failures

### DIFF
--- a/src/miro_backend/services/idempotency.py
+++ b/src/miro_backend/services/idempotency.py
@@ -35,7 +35,13 @@ def purge_expired_idempotency(
                 delete(Idempotency).where(Idempotency.created_at < cutoff)
             )
             session.commit()
-        except OperationalError:
+        except OperationalError as exc:
+            logfire.warning(
+                "failed to purge expired idempotency rows",
+                ttl_seconds=int(ttl.total_seconds()),
+                session=str(session.bind),
+                error=exc,
+            )
             return 0
         return result.rowcount or 0
 


### PR DESCRIPTION
## Summary
- log OperationalError during idempotency purge with TTL and session context
- cover failure path with a new test

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/services/idempotency.py tests/test_idempotency_cleanup.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1cf305904832ba58f2dac7ed73112