### PR TITLE
refactor(miro): centralize http requests

### DIFF
--- a/tests/test_miro_client.py
+++ b/tests/test_miro_client.py
@@ -1,7 +1,7 @@
-import httpx
 from urllib.parse import parse_qsl
-from typing import Any, cast
+from typing import Any, Awaitable, Callable
 
+import httpx
 import pytest
 
 from miro_backend.core.config import settings
@@ -55,23 +55,7 @@ async def test_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
     async_client = httpx.AsyncClient(transport=transport)
     monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: async_client)
 
-    class TestClient(MiroClient):  # type: ignore[misc]
-        async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    "https://api.miro.com/v1/oauth/token",
-                    data={
-                        "grant_type": "refresh_token",
-                        "refresh_token": refresh_token,
-                        "client_id": settings.client_id,
-                        "client_secret": settings.client_secret.get_secret_value(),
-                    },
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                )
-                response.raise_for_status()
-                return cast(dict[str, Any], response.json())
-
-    client = TestClient()
+    client = MiroClient()
     res = await client.refresh_token("r")
 
     assert res == {"access_token": "a", "refresh_token": "b", "expires_in": 1}
@@ -81,3 +65,61 @@ async def test_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
         "client_id": settings.client_id,
         "client_secret": settings.client_secret.get_secret_value(),
     }
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+@pytest.mark.parametrize(  # type: ignore[misc]
+    ("caller", "method", "url"),
+    [
+        (lambda c: c.create_node("n", {}, "t"), "PUT", "/graph/nodes/n"),
+        (lambda c: c.update_card("c1", {}, "t"), "PATCH", "/cards/c1"),
+        (
+            lambda c: c.create_shape("b", "s", {}, "t"),
+            "PUT",
+            "/boards/b/shapes/s",
+        ),
+        (
+            lambda c: c.update_shape("b", "s", {}, "t"),
+            "PATCH",
+            "/boards/b/shapes/s",
+        ),
+        (lambda c: c.delete_shape("b", "s", "t"), "DELETE", "/boards/b/shapes/s"),
+        (
+            lambda c: c.exchange_code(
+                "code",
+                "redir",
+                "https://api.miro.com/v1/oauth/token",
+                "id",
+                "secret",
+                None,
+            ),
+            "POST",
+            "https://api.miro.com/v1/oauth/token",
+        ),
+        (
+            lambda c: c.refresh_token("r"),
+            "POST",
+            settings.oauth_token_url,
+        ),
+    ],
+)
+async def test_api_methods_delegate_to_request(
+    monkeypatch: pytest.MonkeyPatch,
+    caller: Callable[[MiroClient], Awaitable[Any]],
+    method: str,
+    url: str,
+) -> None:
+    client = MiroClient()
+    captured: dict[str, str] = {}
+
+    async def fake_request(
+        self: MiroClient, m: str, u: str, **kwargs: object
+    ) -> httpx.Response:
+        captured["method"] = m
+        captured["url"] = u
+        return httpx.Response(200, json={})
+
+    monkeypatch.setattr(MiroClient, "_request", fake_request)
+    await caller(client)
+    assert captured["method"] == method
+    assert captured["url"] == url


### PR DESCRIPTION
## Summary
- add _request helper to handle AsyncClient calls and translate errors
- refactor MiroClient API methods to use _request
- test RequestError handling and delegation through _request

## Testing
- `pre-commit run --files src/miro_backend/services/miro_client.py tests/test_miro_client.py tests/test_miro_client_errors.py` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest tests/test_miro_client.py tests/test_miro_client_errors.py -q` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_68a2f6662540832b9d1b6885ac0001d9