### PR TITLE
docs: clarify CORS origin configuration

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,8 +1,11 @@
 # Example configuration for the Miro backend service
 # Copy to `config.yaml` and adjust values for your environment.
 database_url: sqlite:///./app.db
-cors_origins:
-  - "https://example.com"  # Explicit origins; avoid "*" in production
+cors_origins:  # Allowed domains for cross-origin requests
+  - "https://app.example.com"
+  - "https://admin.example.com"
+  # - "https://*.example.org"  # Wildcard subdomains
+  # - "*"  # Allow all origins (development only; not for production)
 client_id: your-client-id
 client_secret: your-client-secret
 webhook_secret: change-me

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -40,3 +40,17 @@ Populate `config/.env` with values for:
 ### Continuous integration
 
 Provision the same variables through your CI secret store (e.g. GitHub Actions secrets) and expose them as environment variables at build and deploy time. Never commit real secret values to the repository.
+
+### CORS origins
+
+Configure Cross-Origin Resource Sharing in `config/config.yaml`:
+
+```yaml
+cors_origins:
+  - "https://app.example.com"
+  - "https://admin.example.com"
+  # - "https://*.example.org"  # Wildcard subdomains
+  # - "*"  # Allow all origins (development only; not for production)
+```
+
+List each allowed origin explicitly. Wildcards can match subdomains, but avoid using `"*"` in production to restrict cross-origin access.


### PR DESCRIPTION
## Summary
- document multi-origin, wildcard, and production guidance for `cors_origins` in sample config
- explain CORS origin configuration in deployment guide

## Testing
- `poetry run env SKIP=pytest pre-commit run --files config/config.example.yaml docs/DEPLOYMENT.md`
- `poetry run pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a4193c0604832ba1ab7e519a233834