### PR TITLE
fix(config): align OAuth redirect env var

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -2,8 +2,11 @@ MIRO_CLIENT_ID=your-client-id
 MIRO_CLIENT_SECRET=your-client-secret
 MIRO_WEBHOOK_SECRET=change-me
 
+# Comma-separated list of allowed CORS origins
+MIRO_CORS_ORIGINS=https://example.com
+
 # OAuth redirect URL after user authorisation
-MIRO_REDIRECT_URI=http://localhost:8000/oauth/callback
+MIRO_OAUTH_REDIRECT_URI=http://localhost:8000/oauth/callback
 
 # Base URL for Miro's OAuth consent screen (optional)
 MIRO_OAUTH_AUTH_BASE=https://miro.com

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
         description="Space-separated list of OAuth scopes requested.",
     )
     oauth_redirect_uri: str = Field(
-        alias="MIRO_REDIRECT_URI",
+        alias="MIRO_OAUTH_REDIRECT_URI",
         description="Callback URL registered with Miro for OAuth redirects.",
     )
     encryption_key: str | None = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,4 @@ import os
 os.environ["MIRO_CLIENT_ID"] = "test-client-id"
 os.environ["MIRO_CLIENT_SECRET"] = "test-client-secret"
 os.environ["MIRO_WEBHOOK_SECRET"] = "test-webhook-secret"
-os.environ["MIRO_REDIRECT_URI"] = "http://redirect"
+os.environ["MIRO_OAUTH_REDIRECT_URI"] = "http://redirect"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ def test_defaults_used_when_no_overrides(
     monkeypatch.setenv("MIRO_CLIENT_ID", "id")
     monkeypatch.setenv("MIRO_CLIENT_SECRET", "secret")
     monkeypatch.setenv("MIRO_WEBHOOK_SECRET", "hook")
-    monkeypatch.setenv("MIRO_REDIRECT_URI", "http://redirect")
+    monkeypatch.setenv("MIRO_OAUTH_REDIRECT_URI", "http://redirect")
 
     settings = Settings()
     assert settings.database_url == "sqlite:///./app.db"
@@ -91,7 +91,7 @@ def test_missing_redirect_uri_raises_error(
     """Unsetting redirect URI triggers a validation error."""
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("MIRO_REDIRECT_URI", raising=False)
+    monkeypatch.delenv("MIRO_OAUTH_REDIRECT_URI", raising=False)
     monkeypatch.setenv("MIRO_CONFIG_FILE", str(tmp_path / "missing.yaml"))
 
     with pytest.raises(ValidationError):


### PR DESCRIPTION
## Summary
- align redirect URI env var with other OAuth settings
- add explicit CORS origin in `.env.example`
- adjust tests for new env var

## Testing
- `SKIP=pytest poetry run pre-commit run --files config/.env.example src/miro_backend/core/config.py tests/conftest.py tests/test_config.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31f75c6fc832b9e23cf896dab28e7