### PR TITLE
fix(logs): cap log ingestion payload

### DIFF
--- a/src/miro_backend/api/routers/logs.py
+++ b/src/miro_backend/api/routers/logs.py
@@ -15,7 +15,7 @@ from ...services.log_repository import LogRepository, get_log_repository
 
 router = APIRouter(prefix="/api/logs", tags=["logs"])
 
-MAX_BATCH = 100
+MAX_LOG_ENTRIES = 1000
 
 
 @router.post("/", status_code=status.HTTP_202_ACCEPTED, response_class=Response)  # type: ignore[misc]
@@ -34,11 +34,13 @@ def capture_logs(
     """
 
     with logfire.span("capture logs"):
-        if len(entries) > MAX_BATCH:
+        if len(entries) > MAX_LOG_ENTRIES:
             logfire.warning(
                 "too many log entries", count=len(entries)
             )  # warn when batch exceeds limit
-            raise PayloadTooLargeError("too many log entries")
+            raise PayloadTooLargeError(
+                f"Maximum {MAX_LOG_ENTRIES} log entries per request"
+            )
 
         models = [
             LogEntry(

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -56,7 +56,7 @@ def test_capture_rejects_large_batch(client: TestClient) -> None:
             "level": "info",
             "message": "m",
         }
-    ] * 101
+    ] * 1001
 
     response = client.post("/api/logs", json=payload)
     assert response.status_code == 413


### PR DESCRIPTION
## Summary
- enforce maximum of 1000 log entries per ingestion request
- test oversized log batch rejection

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/logs.py tests/test_logs_controller.py`
- `poetry run pytest` *(fails: KeyboardInterrupt after tests completed; 51 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3060001e8832b8551cb58ac7f57f7