### PR TITLE
feat(token-service): serialize token refresh per user

### DIFF
--- a/src/miro_backend/services/token_service.py
+++ b/src/miro_backend/services/token_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
@@ -12,6 +13,7 @@ from .miro_client import MiroClient
 from . import crypto
 
 REFRESH_MARGIN = timedelta(seconds=30)
+_locks: dict[str, asyncio.Lock] = {}
 
 
 async def get_valid_access_token(
@@ -20,6 +22,7 @@ async def get_valid_access_token(
     """Return a valid access token for ``user_id``.
     Refreshes the token via ``client`` when the stored one is about to expire.
     The updated token information is persisted by committing ``session``.
+    Safe for concurrent calls; refreshes are synchronised per user.
 
     Args:
         session: Active database session.
@@ -32,26 +35,28 @@ async def get_valid_access_token(
     Raises:
         ValueError: If no user exists for ``user_id``.
     """
-    user = session.query(User).filter(User.user_id == user_id).one_or_none()
-    if user is None:
-        raise ValueError(f"Unknown user_id {user_id!r}")  # pragma: no cover
-    access = crypto.decrypt(user.access_token)
-    refresh = crypto.decrypt(user.refresh_token)
-    expires_at = (
-        user.expires_at
-        if user.expires_at.tzinfo is not None
-        else user.expires_at.replace(tzinfo=timezone.utc)
-    )
-    if expires_at - datetime.now(timezone.utc) > REFRESH_MARGIN:
-        return access
+    lock = _locks.setdefault(user_id, asyncio.Lock())
+    async with lock:
+        user = session.query(User).filter(User.user_id == user_id).one_or_none()
+        if user is None:
+            raise ValueError(f"Unknown user_id {user_id!r}")  # pragma: no cover
+        access = crypto.decrypt(user.access_token)
+        refresh = crypto.decrypt(user.refresh_token)
+        expires_at = (
+            user.expires_at
+            if user.expires_at.tzinfo is not None
+            else user.expires_at.replace(tzinfo=timezone.utc)
+        )
+        if expires_at - datetime.now(timezone.utc) > REFRESH_MARGIN:
+            return access
 
-    tokens = await client.refresh_token(refresh)
-    access_new = cast(str, tokens["access_token"])
-    user.access_token = crypto.encrypt(access_new)
-    if refresh_new := tokens.get("refresh_token"):
-        user.refresh_token = crypto.encrypt(refresh_new)
-    expires_in = int(tokens.get("expires_in", 0))
-    user.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
-    session.commit()
+        tokens = await client.refresh_token(refresh)
+        access_new = cast(str, tokens["access_token"])
+        user.access_token = crypto.encrypt(access_new)
+        if refresh_new := tokens.get("refresh_token"):
+            user.refresh_token = crypto.encrypt(refresh_new)
+        expires_in = int(tokens.get("expires_in", 0))
+        user.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+        session.commit()
 
-    return access_new
+        return access_new


### PR DESCRIPTION
## Summary
- guard token refresh with per-user asyncio lock
- test concurrent refresh calls invoke client once

## Testing
- `poetry run pre-commit run --files src/miro_backend/services/token_service.py tests/test_token_service.py` *(failed: KeyboardInterrupt)*
- `poetry run pytest tests/test_token_service.py::test_refresh_token_called_once_concurrently -q` *(failed: Coverage failure: total of 26 is less than fail-under=96)*

------
https://chatgpt.com/codex/tasks/task_e_68a2faa21a90832baca939157917623d