### PR TITLE
refactor(ui): use design-system components for styling

### DIFF
--- a/web/client/src/assets/style.css
+++ b/web/client/src/assets/style.css
@@ -3,26 +3,6 @@
 @import '@mirohq/design-system-themes/base.css';
 @import '@mirohq/design-system-themes/light.css';
 
-:root {
-  /* Design-system token variables */
-  --space-xxsmall: var(--space-50);
-  --space-xsmall: var(--space-100);
-  --space-small: var(--space-200);
-  --space-medium: var(--space-300);
-  --space-large: var(--space-400);
-  --space-xlarge: var(--space-500);
-  --indigoAlpha40: var(--colors-alpha-gray-400);
-  --accent-color: var(--colors-blue-700);
-  --green700: var(--colors-green-700);
-  --red700: var(--colors-red-700);
-  --red600: var(--colors-red-600);
-  --white: var(--white);
-  --black: var(--black);
-  --primary-text-color: var(--colors-gray-900);
-  --font-size-large: var(--fontSize-250);
-  --font-weight-bold: var(--font-weights-semibold);
-}
-
 *,
 *:before,
 *:after {
@@ -44,32 +24,7 @@ body {
 }
 
 .drawer {
-  width: 320px;
-}
-
-.custom-dropped-files {
-  list-style: none;
-  padding: var(--space-50) var(--space-100);
-  border: 3px dashed var(--colors-alpha-black-400);
-  max-height: 80px;
-  overflow-y: auto;
-  font-size: var(--font-size-200);
-}
-
-.custom-segment button + button {
-  margin-left: var(--space-50);
-}
-
-.custom-visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
+  width: var(--size-drawer);
 }
 
 .search-input {
@@ -80,67 +35,6 @@ body {
 
 .search-input input {
   flex: 1;
-}
-
-.custom-form-group-small {
-  margin-bottom: var(--space-small);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xsmall);
-}
-
-.custom-modal-container {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-}
-
-.custom-modal-backdrop {
-  position: absolute;
-  inset: 0;
-  background: var(--colors-background-alpha-neutrals-overlay-subtle);
-  border: none;
-}
-
-.custom-modal {
-  position: relative;
-  margin: auto;
-  border: none;
-  border-radius: var(--radii-100);
-  background: var(--colors-background-neutrals);
-  color: var(--primary-text-color);
-  padding: var(--space-medium);
-  max-width: 320px;
-}
-
-.custom-modal-small {
-  width: 300px;
-}
-
-.custom-modal-medium {
-  width: 320px;
-}
-
-.custom-modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--space-small);
-}
-
-.custom-modal-content {
-  overflow-y: auto;
-}
-
-.page-help {
-  position: absolute;
-  top: var(--space-100);
-  right: var(--space-100);
-}
-
-.skeleton {
-  background-color: var(--colors-gray-200);
-  color: transparent;
 }
 
 .toast-container {
@@ -154,8 +48,8 @@ body {
 }
 
 .toast-thumb {
-  width: 24px;
-  height: 24px;
+  width: var(--size-thumb);
+  height: var(--size-thumb);
   object-fit: cover;
   border-radius: var(--radii-50);
 }
@@ -185,23 +79,4 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.sync-status-bar {
-  position: absolute;
-  bottom: var(--space-100);
-  right: var(--space-100);
-  padding: var(--space-100) var(--space-150);
-  background: var(--colors-gray-900);
-  color: var(--colors-white);
-  border-radius: var(--radii-100);
-  box-shadow: var(--shadows-100);
-  font-size: var(--fontSize-200);
-}
-
-.sync-progress {
-  width: 100%;
-  height: 8px;
-  border-radius: var(--radii-100);
-  margin-bottom: var(--space-100);
 }

--- a/web/client/src/components/BoardLoader.tsx
+++ b/web/client/src/components/BoardLoader.tsx
@@ -1,6 +1,14 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '../core/utils/api-fetch';
 import { Button } from '../ui/components/Button';
+import { styled } from '@mirohq/design-system';
+
+const Skeleton = styled('div', {
+  backgroundColor: 'var(--colors-gray-200)',
+  color: 'transparent',
+  height: 'var(--space-250)',
+  marginBottom: 'var(--space-100)',
+});
 
 interface BoardLoaderProps {
   readonly boardId: string;
@@ -19,13 +27,7 @@ export function BoardLoader({ boardId }: BoardLoaderProps): JSX.Element {
   const [version, setVersion] = useState(0);
   const [loading, setLoading] = useState(true);
 
-  const SkeletonRow = (): JSX.Element => (
-    <div
-      data-testid='skeleton'
-      className='skeleton'
-      style={{ height: 20, marginBottom: 8 }}
-    />
-  );
+  const SkeletonRow = (): JSX.Element => <Skeleton data-testid='skeleton' />;
 
   const fetchShapes = useCallback(
     async (since: number): Promise<void> => {

--- a/web/client/src/components/JobDrawer.tsx
+++ b/web/client/src/components/JobDrawer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { useJob } from '../core/hooks/useJob';
 import { useFocusTrap } from '../core/hooks/useFocusTrap';
 import { Button, ButtonToolbar, Checkbox } from '../ui/components';
@@ -83,12 +84,13 @@ export function JobDrawer({
       role='dialog'
       aria-modal='true'>
       <ScrollArea>
-        <div
-          aria-live='polite'
-          role='status'
-          className='custom-visually-hidden'>
-          {announcement}
-        </div>
+        <VisuallyHidden asChild>
+          <div
+            aria-live='polite'
+            role='status'>
+            {announcement}
+          </div>
+        </VisuallyHidden>
         <Checkbox
           label='Close when done'
           value={closeOnDone}

--- a/web/client/src/components/SyncStatusBar.tsx
+++ b/web/client/src/components/SyncStatusBar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { styled } from '@mirohq/design-system';
 import { useSyncStore } from '../core/state/sync-store';
 import { apiFetch } from '../core/utils/api-fetch';
 
@@ -94,23 +95,36 @@ export function SyncStatusBar(): JSX.Element {
   } else if (state === 'nearLimit') {
     content = 'Slowing to avoid limits';
   } else if (remaining > 0) {
-    progress = (
-      <div
-        data-testid='sync-progress'
-        className='skeleton sync-progress'
-      />
-    );
+    progress = <Progress data-testid='sync-progress' />;
     content = `Syncing ${remaining} changes…`;
   } else {
     content = 'All changes saved';
   }
 
   return (
-    <div
-      className='sync-status-bar'
-      role='status'>
+    <StatusBar role='status'>
       {progress}
       {content}
-    </div>
+    </StatusBar>
   );
 }
+
+const StatusBar = styled('div', {
+  position: 'absolute',
+  bottom: 'var(--space-100)',
+  right: 'var(--space-100)',
+  padding: 'var(--space-100) var(--space-150)',
+  background: 'var(--colors-gray-900)',
+  color: 'var(--colors-white)',
+  borderRadius: 'var(--radii-100)',
+  boxShadow: 'var(--shadows-100)',
+  fontSize: 'var(--fontSize-200)',
+});
+
+const Progress = styled('div', {
+  width: '100%',
+  height: 'var(--space-100)',
+  borderRadius: 'var(--radii-100)',
+  marginBottom: 'var(--space-100)',
+  backgroundColor: 'var(--colors-gray-200)',
+});

--- a/web/client/src/ui/components/DroppedFileList.tsx
+++ b/web/client/src/ui/components/DroppedFileList.tsx
@@ -1,0 +1,14 @@
+import { styled } from '@mirohq/design-system';
+
+/**
+ * Scrollable list styling for dropped files.
+ */
+export const DroppedFileList = styled('ul', {
+  listStyle: 'none',
+  padding: 'var(--space-50) var(--space-100)',
+  border: 'var(--border-widths-md) dashed var(--colors-alpha-black-400)',
+  maxHeight: 'var(--size-dropped-files-max)',
+  overflowY: 'auto',
+  fontSize: 'var(--font-200)',
+  margin: 0,
+});

--- a/web/client/src/ui/components/FilterDropdown.tsx
+++ b/web/client/src/ui/components/FilterDropdown.tsx
@@ -1,4 +1,10 @@
-import { DropdownMenu, IconButton, IconFunnel } from '@mirohq/design-system';
+import {
+  DropdownMenu,
+  Flex,
+  IconButton,
+  IconFunnel,
+} from '@mirohq/design-system';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import React from 'react';
 import { InputField } from './InputField';
 
@@ -63,8 +69,13 @@ export function FilterDropdown({
           Whole word
         </DropdownMenu.SwitchItem>
         <DropdownMenu.Separator />
-        <div className='custom-form-group-small'>
-          <legend className='custom-visually-hidden'>Widget Types</legend>
+        <Flex
+          direction='column'
+          gap={100}
+          css={{ marginBottom: 'var(--space-200)' }}>
+          <VisuallyHidden asChild>
+            <legend>Widget Types</legend>
+          </VisuallyHidden>
           <div>
             {['shape', 'card', 'sticky_note', 'text'].map(t => (
               <DropdownMenu.CheckboxItem
@@ -75,7 +86,7 @@ export function FilterDropdown({
               </DropdownMenu.CheckboxItem>
             ))}
           </div>
-        </div>
+        </Flex>
         <InputField
           label='Tag IDs'
           value={tagIds}

--- a/web/client/src/ui/components/IntroScreen.tsx
+++ b/web/client/src/ui/components/IntroScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import introText from '../intro.md?raw';
 import { Button } from './Button';
 import { Markdown } from './Markdown';
@@ -22,7 +23,7 @@ export function IntroScreen({ onStart }: IntroScreenProps): React.JSX.Element {
         className='intro-screen'
         data-testid='intro-screen'>
         <Markdown source={introText} />
-        <span className='custom-visually-hidden'>Welcome to Quick Tools</span>
+        <VisuallyHidden>Welcome to Quick Tools</VisuallyHidden>
         <Button
           variant='primary'
           onClick={onStart}

--- a/web/client/src/ui/components/JsonDropZone.tsx
+++ b/web/client/src/ui/components/JsonDropZone.tsx
@@ -1,12 +1,9 @@
 import { IconSquareArrowIn, Text } from '@mirohq/design-system';
-import { space as dsSpace } from '@mirohq/design-tokens';
 import React from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { useDropzone } from 'react-dropzone';
 import { getDropzoneStyle } from '../hooks/ui-utils';
 import { Button } from './Button';
-
-// Provide semantic spacing aliases until the design tokens include them.
-const space = { ...dsSpace, small: dsSpace[200] } as const;
 
 export type JsonDropZoneProps = Readonly<{
   /** Callback invoked with selected files. */
@@ -47,35 +44,36 @@ export function JsonDropZone({
         aria-label='File drop area'
         aria-describedby='dropzone-instructions'>
         {/* hidden input ensures keyboard selection triggers the drop handler */}
-        <input
-          className='custom-visually-hidden'
-          data-testid='file-input'
-          onChange={onChange}
-          aria-label='JSON file input'
-          {...fileInputProps}
-        />
+        <VisuallyHidden asChild>
+          <input
+            data-testid='file-input'
+            onChange={onChange}
+            aria-label='JSON file input'
+            {...fileInputProps}
+          />
+        </VisuallyHidden>
         {dropzone.isDragAccept ? (
-          <p style={{ margin: space.small }}>Drop your JSON file here</p>
+          <p style={{ margin: 'var(--space-200)' }}>Drop your JSON file here</p>
         ) : (
-          <div style={{ padding: space[200] }}>
+          <div style={{ padding: 'var(--space-200)' }}>
             <Button
               variant='primary'
               iconPosition='start'
               icon={<IconSquareArrowIn />}>
               <Text>Select JSON file</Text>
             </Button>
-            <p style={{ marginTop: space.small }}>
+            <p style={{ marginTop: 'var(--space-200)' }}>
               Or drop your JSON file here
             </p>
           </div>
         )}
       </div>
-      <p
-        id='dropzone-instructions'
-        className='custom-visually-hidden'>
-        Press Enter to open the file picker or drop a JSON file on the area
-        above.
-      </p>
+      <VisuallyHidden asChild>
+        <p id='dropzone-instructions'>
+          Press Enter to open the file picker or drop a JSON file on the area
+          above.
+        </p>
+      </VisuallyHidden>
     </>
   );
 }

--- a/web/client/src/ui/components/Modal.tsx
+++ b/web/client/src/ui/components/Modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { styled } from '@mirohq/design-system';
 import { Button } from './Button';
 
 export interface ModalProps {
@@ -101,13 +102,12 @@ export function Modal({
 
   // Close the modal when the backdrop is activated via mouse or keyboard
   return (
-    <div className='custom-modal-container'>
-      <div
+    <Container>
+      <Backdrop
         role='button'
         tabIndex={0}
         aria-label='Close modal'
         data-testid='modal-backdrop'
-        className='custom-modal-backdrop'
         onClick={e => {
           if (e.target === e.currentTarget) {
             onClose();
@@ -123,14 +123,14 @@ export function Modal({
           }
         }}
       />
-      <dialog
+      <Dialog
         role='dialog'
         open
         aria-label={title}
         aria-modal='true'
-        className={`custom-modal custom-modal-${size}`}
-        ref={ref}>
-        <header className='custom-modal-header'>
+        ref={ref}
+        size={size}>
+        <Header>
           <h3>{title}</h3>
           <Button
             variant='secondary'
@@ -138,9 +138,44 @@ export function Modal({
             onClick={onClose}>
             ×
           </Button>
-        </header>
-        <div className='custom-modal-content'>{children}</div>
-      </dialog>
-    </div>
+        </Header>
+        <Content>{children}</Content>
+      </Dialog>
+    </Container>
   );
 }
+
+const Container = styled('div', { position: 'fixed', inset: 0, zIndex: 1000 });
+
+const Backdrop = styled('div', {
+  position: 'absolute',
+  inset: 0,
+  background: 'var(--colors-background-alpha-neutrals-overlay-subtle)',
+  border: 'none',
+});
+
+const Dialog = styled('dialog', {
+  position: 'relative',
+  margin: 'auto',
+  border: 'none',
+  borderRadius: 'var(--radii-100)',
+  background: 'var(--colors-background-neutrals)',
+  color: 'var(--primary-text-color)',
+  padding: 'var(--space-medium)',
+  maxWidth: 'var(--size-modal-medium)',
+  variants: {
+    size: {
+      small: { width: 'var(--size-modal-small)' },
+      medium: { width: 'var(--size-modal-medium)' },
+    },
+  },
+});
+
+const Header = styled('header', {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: 'var(--space-small)',
+});
+
+const Content = styled('div', { overflowY: 'auto' });

--- a/web/client/src/ui/components/PageHelp.tsx
+++ b/web/client/src/ui/components/PageHelp.tsx
@@ -1,4 +1,8 @@
-import { IconButton, IconQuestionMarkCircle } from '@mirohq/design-system';
+import {
+  IconButton,
+  IconQuestionMarkCircle,
+  styled,
+} from '@mirohq/design-system';
 import React from 'react';
 import { Tooltip } from './Tooltip';
 
@@ -13,14 +17,14 @@ export interface PageHelpProps {
  * Displays a question mark icon with a tooltip describing the page.
  *
  * Position this component inside a relatively positioned container so the icon
- * overlays the top-right corner via CSS class `page-help`.
+ * overlays the top-right corner.
  */
 export function PageHelp({
   content,
   ariaLabel = 'Help',
 }: PageHelpProps): React.JSX.Element {
   return (
-    <div className='page-help'>
+    <Container>
       <Tooltip
         content={content}
         side='left'
@@ -32,6 +36,12 @@ export function PageHelp({
           <IconQuestionMarkCircle />
         </IconButton>
       </Tooltip>
-    </div>
+    </Container>
   );
 }
+
+const Container = styled('div', {
+  position: 'absolute',
+  top: 'var(--space-100)',
+  right: 'var(--space-100)',
+});

--- a/web/client/src/ui/components/SegmentedControl.tsx
+++ b/web/client/src/ui/components/SegmentedControl.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Flex } from '@mirohq/design-system';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { Button } from './Button';
 
 export interface SegmentedOption {
@@ -21,8 +23,12 @@ export function SegmentedControl({
   options,
 }: SegmentedControlProps): React.JSX.Element {
   return (
-    <fieldset className='custom-segment'>
-      <legend className='custom-visually-hidden'>Layout type</legend>
+    <Flex
+      as='fieldset'
+      gap={50}>
+      <VisuallyHidden asChild>
+        <legend>Layout type</legend>
+      </VisuallyHidden>
       {options.map(opt => (
         <Button
           key={opt.value}
@@ -31,6 +37,6 @@ export function SegmentedControl({
           {opt.label}
         </Button>
       ))}
-    </fieldset>
+    </Flex>
   );
 }

--- a/web/client/src/ui/components/index.ts
+++ b/web/client/src/ui/components/index.ts
@@ -18,3 +18,4 @@ export { FormGroup } from './FormGroup';
 export { Tooltip } from './Tooltip';
 export { PageHelp } from './PageHelp';
 export { ButtonToolbar } from './ButtonToolbar';
+export { DroppedFileList } from './DroppedFileList';

--- a/web/client/src/ui/hooks/ui-utils.ts
+++ b/web/client/src/ui/hooks/ui-utils.ts
@@ -10,7 +10,7 @@ const dropzoneStyles = {
   flexDirection: 'column',
   justifyContent: 'center',
   textAlign: 'center',
-  border: `3px dashed ${colors['alpha-black-400']}`,
+  border: `var(--border-widths-md) dashed ${colors['alpha-black-400']}`,
   color: colors['gray-700'],
   fontWeight: fontWeights.semibold,
   fontSize: fontSizes[200],

--- a/web/client/src/ui/pages/ArrangeTab.tsx
+++ b/web/client/src/ui/pages/ArrangeTab.tsx
@@ -15,6 +15,7 @@ import {
   SelectField,
   SelectOption,
 } from '../components';
+import { Flex } from '@mirohq/design-system';
 import { PageHelp } from '../components/PageHelp';
 import { TabPanel } from '../components/TabPanel';
 import type { TabTuple } from './tab-definitions';
@@ -134,7 +135,10 @@ export const ArrangeTab: React.FC = () => {
         </Grid.Item>
 
         <Grid.Item>
-          <div className='custom-form-group-small'>
+          <Flex
+            direction='column'
+            gap={100}
+            css={{ marginBottom: 'var(--space-200)' }}>
             <SelectField
               label='Axis'
               value={spacing.axis}
@@ -167,7 +171,7 @@ export const ArrangeTab: React.FC = () => {
                 </Button>
               </ButtonToolbar>
             </StickyActions>
-          </div>
+          </Flex>
         </Grid.Item>
       </Grid>
     </TabPanel>

--- a/web/client/src/ui/pages/CardsTab.tsx
+++ b/web/client/src/ui/pages/CardsTab.tsx
@@ -1,7 +1,14 @@
 import { Grid, IconArrowArcLeft, IconPlus, Text } from '@mirohq/design-system';
 import React from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { CardProcessor } from '../../board/card-processor';
-import { Button, ButtonToolbar, Checkbox, InputField } from '../components';
+import {
+  Button,
+  ButtonToolbar,
+  Checkbox,
+  DroppedFileList,
+  InputField,
+} from '../components';
 import { StickyActions } from '../StickyActions';
 import { JsonDropZone } from '../components/JsonDropZone';
 import { PageHelp } from '../components/PageHelp';
@@ -70,15 +77,17 @@ export const CardsTab: React.FC = () => {
       {files.length > 0 && (
         <Grid columns={2}>
           <Grid.Item>
-            <ul className='custom-dropped-files'>
+            <DroppedFileList>
               {files.map(file => (
                 <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
               ))}
-            </ul>
+            </DroppedFileList>
           </Grid.Item>
           <Grid.Item>
             <fieldset>
-              <legend className='custom-visually-hidden'>Card options</legend>
+              <VisuallyHidden asChild>
+                <legend>Card options</legend>
+              </VisuallyHidden>
               <Checkbox
                 label='Wrap items in frame'
                 value={withFrame}

--- a/web/client/src/ui/pages/StructuredTab.tsx
+++ b/web/client/src/ui/pages/StructuredTab.tsx
@@ -1,6 +1,7 @@
 import { Grid, IconArrowArcLeft, IconPlus, Text } from '@mirohq/design-system';
 import { space } from '@mirohq/design-tokens';
 import React from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import {
   ExistingNodeMode,
   GraphProcessor,
@@ -25,6 +26,7 @@ import {
   Button,
   ButtonToolbar,
   Checkbox,
+  DroppedFileList,
   InputField,
   SelectField,
   SelectOption,
@@ -174,17 +176,17 @@ export const StructuredTab: React.FC = () => {
       {importQueue.length > 0 && (
         <Grid columns={2}>
           <Grid.Item>
-            <ul className='custom-dropped-files'>
+            <DroppedFileList>
               {importQueue.map(file => (
                 <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
               ))}
-            </ul>
+            </DroppedFileList>
           </Grid.Item>
           <Grid.Item>
             <fieldset>
-              <legend className='custom-visually-hidden'>
-                Diagram options
-              </legend>
+              <VisuallyHidden asChild>
+                <legend>Diagram options</legend>
+              </VisuallyHidden>
               <SelectField
                 label='Layout type'
                 value={layoutChoice}

--- a/web/client/src/ui/pages/StyleTab.tsx
+++ b/web/client/src/ui/pages/StyleTab.tsx
@@ -80,10 +80,10 @@ export const StyleTab: React.FC = () => {
               data-testid='adjust-preview'
               style={{
                 display: 'inline-block',
-                width: '24px',
-                height: '24px',
+                width: 'var(--size-thumb)',
+                height: 'var(--size-thumb)',
                 marginLeft: space[200],
-                border: `1px solid ${colors['gray-200']}`,
+                border: `var(--border-widths-sm) solid ${colors['gray-200']}`,
                 backgroundColor: preview,
               }}
             />
@@ -183,7 +183,7 @@ export const StyleTab: React.FC = () => {
                       borderWidth: style.borderWidth,
                       borderStyle: 'solid',
                       display: 'inline-block',
-                      padding: '0 4px',
+                      padding: `0 var(--space-50)`,
                     }}>
                     {preset.label}
                   </Button>

--- a/web/client/src/ui/tokens.css
+++ b/web/client/src/ui/tokens.css
@@ -1,10 +1,31 @@
 :root {
+  --space-xxsmall: var(--space-50);
+  --space-xsmall: var(--space-100);
+  --space-small: var(--space-200);
+  --space-medium: var(--space-300);
+  --space-large: var(--space-400);
+  --space-xlarge: var(--space-500);
   --space-100: 8px; /* base-8 rhythm */
   --space-200: 16px;
   --space-300: 24px;
   --font-200: 14px; /* body */
   --font-300: 16px; /* large body */
+  --font-size-large: var(--fontSize-250);
+  --font-weight-bold: var(--font-weights-semibold);
   --radius-200: 8px;
+  --indigoAlpha40: var(--colors-alpha-gray-400);
+  --accent-color: var(--colors-blue-700);
+  --green700: var(--colors-green-700);
+  --red700: var(--colors-red-700);
+  --red600: var(--colors-red-600);
+  --white: var(--white);
+  --black: var(--black);
+  --primary-text-color: var(--colors-gray-900);
+  --size-drawer: 320px;
+  --size-modal-small: 300px;
+  --size-modal-medium: 320px;
+  --size-thumb: 24px;
+  --size-dropped-files-max: 80px;
 }
 
 .h2 {

--- a/web/client/tests/json-dropzone.test.tsx
+++ b/web/client/tests/json-dropzone.test.tsx
@@ -8,7 +8,6 @@ test('invokes callback when file selected', async () => {
   const handle = vi.fn();
   render(<JsonDropZone onFiles={handle} />);
   const input = screen.getByTestId('file-input');
-  expect(input).toHaveClass('custom-visually-hidden');
   const file = new File(['{}'], 'test.json', { type: 'application/json' });
   await act(async () => fireEvent.change(input, { target: { files: [file] } }));
   expect(handle).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- replace custom utility classes with design-system components and VisuallyHidden wrappers
- centralize sizing tokens and remove bespoke CSS rules
- introduce DroppedFileList component for uploaded files

## Testing
- `npm run prettier --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run test --silent` *(fails: `miro is not defined` and modal role expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d3554318832b9ff7091ff8e8ee75