### PR TITLE
feat(queue): track completion and retries

### DIFF
--- a/tests/test_batch_idempotency.py
+++ b/tests/test_batch_idempotency.py
@@ -51,7 +51,8 @@ def test_post_batch_is_idempotent_across_reloads(
 
     async def drain(q: ChangeQueue) -> None:
         while not q._queue.empty():
-            await q.dequeue()
+            task = await q.dequeue()
+            await q.mark_task_succeeded(task)
 
     asyncio.run(drain(queue))
 

--- a/tests/test_change_queue_persistence.py
+++ b/tests/test_change_queue_persistence.py
@@ -18,7 +18,7 @@ from miro_backend.queue.tasks import CreateNode
 
 @pytest.mark.asyncio()  # type: ignore[misc]
 async def test_enqueue_dequeue_persists() -> None:
-    """Enqueue and dequeue should call persistence hooks."""
+    """Ensure persistence helpers are invoked for success."""
 
     persistence = mock.AsyncMock()
     persistence.load = mock.Mock(return_value=[])
@@ -29,6 +29,10 @@ async def test_enqueue_dequeue_persists() -> None:
     persistence.save.assert_awaited_once_with(task)
 
     await queue.dequeue()
+    persistence.delete.assert_not_called()
+
+    await queue.mark_task_succeeded(task)
+    persistence.mark_completed.assert_awaited_once_with(task)
     persistence.delete.assert_awaited_once_with(task)
 
 
@@ -50,6 +54,8 @@ async def test_tasks_survive_restart(tmp_path: Path) -> None:
     restored = ChangeQueue(persistence=persistence)
     loaded = await restored.dequeue()
     assert loaded == task
+
+    await restored.mark_task_succeeded(loaded)
 
     empty = ChangeQueue(persistence=persistence)
     assert empty._queue.empty()


### PR DESCRIPTION
## Summary
- avoid dropping tasks from persistence during dequeue
- track task status and retry attempts in queue persistence
- mark tasks succeeded or failed to manage persistence

## Testing
- `poetry run black src/miro_backend/queue/persistence.py src/miro_backend/queue/change_queue.py tests/test_change_queue_persistence.py tests/test_batch_idempotency.py`
- `poetry run ruff check src/miro_backend/queue/persistence.py src/miro_backend/queue/change_queue.py tests/test_change_queue_persistence.py tests/test_batch_idempotency.py`
- `poetry run pytest tests/test_change_queue_persistence.py tests/test_batch_idempotency.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a251641c64832b8fec442ca368b669