### PR TITLE
feat: add TTL-based cache cleanup

### DIFF
--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -110,6 +110,16 @@ class Settings(BaseSettings):
         alias="MIRO_IDEMPOTENCY_CACHE_TTL_SECONDS",
         description="Time-to-live for cached idempotent responses in seconds.",
     )
+    cache_cleanup_seconds: float = Field(
+        default=60 * 60 * 24,
+        alias="MIRO_CACHE_CLEANUP_SECONDS",
+        description="Interval in seconds between cache cleanup runs.",
+    )
+    cache_ttl_seconds: float = Field(
+        default=60 * 60 * 24,
+        alias="MIRO_CACHE_TTL_SECONDS",
+        description="Maximum age in seconds for cached board state.",
+    )
 
     model_config = SettingsConfigDict(
         env_file="config/.env", extra="ignore", populate_by_name=True

--- a/src/miro_backend/db/migrations/versions/e6bfc2f6b8a3_add_created_at_to_cache_entries.py
+++ b/src/miro_backend/db/migrations/versions/e6bfc2f6b8a3_add_created_at_to_cache_entries.py
@@ -1,0 +1,31 @@
+"""add created_at to cache_entries
+
+Revision ID: e6bfc2f6b8a3
+Revises: a54a1dc7f72e
+Create Date: 2025-08-17 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e6bfc2f6b8a3"
+down_revision: Union[str, Sequence[str], None] = "a54a1dc7f72e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:  # pragma: no cover - migration code
+    op.add_column(
+        "cache_entries",
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+    )
+
+
+def downgrade() -> None:  # pragma: no cover - migration code
+    op.drop_column("cache_entries", "created_at")

--- a/src/miro_backend/models/cache.py
+++ b/src/miro_backend/models/cache.py
@@ -1,8 +1,9 @@
 """Database models for cached data."""
 
+from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Integer, String, JSON
+from sqlalchemy import DateTime, Integer, String, JSON
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..db.session import Base
@@ -16,3 +17,6 @@ class CacheEntry(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     key: Mapped[str] = mapped_column(String, unique=True, index=True)
     value: Mapped[dict[str, Any]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )

--- a/src/miro_backend/services/cache.py
+++ b/src/miro_backend/services/cache.py
@@ -1,0 +1,62 @@
+"""Cache maintenance utilities."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import logfire
+from sqlalchemy import delete
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session, sessionmaker
+
+from ..core.config import settings
+from ..db.session import SessionLocal
+from ..models import CacheEntry
+
+
+def purge_expired_cache(
+    session_factory: sessionmaker[Session] = SessionLocal,
+    ttl: timedelta = timedelta(hours=24),
+) -> int:
+    """Delete cache rows older than ``ttl``.
+
+    Args:
+        session_factory: Factory for database sessions.
+        ttl: Maximum age for cache records.
+
+    Returns:
+        Number of rows removed.
+    """
+
+    cutoff = datetime.now(tz=UTC) - ttl
+    with session_factory() as session:
+        try:
+            result = session.execute(
+                delete(CacheEntry).where(CacheEntry.created_at < cutoff)
+            )
+            session.commit()
+        except OperationalError as exc:  # pragma: no cover - log and continue
+            logfire.warning(
+                "failed to purge expired cache rows",
+                ttl_seconds=int(ttl.total_seconds()),
+                session=str(session.bind),
+                error=exc,
+            )
+            return 0
+        return result.rowcount or 0
+
+
+async def cleanup_cache() -> None:
+    """Periodically purge expired cache rows."""
+
+    try:
+        while True:
+            ttl = timedelta(seconds=settings.cache_ttl_seconds)
+            deleted = await asyncio.to_thread(purge_expired_cache, ttl=ttl)
+            if deleted:
+                logfire.info("removed stale cache rows", extra={"count": deleted})
+            await asyncio.sleep(settings.cache_cleanup_seconds)
+    except asyncio.CancelledError:  # pragma: no cover - shutdown path
+        logfire.info("cache cleanup stopped")
+        raise

--- a/src/miro_backend/services/repository.py
+++ b/src/miro_backend/services/repository.py
@@ -8,6 +8,7 @@ business logic.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any, Generic, TypeVar
 
 import logfire
@@ -72,11 +73,13 @@ class Repository(Generic[ModelT]):
         """Store ``snapshot`` as the cached state for ``board_id``."""
 
         entry = self.session.query(CacheEntry).filter_by(key=board_id).one_or_none()
+        now = datetime.utcnow()
         if entry is None:
-            entry = CacheEntry(key=board_id, value=snapshot)
+            entry = CacheEntry(key=board_id, value=snapshot, created_at=now)
             self.session.add(entry)
         else:
             entry.value = snapshot
+            entry.created_at = now
         self.session.commit()
         logfire.info("board state updated", board_id=board_id)
 

--- a/tests/test_cache_cleanup.py
+++ b/tests/test_cache_cleanup.py
@@ -1,0 +1,72 @@
+"""Verify expired cache entries are purged."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from contextlib import contextmanager
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import sessionmaker
+
+from miro_backend.db.session import Base
+from miro_backend.models import CacheEntry
+from miro_backend.services.cache import purge_expired_cache
+
+
+def test_purge_expired_cache(tmp_path: Path) -> None:
+    """Rows older than the TTL should be deleted."""
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path/'cache.db'}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    old_time = datetime.now(tz=UTC) - timedelta(days=3)
+    fresh_time = datetime.now(tz=UTC)
+    with Session() as session:
+        session.add(CacheEntry(key="old", value={}, created_at=old_time))
+        session.add(CacheEntry(key="new", value={}, created_at=fresh_time))
+        session.commit()
+
+    deleted = purge_expired_cache(Session, ttl=timedelta(days=2))
+    assert deleted == 1
+
+    with Session() as session:
+        remaining = {row.key for row in session.query(CacheEntry).all()}
+    assert remaining == {"new"}
+
+
+def test_purge_logs_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operational errors should log a warning and return zero."""
+
+    @contextmanager
+    def failing_session_factory() -> Iterator[object]:
+        class FailingSession:
+            bind = "failing-db"
+
+            def execute(self, *_: object, **__: object) -> None:
+                raise OperationalError("stmt", {}, RuntimeError())
+
+            def commit(self) -> None:  # pragma: no cover - not reached
+                pass
+
+        yield FailingSession()
+
+    warn = MagicMock()
+    monkeypatch.setattr("miro_backend.services.cache.logfire.warning", warn)
+
+    deleted = purge_expired_cache(failing_session_factory, ttl=timedelta(hours=1))
+
+    assert deleted == 0
+    warn.assert_called_once()
+    message, kwargs = warn.call_args
+    assert "failed to purge" in message[0]
+    assert kwargs["ttl_seconds"] == 3600
+    assert kwargs["session"] == "failing-db"
+    assert isinstance(kwargs["error"], OperationalError)

--- a/tests/test_config_cache_cleanup.py
+++ b/tests/test_config_cache_cleanup.py
@@ -1,0 +1,27 @@
+"""Configuration tests for cache cleanup settings."""
+
+from __future__ import annotations
+
+import pytest
+
+from miro_backend.core.config import Settings
+
+
+def test_cache_cleanup_seconds_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIRO_CACHE_CLEANUP_SECONDS", raising=False)
+    settings = Settings()
+    assert settings.cache_cleanup_seconds == 60 * 60 * 24
+
+    monkeypatch.setenv("MIRO_CACHE_CLEANUP_SECONDS", "123")
+    settings = Settings()
+    assert settings.cache_cleanup_seconds == 123
+
+
+def test_cache_ttl_seconds_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIRO_CACHE_TTL_SECONDS", raising=False)
+    settings = Settings()
+    assert settings.cache_ttl_seconds == 60 * 60 * 24
+
+    monkeypatch.setenv("MIRO_CACHE_TTL_SECONDS", "321")
+    settings = Settings()
+    assert settings.cache_ttl_seconds == 321


### PR DESCRIPTION
## Summary
- add created_at column to cache entries
- update repository to refresh timestamps
- schedule and implement cache cleanup worker with TTL config
- test cache cleanup and config

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/models/cache.py src/miro_backend/services/repository.py src/miro_backend/services/cache.py src/miro_backend/core/config.py src/miro_backend/main.py src/miro_backend/db/migrations/versions/e6bfc2f6b8a3_add_created_at_to_cache_entries.py tests/test_cache_cleanup.py tests/test_config_cache_cleanup.py`
- `poetry run pytest tests/test_cache_cleanup.py tests/test_config_cache_cleanup.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a43b8cb93c832ba7374d727b677a26