### PR TITLE
fix(config): remove duplicate OAuth keys and clarify CORS

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -2,19 +2,14 @@
 # Copy to `config.yaml` and adjust values for your environment.
 database_url: sqlite:///./app.db
 cors_origins:
-  - "https://example.com"
+  - "https://example.com"  # Explicit origins; avoid "*" in production
 client_id: your-client-id
 client_secret: your-client-secret
-redirect_uri: http://localhost:8000/oauth/callback  # OAuth callback URL
-oauth_auth_base: https://miro.com  # Base URL for OAuth authorisation (optional)
-oauth_token_url: https://api.miro.com/v1/oauth/token  # OAuth token endpoint (optional)
-oauth_scope: "boards:read boards:write"  # Scopes requested during OAuth (optional)
 webhook_secret: change-me
-redirect_uri: https://example.com/oauth/callback
-oauth_auth_base: https://miro.com/oauth/authorize
-oauth_token_url: https://api.miro.com/v1/oauth/token
-oauth_scope: boards:read boards:write
-oauth_redirect_uri: https://example.com/oauth/callback
+oauth_auth_base: https://miro.com/oauth/authorize  # Base URL for OAuth authorisation
+oauth_token_url: https://api.miro.com/v1/oauth/token  # OAuth token endpoint
+oauth_scope: boards:read boards:write  # OAuth scopes requested
+oauth_redirect_uri: https://example.com/oauth/callback  # OAuth callback URL
 logfire_service_name: miro-backend
 logfire_send_to_logfire: false
 http_timeout_seconds: 10.0  # HTTP client timeout for Miro API calls


### PR DESCRIPTION
## Summary
- remove duplicated OAuth values in example config
- warn against wildcard CORS origins in example

## Testing
- `SKIP=pytest poetry run pre-commit run --files config/config.example.yaml`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a30632d1ac832b89452f5fae5c01db