### PR TITLE
feat(db): use enums for job and task status

### DIFF
--- a/src/miro_backend/db/migrations/versions/e1f859591b2d_use_enums_for_status.py
+++ b/src/miro_backend/db/migrations/versions/e1f859591b2d_use_enums_for_status.py
@@ -1,0 +1,57 @@
+"""use enums for job and task status
+
+Revision ID: e1f859591b2d
+Revises: a54a1dc7f72e
+Create Date: 2025-08-17 00:00:01.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f859591b2d"
+down_revision: Union[str, Sequence[str], None] = "a54a1dc7f72e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+job_status = sa.Enum(
+    "queued", "running", "succeeded", "failed", name="jobstatus", native_enum=False
+)
+task_status = sa.Enum(
+    "queued", "processing", "completed", "failed", name="taskstatus", native_enum=False
+)
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "jobs", "status", existing_type=sa.String(), type_=job_status, nullable=False
+    )
+    op.alter_column(
+        "queue_tasks",
+        "status",
+        existing_type=sa.String(),
+        type_=task_status,
+        nullable=False,
+        server_default=sa.text("'queued'"),
+        existing_server_default=sa.text("'queued'"),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "queue_tasks",
+        "status",
+        existing_type=task_status,
+        type_=sa.String(),
+        nullable=False,
+        server_default="queued",
+    )
+    op.alter_column(
+        "jobs", "status", existing_type=job_status, type_=sa.String(), nullable=False
+    )
+    job_status.drop(op.get_bind(), checkfirst=False)
+    task_status.drop(op.get_bind(), checkfirst=False)

--- a/src/miro_backend/models/__init__.py
+++ b/src/miro_backend/models/__init__.py
@@ -7,13 +7,14 @@ from .shape import Shape
 from .tag import Tag
 from .user import User
 from .idempotency import Idempotency
-from .job import Job
+from .job import Job, JobStatus
 
 __all__ = [
     "Board",
     "CacheEntry",
     "Idempotency",
     "Job",
+    "JobStatus",
     "LogEntry",
     "Shape",
     "Tag",

--- a/src/miro_backend/models/job.py
+++ b/src/miro_backend/models/job.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import DateTime, JSON, String
+from sqlalchemy import DateTime, JSON, Enum as SAEnum, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..db.session import Base
+
+
+class JobStatus(StrEnum):
+    """Possible states for a background job."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
 
 
 class Job(Base):
@@ -20,7 +30,9 @@ class Job(Base):
     id: Mapped[str] = mapped_column(
         String, primary_key=True, default=lambda: str(uuid4())
     )
-    status: Mapped[str] = mapped_column(String)
+    status: Mapped[JobStatus] = mapped_column(
+        SAEnum(JobStatus, native_enum=False), default=JobStatus.QUEUED
+    )
     results: Mapped[dict[str, Any] | None] = mapped_column(
         JSON, default=None, nullable=True
     )

--- a/src/miro_backend/schemas/job.py
+++ b/src/miro_backend/schemas/job.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from ..models import JobStatus
+
 
 class Job(BaseModel):
     """Representation of a background job."""
@@ -14,6 +16,6 @@ class Job(BaseModel):
     model_config = ConfigDict(extra="forbid", from_attributes=True)
 
     id: str
-    status: str
+    status: JobStatus
     results: dict[str, Any] | None = None
     updated_at: datetime

--- a/src/miro_backend/services/batch_service.py
+++ b/src/miro_backend/services/batch_service.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
 
-from ..models import Job
+from ..models import Job, JobStatus
 from ..queue.tasks import ChangeTask, CreateNode, UpdateCard
 from ..services.repository import Repository
 
@@ -40,7 +40,10 @@ async def enqueue_operations(
 
     repo: Repository[Job] = Repository(session, Job)
     job = repo.add(
-        Job(status="queued", results={"total": len(operations), "operations": []})
+        Job(
+            status=JobStatus.QUEUED,
+            results={"total": len(operations), "operations": []},
+        )
     )
 
     for op in operations:

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from miro_backend.schemas.tag import Tag
 from miro_backend.schemas.job import Job
 from miro_backend.schemas.user_info import UserInfo
+from miro_backend.models import JobStatus
 
 
 def test_tag_rejects_unknown_field() -> None:
@@ -25,7 +26,7 @@ def test_job_rejects_unknown_field() -> None:
     with pytest.raises(ValidationError):
         Job(
             id="j1",
-            status="queued",
+            status=JobStatus.QUEUED,
             updated_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
             results=None,
             unknown="x",


### PR DESCRIPTION
## Summary
- add `JobStatus` and `TaskStatus` enums
- persist job and queue task statuses as SQLAlchemy Enums
- migrate existing status columns to Enum types

## Testing
- `poetry run pre-commit run --files src/miro_backend/models/job.py src/miro_backend/models/__init__.py src/miro_backend/queue/persistence.py src/miro_backend/queue/change_queue.py src/miro_backend/services/batch_service.py src/miro_backend/schemas/job.py tests/test_jobs_controller.py tests/test_schema_validation.py src/miro_backend/db/migrations/versions/e1f859591b2d_use_enums_for_status.py`
- `poetry run pytest` *(fails: TypeError in `tests/integration/test_miro_client.py`, OperationalError in cache tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a43b8aed10832ba92be9da3215c3ea