### PR TITLE
fix(miro-client): parse http-date Retry-After

### DIFF
--- a/tests/test_miro_client_errors.py
+++ b/tests/test_miro_client_errors.py
@@ -1,8 +1,9 @@
-import pytest
 import httpx
+import pytest
+from datetime import datetime, timedelta, timezone
 
-from miro_backend.services.miro_client import MiroClient
 from miro_backend.services.errors import HttpError, RateLimitedError
+from miro_backend.services.miro_client import MiroClient
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
@@ -12,6 +13,28 @@ async def test_raise_for_status_rate_limited() -> None:
     with pytest.raises(RateLimitedError) as exc:
         client._raise_for_status(response)
     assert exc.value.retry_after == 1
+    assert exc.value.status == 429
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_raise_for_status_rate_limited_http_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = MiroClient()
+    fixed_now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:  # type: ignore[override]
+            return fixed_now
+
+    monkeypatch.setattr("miro_backend.services.miro_client.datetime", FixedDateTime)
+    retry_at = fixed_now + timedelta(seconds=5)
+    header = retry_at.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    response = httpx.Response(429, headers={"Retry-After": header})
+    with pytest.raises(RateLimitedError) as exc:
+        client._raise_for_status(response)
+    assert exc.value.retry_after == 5.0
     assert exc.value.status == 429
 
 


### PR DESCRIPTION
## Summary
- handle HTTP-date Retry-After headers and calculate delay in UTC
- test rate limit handling with HTTP-date headers

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/services/miro_client.py tests/test_miro_client_errors.py`
- `poetry run pytest -q` *(fails: KeyboardInterrupt, but shows 50 passed before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e4de4f64832bb75d9850dcc30b6c