### PR TITLE
feat(queue): add task success metrics

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -34,6 +34,8 @@ from .queue.change_queue import (  # noqa: E402
     change_queue_length,
     task_dlq,
     task_retries,
+    task_success,
+    task_duration,
 )
 from .services.miro_client import MiroClient  # noqa: E402
 from .services.idempotency import cleanup_idempotency  # noqa: E402
@@ -191,6 +193,8 @@ instrumentator = Instrumentator().instrument(app)
 instrumentator.registry.register(change_queue_length)
 instrumentator.registry.register(task_retries)
 instrumentator.registry.register(task_dlq)
+instrumentator.registry.register(task_success)
+instrumentator.registry.register(task_duration)
 
 
 @app.get("/metrics")  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- track successful change tasks and their processing time via Prometheus metrics
- expose new metrics through FastAPI instrumentation
- test metrics recording after successful task execution

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/queue/change_queue.py src/miro_backend/main.py tests/test_change_queue_metric.py`
- `poetry run pytest tests/test_change_queue_metric.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a423aae69c832b80bda491b16d6c8d