### PR TITLE
feat(logs): enforce payload size limits

### DIFF
--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -60,3 +60,17 @@ def test_capture_rejects_large_batch(client: TestClient) -> None:
 
     response = client.post("/api/logs", json=payload)
     assert response.status_code == 413
+
+
+def test_capture_rejects_large_payload(client: TestClient) -> None:
+    payload = [
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": "info",
+            "message": "m" * 1024,
+        }
+        for _ in range(1000)
+    ]
+
+    response = client.post("/api/logs", json=payload)
+    assert response.status_code == 413


### PR DESCRIPTION
## Summary
- add request body size validation to log ingestion endpoint
- test log API rejects oversized payloads

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/logs.py tests/test_logs_controller.py`
- `poetry run pytest --no-cov tests/test_logs_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a403274d54832b9f958a8c09715f2e