### PR TITLE
feat(queue): track task status

### DIFF
--- a/src/miro_backend/db/migrations/versions/a54a1dc7f72e_extend_queue_tasks.py
+++ b/src/miro_backend/db/migrations/versions/a54a1dc7f72e_extend_queue_tasks.py
@@ -1,0 +1,43 @@
+"""add status, claimed_at and attempts to queue tasks
+
+Revision ID: a54a1dc7f72e
+Revises: 78b2ba4eb105
+Create Date: 2025-08-17 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a54a1dc7f72e"
+down_revision: Union[str, Sequence[str], None] = "78b2ba4eb105"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:  # pragma: no cover - migration code
+    op.add_column(
+        "queue_tasks",
+        sa.Column("status", sa.String(), nullable=False, server_default="queued"),
+    )
+    op.add_column(
+        "queue_tasks",
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "queue_tasks",
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_index(
+        op.f("ix_queue_tasks_status"), "queue_tasks", ["status"], unique=False
+    )
+
+
+def downgrade() -> None:  # pragma: no cover - migration code
+    op.drop_index(op.f("ix_queue_tasks_status"), table_name="queue_tasks")
+    op.drop_column("queue_tasks", "attempts")
+    op.drop_column("queue_tasks", "claimed_at")
+    op.drop_column("queue_tasks", "status")

--- a/tests/test_change_queue_persistence.py
+++ b/tests/test_change_queue_persistence.py
@@ -21,6 +21,7 @@ async def test_enqueue_dequeue_persists() -> None:
     """Ensure persistence helpers are invoked for success."""
 
     persistence = mock.AsyncMock()
+    persistence.save = mock.AsyncMock(return_value=1)
     persistence.claim_next = mock.AsyncMock(return_value=None)
     queue = ChangeQueue(persistence=persistence)
     task = CreateNode(node_id="n1", data={}, user_id="u1")
@@ -33,8 +34,8 @@ async def test_enqueue_dequeue_persists() -> None:
     persistence.delete.assert_not_called()
 
     await queue.mark_task_succeeded(task)
-    persistence.mark_completed.assert_awaited_once_with(task)
-    persistence.delete.assert_awaited_once_with(task)
+    persistence.mark_completed.assert_awaited_once_with(1)
+    persistence.delete.assert_awaited_once_with(1)
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- track queue task status, claim time, and attempts
- atomically claim queued tasks by id
- migrate DB for new queue task fields

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/change_queue.py src/miro_backend/queue/persistence.py tests/test_change_queue_persistence.py src/miro_backend/db/migrations/versions/a54a1dc7f72e_extend_queue_tasks.py`
- `poetry run pytest tests/test_change_queue_persistence.py tests/test_batch_idempotency.py tests/test_idempotency_persistence.py` *(fails: Required test coverage of 96% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a287178604832b9ad8d51d217854af