### PR TITLE
Treat HTTP 409 conflicts as retryable writes

### DIFF
--- a/src/miro_backend/queue/change_queue.py
+++ b/src/miro_backend/queue/change_queue.py
@@ -255,7 +255,7 @@ class ChangeQueue:
                         )
                         retryable = (
                             network_error
-                            or status in {429}
+                            or status in {429, 409}
                             or (isinstance(status, int) and 500 <= status < 600)
                         )
                         if retryable:

--- a/tests/test_worker_retryable_http.py
+++ b/tests/test_worker_retryable_http.py
@@ -1,0 +1,103 @@
+"""Tests for retryable HTTP errors in ChangeQueue worker."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from miro_backend.queue import ChangeQueue, CreateNode
+from miro_backend.queue.change_queue import task_retries
+from miro_backend.services.errors import HttpError
+
+
+class ConflictOnceClient:
+    """Client that raises a conflict once before succeeding."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create_node(
+        self, node_id: str, data: dict[str, int], _token: str
+    ) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            raise HttpError(409)
+
+
+class BadRequestClient:
+    """Client that always raises a bad request error."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create_node(
+        self, node_id: str, data: dict[str, int], _token: str
+    ) -> None:
+        self.calls += 1
+        raise HttpError(400)
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_conflict_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP 409 errors should be retried."""
+
+    queue = ChangeQueue()
+    client = ConflictOnceClient()
+
+    async def _token(*_: object) -> str:
+        return "t"
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(_: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.get_valid_access_token", _token
+    )
+    monkeypatch.setattr("miro_backend.queue.change_queue.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.random.uniform", lambda _a, _b: 0
+    )
+
+    task_retries.labels(type="CreateNode")._value.set(0)
+
+    await queue.enqueue(CreateNode(node_id="n1", data={}, user_id="u1"))
+    worker = asyncio.create_task(queue.worker(object(), client))
+    try:
+        while client.calls < 2:
+            await real_sleep(0)
+    finally:
+        worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+
+    assert client.calls == 2
+    assert task_retries.labels(type="CreateNode")._value.get() == 1
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_bad_request_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP 400 errors should not be retried."""
+
+    queue = ChangeQueue()
+    client = BadRequestClient()
+
+    async def _token(*_: object) -> str:
+        return "t"
+
+    monkeypatch.setattr(
+        "miro_backend.queue.change_queue.get_valid_access_token", _token
+    )
+
+    task_retries.labels(type="CreateNode")._value.set(0)
+
+    await queue.enqueue(CreateNode(node_id="n1", data={}, user_id="u1"))
+    worker = asyncio.create_task(queue.worker(object(), client))
+    with pytest.raises(HttpError):
+        await worker
+
+    assert client.calls == 1
+    assert task_retries.labels(type="CreateNode")._value.get() == 0


### PR DESCRIPTION
## Summary
- allow ChangeQueue worker to retry 409 conflict responses
- test that conflicts are retried while other 4xx failures are not

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/change_queue.py tests/test_worker_retryable_http.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a3b7146c832b8e6f6cf5bc322c08