### PR TITLE
fix(db): load Alembic URL from environment

### DIFF
--- a/config/alembic.ini
+++ b/config/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = src/miro_backend/db/migrations
-sqlalchemy.url = sqlite:///./app.db
+sqlalchemy.url = %(DB_URL)s
 
 [loggers]
 keys = root,sqlalchemy,alembic


### PR DESCRIPTION
## Summary
- reference database URL via environment variable in Alembic config

## Testing
- `poetry run pre-commit run --files config/alembic.ini`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3be6ec448832b829a66b53fc39738