### PR TITLE
fix(miro_client): reuse persistent async client

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -124,6 +124,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
             await worker
         with contextlib.suppress(asyncio.CancelledError):
             await cleanup_task
+        await client.aclose()
         session.close()
         logfire.info("change worker stopped")  # event for worker shutdown
         logfire.info("idempotency cleanup stopped")  # event for cleanup shutdown

--- a/tests/test_miro_client_errors.py
+++ b/tests/test_miro_client_errors.py
@@ -1,7 +1,6 @@
 import httpx
 import pytest
 from datetime import datetime, timedelta, timezone
-from types import TracebackType
 
 from miro_backend.services.errors import HttpError, RateLimitedError
 from miro_backend.services.miro_client import MiroClient
@@ -15,6 +14,7 @@ async def test_raise_for_status_rate_limited() -> None:
         client._raise_for_status(response)
     assert exc.value.retry_after == 1
     assert exc.value.status == 429
+    await client.aclose()
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
@@ -37,6 +37,7 @@ async def test_raise_for_status_rate_limited_http_date(
         client._raise_for_status(response)
     assert exc.value.retry_after == 5.0
     assert exc.value.status == 429
+    await client.aclose()
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
@@ -46,33 +47,21 @@ async def test_raise_for_status_server_error() -> None:
     with pytest.raises(HttpError) as exc:
         client._raise_for_status(response)
     assert exc.value.status == 503
+    await client.aclose()
 
 
 @pytest.mark.asyncio()  # type: ignore[misc]
 async def test_request_error_translated(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FailingAsyncClient:
-        async def __aenter__(self) -> "FailingAsyncClient":
-            return self
+    async def failing_request(
+        self: httpx.AsyncClient, method: str, url: str, **kwargs: object
+    ) -> httpx.Response:
+        raise httpx.RequestError(
+            "boom", request=httpx.Request(method, "https://example.org")
+        )
 
-        async def __aexit__(
-            self,
-            exc_type: type[BaseException] | None,
-            exc: BaseException | None,
-            tb: TracebackType | None,
-        ) -> None:
-            return None
-
-        async def request(
-            self, method: str, url: str, **kwargs: object
-        ) -> httpx.Response:
-            raise httpx.RequestError(
-                "boom", request=httpx.Request(method, "https://example.org")
-            )
-
-    monkeypatch.setattr(
-        httpx, "AsyncClient", lambda *args, **kwargs: FailingAsyncClient()
-    )
+    monkeypatch.setattr(httpx.AsyncClient, "request", failing_request)
     client = MiroClient()
     with pytest.raises(HttpError) as exc:
         await client._request("GET", "/x")
     assert exc.value.status == 503
+    await client.aclose()


### PR DESCRIPTION
## Summary
- reuse a persistent httpx.AsyncClient in MiroClient with lifecycle management
- ensure FastAPI lifespan closes the shared client
- test that requests reuse a single underlying connection

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/main.py src/miro_backend/services/miro_client.py tests/test_miro_client.py tests/test_miro_client_errors.py`
- `PYTEST_ADDOPTS="--cov-fail-under=0" poetry run pytest tests/test_miro_client.py tests/test_miro_client_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4238cca18832bb3409e2f45a95921