### PR TITLE
feat: make idempotency cleanup interval configurable

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -17,6 +17,9 @@ MIRO_OAUTH_SCOPE="boards:read boards:write"
 # HTTP client timeout for calls to Miro in seconds
 MIRO_HTTP_TIMEOUT_SECONDS=10.0
 
+# Interval for cleaning expired idempotency records in seconds
+MIRO_IDEMPOTENCY_CLEANUP_SECONDS=86400
+
 # Optional base64-encoded 32-byte key for encrypting tokens
 MIRO_ENCRYPTION_KEY=
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -18,4 +18,5 @@ oauth_redirect_uri: https://example.com/oauth/callback
 logfire_service_name: miro-backend
 logfire_send_to_logfire: false
 http_timeout_seconds: 10.0  # HTTP client timeout for Miro API calls
+idempotency_cleanup_seconds: 86400  # Interval between idempotency cleanup runs
 encryption_key: ""  # Base64-encoded 32-byte key for encrypting tokens (optional)

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -95,6 +95,11 @@ class Settings(BaseSettings):
         alias="MIRO_BUCKET_REFRESH_MS",
         description="Interval in milliseconds for refilling the token bucket.",
     )
+    idempotency_cleanup_seconds: float = Field(
+        default=60 * 60 * 24,
+        alias="MIRO_IDEMPOTENCY_CLEANUP_SECONDS",
+        description="Interval in seconds between idempotency cleanup runs.",
+    )
 
     model_config = SettingsConfigDict(
         env_file="config/.env", extra="ignore", populate_by_name=True

--- a/src/miro_backend/services/idempotency.py
+++ b/src/miro_backend/services/idempotency.py
@@ -10,6 +10,7 @@ from sqlalchemy import delete
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 
+from ..core.config import settings
 from ..db.session import SessionLocal
 from ..models import Idempotency
 
@@ -48,7 +49,7 @@ async def cleanup_idempotency() -> None:
             deleted = await asyncio.to_thread(purge_expired_idempotency)
             if deleted:
                 logfire.info("removed stale idempotency rows", extra={"count": deleted})
-            await asyncio.sleep(60 * 60 * 24)
+            await asyncio.sleep(settings.idempotency_cleanup_seconds)
     except asyncio.CancelledError:
         logfire.info("idempotency cleanup stopped")
         raise

--- a/tests/test_config_idempotency_cleanup.py
+++ b/tests/test_config_idempotency_cleanup.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from miro_backend.core.config import Settings
+
+
+def test_idempotency_cleanup_seconds_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MIRO_IDEMPOTENCY_CLEANUP_SECONDS", raising=False)
+    settings = Settings()
+    assert settings.idempotency_cleanup_seconds == 60 * 60 * 24
+
+    monkeypatch.setenv("MIRO_IDEMPOTENCY_CLEANUP_SECONDS", "123")
+    settings = Settings()
+    assert settings.idempotency_cleanup_seconds == 123


### PR DESCRIPTION
## Summary
- add configurable `IDEMPOTENCY_CLEANUP_SECONDS` setting
- use configurable interval in idempotency cleanup task
- document new setting and cover with tests

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/core/config.py src/miro_backend/services/idempotency.py config/config.example.yaml config/.env.example tests/test_config_idempotency_cleanup.py`
- `poetry run pytest --no-cov tests/test_config_idempotency_cleanup.py tests/test_config.py tests/test_idempotency_cleanup.py tests/test_config_bucket_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1cf441fb8832baa23d76f0794f220