### PR TITLE
feat(batch): add ttl cache for idempotent responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
           "pydantic",
           "pydantic-settings",
           "types-PyYAML",
+          "types-cachetools",
         ]
   - repo: local
     hooks:

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -17,4 +17,6 @@ logfire_service_name: miro-backend
 logfire_send_to_logfire: false
 http_timeout_seconds: 10.0  # HTTP client timeout for Miro API calls
 idempotency_cleanup_seconds: 86400  # Interval between idempotency cleanup runs
+idempotency_cache_size: 128  # Maximum number of idempotent responses to cache
+idempotency_cache_ttl_seconds: 60.0  # TTL for idempotent response cache in seconds
 encryption_key: ""  # Base64-encoded 32-byte key for encrypting tokens (optional)

--- a/poetry.lock
+++ b/poetry.lock
@@ -113,6 +113,18 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2092,6 +2104,18 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
+name = "types-cachetools"
+version = "5.5.0.20240820"
+description = "Typing stubs for cachetools"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "types-cachetools-5.5.0.20240820.tar.gz", hash = "sha256:b888ab5c1a48116f7799cd5004b18474cd82b5463acb5ffb2db2fc9c7b053bc0"},
+    {file = "types_cachetools-5.5.0.20240820-py3-none-any.whl", hash = "sha256:efb2ed8bf27a4b9d3ed70d33849f536362603a90b8090a328acf0cd42fda82e2"},
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250809"
 description = "Typing stubs for PyYAML"
@@ -2560,4 +2584,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "4db964e2970fb2819c25528fc4ccbb23425d7445f04031f3e8aeba1ca28c2d3c"
+content-hash = "8e9dab1800efe126a447298cd9d1172e948e179c1bbc85c94da836a02c721a00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ prometheus-fastapi-instrumentator = "^6.1.0"
 pydantic-settings = "^2.10.1"
 pyyaml = "^6.0.2"
 cryptography = "^42.0.5"
+cachetools = "^5.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2"
@@ -31,6 +32,7 @@ httpx = "^0.27"
 pytest-cov = "^6.2.1"
 pytest-asyncio = "^1.1.0"
 types-pyyaml = "^6.0.12.20250809"
+types-cachetools = "^5.3.0"
 
 [tool.black]
 line-length = 88

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -100,6 +100,16 @@ class Settings(BaseSettings):
         alias="MIRO_IDEMPOTENCY_CLEANUP_SECONDS",
         description="Interval in seconds between idempotency cleanup runs.",
     )
+    idempotency_cache_size: int = Field(
+        default=128,
+        alias="MIRO_IDEMPOTENCY_CACHE_SIZE",
+        description="Maximum number of idempotent responses to cache in memory.",
+    )
+    idempotency_cache_ttl_seconds: float = Field(
+        default=60.0,
+        alias="MIRO_IDEMPOTENCY_CACHE_TTL_SECONDS",
+        description="Time-to-live for cached idempotent responses in seconds.",
+    )
 
     model_config = SettingsConfigDict(
         env_file="config/.env", extra="ignore", populate_by_name=True


### PR DESCRIPTION
## Summary
- replace idempotency dict with TTL-based cache
- make cache size and TTL configurable
- test cache eviction and DB fallback

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/core/config.py src/miro_backend/api/routers/batch.py config/config.example.yaml tests/test_batch_idempotency.py pyproject.toml poetry.lock .pre-commit-config.yaml`
- `poetry run pytest tests/test_batch_idempotency.py` *(fails: Coverage failure: total of 62 is less than fail-under=96)*

------
https://chatgpt.com/codex/tasks/task_e_68a423945f30832b98c1f2aa3c5a6ec7