### PR TITLE
feat(queue): purge permanently failed tasks

### DIFF
--- a/tests/test_change_queue_persistence.py
+++ b/tests/test_change_queue_persistence.py
@@ -12,7 +12,10 @@ from sqlalchemy.orm import sessionmaker
 
 from miro_backend.db.session import Base
 from miro_backend.queue import ChangeQueue
-from miro_backend.queue.persistence import SqlAlchemyQueuePersistence
+from miro_backend.queue.persistence import (
+    SqlAlchemyQueuePersistence,
+    QueuedTask,
+)
 from miro_backend.queue.tasks import CreateNode
 
 
@@ -62,3 +65,24 @@ async def test_tasks_survive_restart(tmp_path: Path) -> None:
     empty = ChangeQueue(persistence=persistence)
     assert empty._queue.empty()
     assert await empty.persistence.claim_next() is None
+
+
+@pytest.mark.asyncio()  # type: ignore[misc]
+async def test_ack_failure_removes_task(tmp_path: Path) -> None:
+    """Failed tasks should be removed from persistence."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'tasks.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    persistence = SqlAlchemyQueuePersistence(Session)
+
+    queue = ChangeQueue(persistence=persistence)
+    task = CreateNode(node_id="n1", data={}, user_id="u1")
+    await queue.enqueue(task)
+
+    await queue.ack_task_failed(task)
+
+    with Session() as s:
+        assert s.query(QueuedTask).count() == 0


### PR DESCRIPTION
## Summary
- delete tasks from persistence when they fail permanently
- expose `ack_task_failed` helper on `ChangeQueue`
- cover permanent failure cleanup in tests

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/persistence.py src/miro_backend/queue/change_queue.py tests/test_change_queue_persistence.py tests/test_worker_persistence.py`
- `poetry run pytest tests/test_change_queue_persistence.py tests/test_worker_persistence.py --cov=src/miro_backend/queue --cov-report=term --cov-report=xml --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a3c2fce934832ba974dfa11d91d2a2