### PR TITLE
feat(queue): add DLQ and retry metrics

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -30,7 +30,11 @@ from .core.logging import configure_logging, setup_fastapi  # noqa: E402
 from .core.security import setup_security  # noqa: E402
 from .core.telemetry import setup_telemetry  # noqa: E402
 from .queue import get_change_queue  # noqa: E402
-from .queue.change_queue import change_queue_length  # noqa: E402
+from .queue.change_queue import (  # noqa: E402
+    change_queue_length,
+    task_dlq,
+    task_retries,
+)
 from .services.miro_client import MiroClient  # noqa: E402
 from .services.idempotency import cleanup_idempotency  # noqa: E402
 from .db.session import SessionLocal  # noqa: E402
@@ -178,6 +182,8 @@ app.include_router(jobs_router)
 
 instrumentator = Instrumentator().instrument(app)
 instrumentator.registry.register(change_queue_length)
+instrumentator.registry.register(task_retries)
+instrumentator.registry.register(task_dlq)
 
 
 @app.get("/metrics")  # type: ignore[misc]

--- a/src/miro_backend/queue/persistence.py
+++ b/src/miro_backend/queue/persistence.py
@@ -43,6 +43,17 @@ class QueuedTask(Base):
     attempts: Mapped[int] = mapped_column(Integer, default=0)
 
 
+class DeadLetterTask(Base):
+    """Persisted representation of tasks sent to the dead letter queue."""
+
+    __tablename__ = "dead_letter_tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    type: Mapped[str] = mapped_column(String, index=True)
+    payload: Mapped[str] = mapped_column(Text)
+    error: Mapped[str] = mapped_column(Text)
+
+
 class SqlAlchemyQueuePersistence:
     """Store queue state and idempotent responses in the main database."""
 

--- a/tests/integration/test_miro_client.py
+++ b/tests/integration/test_miro_client.py
@@ -51,6 +51,12 @@ class DummyAsyncClient:
         self.record["call"] = ("DELETE", url, headers, None)
         return httpx.Response(204)
 
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        """Dispatch generic request to verb-specific handlers."""
+
+        func = getattr(self, method.lower())
+        return await func(url, **kwargs)
+
 
 @pytest.mark.integration  # type: ignore[misc]
 @pytest.mark.asyncio  # type: ignore[misc]

--- a/tests/test_worker_dlq.py
+++ b/tests/test_worker_dlq.py
@@ -1,0 +1,85 @@
+"""Tests for DLQ and retry metrics in ChangeQueue worker."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+
+import httpx
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from miro_backend.db.session import Base
+from miro_backend.queue import ChangeQueue, CreateNode
+from miro_backend.queue.change_queue import task_dlq, task_retries
+from miro_backend.queue.persistence import DeadLetterTask, SqlAlchemyQueuePersistence
+
+
+class AlwaysFailClient:
+    """Client that always raises a retryable network error."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create_node(
+        self, node_id: str, data: dict[str, int], _token: str
+    ) -> None:
+        self.calls += 1
+        raise httpx.ReadTimeout("boom")
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_dlq_and_retry_metrics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Task failing all retries should land in DLQ and update metrics."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'tasks.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    persistence = SqlAlchemyQueuePersistence(Session)
+    queue = ChangeQueue(persistence=persistence)
+    client = AlwaysFailClient()
+
+    async def _token(*_: object) -> str:
+        return "t"
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(_: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.get_valid_access_token", _token
+    )
+    monkeypatch.setattr("miro_backend.queue.change_queue.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.random.uniform", lambda _a, _b: 0
+    )
+
+    task_retries.labels(type="CreateNode")._value.set(0)
+    task_dlq.labels(type="CreateNode")._value.set(0)
+
+    await queue.enqueue(CreateNode(node_id="n1", data={}, user_id="u1"))
+    worker = asyncio.create_task(queue.worker(Session(), client))
+    try:
+        while client.calls < 5:
+            await real_sleep(0)
+        for _ in range(10):
+            if not queue.persistence.load():
+                break
+            await real_sleep(0.01)
+    finally:
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+
+    assert client.calls == 5
+    assert task_retries.labels(type="CreateNode")._value.get() == 5
+    assert task_dlq.labels(type="CreateNode")._value.get() == 1
+    with Session() as s:
+        assert s.query(DeadLetterTask).count() == 1


### PR DESCRIPTION
## Summary
- persist tasks that exhaust retries to a dead letter table
- expose Prometheus counters for task retries and DLQ entries
- cover DLQ behaviour with tests

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/persistence.py src/miro_backend/queue/change_queue.py src/miro_backend/main.py tests/test_worker_dlq.py tests/integration/test_miro_client.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2ffc294ac832b909ce000e589e456