### PR TITLE
fix(crypto): validate key and allow rotation

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -45,6 +45,13 @@ change_queue = get_change_queue()
 # Configure structured logging and database instrumentation.
 configure_logging()
 
+# Validate encryption key at startup.
+try:
+    from .services import crypto as _crypto  # noqa: F401
+except ValueError as exc:
+    logfire.error("invalid encryption key", error=str(exc))
+    raise
+
 # Routers are imported after the queue to avoid circular dependencies.
 from .api.routers.auth import router as auth_router  # noqa: E402
 from .api.routers.batch import router as batch_router  # noqa: E402

--- a/tests/test_crypto_key_rotation.py
+++ b/tests/test_crypto_key_rotation.py
@@ -1,0 +1,22 @@
+from importlib import reload
+
+from cryptography.fernet import Fernet
+
+from miro_backend.core import config
+from miro_backend.services import crypto as crypto_module
+
+
+def test_multi_fernet_key_rotation() -> None:
+    new_key = Fernet.generate_key().decode()
+    old_key = Fernet.generate_key().decode()
+    config.settings.encryption_key = f"{new_key},{old_key}"
+    reload(crypto_module)
+    try:
+        old_cipher = Fernet(old_key)
+        token = old_cipher.encrypt(b"secret").decode()
+        assert crypto_module.decrypt(token) == "secret"
+        encrypted = crypto_module.encrypt("another")
+        assert Fernet(new_key).decrypt(encrypted.encode()).decode() == "another"
+    finally:
+        config.settings.encryption_key = None
+        reload(crypto_module)


### PR DESCRIPTION
## Summary
- support comma-separated keys for Fernet rotation
- validate encryption key at startup and log helpful error
- cover multi-key rotation with tests

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/services/crypto.py src/miro_backend/main.py tests/test_crypto_key_rotation.py`
- `poetry run pytest` *(fails: Duplicated timeseries and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3061ba8c0832b85b5736b56da20e6