### PR TITLE
fix: forbid unexpected fields in input schemas

### DIFF
--- a/src/miro_backend/schemas/batch.py
+++ b/src/miro_backend/schemas/batch.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class CreateNodeOperation(BaseModel):
     """Request to create a new node on the board."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["create_node"] = Field(
         description="Discriminator for the operation type"
@@ -19,6 +21,8 @@ class CreateNodeOperation(BaseModel):
 
 class UpdateCardOperation(BaseModel):
     """Request to update an existing card."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: Literal["update_card"] = Field(
         description="Discriminator for the operation type"
@@ -34,6 +38,8 @@ Operation = Annotated[
 
 class BatchRequest(BaseModel):
     """Incoming batch of operations to process."""
+
+    model_config = ConfigDict(extra="forbid")
 
     operations: list[Operation]
 

--- a/src/miro_backend/schemas/card_create.py
+++ b/src/miro_backend/schemas/card_create.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ..queue import CreateNode, ChangeTask
 
 
 class CardCreate(BaseModel):
     """Data describing a card to be created on the board."""
+
+    model_config = ConfigDict(extra="forbid")
 
     id: str | None = None
     title: str

--- a/src/miro_backend/schemas/log_entry.py
+++ b/src/miro_backend/schemas/log_entry.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from html import escape
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 MAX_MESSAGE_LEN = 1024
 MAX_CONTEXT_ITEMS = 20
@@ -15,6 +15,8 @@ MAX_CONTEXT_VALUE_LEN = 1024
 
 class LogEntryIn(BaseModel):
     """Log entry received from the client application."""
+
+    model_config = ConfigDict(extra="forbid")
 
     timestamp: datetime
     level: str = Field(max_length=16)

--- a/src/miro_backend/schemas/shape.py
+++ b/src/miro_backend/schemas/shape.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ShapeBase(BaseModel):
     """Common attributes shared by all shape representations."""
+
+    model_config = ConfigDict(extra="forbid")
 
     content: str
 

--- a/src/miro_backend/schemas/webhook.py
+++ b/src/miro_backend/schemas/webhook.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class WebhookEvent(BaseModel):
     """Single event delivered by a webhook."""
+
+    model_config = ConfigDict(extra="forbid")
 
     event: str
     data: dict[str, Any]
@@ -16,5 +18,7 @@ class WebhookEvent(BaseModel):
 
 class WebhookPayload(BaseModel):
     """Overall payload sent by Miro containing one or more events."""
+
+    model_config = ConfigDict(extra="forbid")
 
     events: list[WebhookEvent]


### PR DESCRIPTION
## Summary
- reject unknown fields for batch requests and operations
- enforce extra=forbid on creation and webhook payload schemas
- tighten log entry input validation

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/schemas/batch.py src/miro_backend/schemas/card_create.py src/miro_backend/schemas/log_entry.py src/miro_backend/schemas/shape.py src/miro_backend/schemas/webhook.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3a7be58b8832bb5d1b005ac4f22b2