### PR TITLE
fix(schemas): forbid unknown fields

### DIFF
--- a/src/miro_backend/schemas/job.py
+++ b/src/miro_backend/schemas/job.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 class Job(BaseModel):
     """Representation of a background job."""
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
 
     id: str
     status: str

--- a/src/miro_backend/schemas/tag.py
+++ b/src/miro_backend/schemas/tag.py
@@ -10,4 +10,4 @@ class Tag(BaseModel):
     board_id: int
     name: str
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(extra="forbid", from_attributes=True)

--- a/src/miro_backend/schemas/user_info.py
+++ b/src/miro_backend/schemas/user_info.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class UserInfo(BaseModel):
@@ -15,3 +15,5 @@ class UserInfo(BaseModel):
     access_token: str
     refresh_token: str
     expires_at: datetime
+
+    model_config = ConfigDict(extra="forbid")

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,46 @@
+"""Ensure schemas reject unknown fields."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from miro_backend.schemas.tag import Tag
+from miro_backend.schemas.job import Job
+from miro_backend.schemas.user_info import UserInfo
+
+
+def test_tag_rejects_unknown_field() -> None:
+    """Tag should forbid unexpected attributes."""
+
+    with pytest.raises(ValidationError):
+        Tag(id=1, board_id=2, name="t", unknown="x")
+
+
+def test_job_rejects_unknown_field() -> None:
+    """Job should forbid unexpected attributes."""
+
+    with pytest.raises(ValidationError):
+        Job(
+            id="j1",
+            status="queued",
+            updated_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            results=None,
+            unknown="x",
+        )
+
+
+def test_user_info_rejects_unknown_field() -> None:
+    """UserInfo should forbid unexpected attributes."""
+
+    with pytest.raises(ValidationError):
+        UserInfo(
+            id="u1",
+            name="name",
+            access_token="a",
+            refresh_token="r",
+            expires_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            unknown="x",
+        )


### PR DESCRIPTION
## Summary
- enforce strict field validation for Tag, Job, and UserInfo schemas
- test that schemas reject unexpected attributes

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/schemas/tag.py src/miro_backend/schemas/job.py src/miro_backend/schemas/user_info.py tests/test_schema_validation.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a416bdaf58832bbfa2b8cc893e1c43