### PR TITLE
feat: instrument log ingestion metrics

### DIFF
--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -59,7 +59,11 @@ from .api.routers.auth import router as auth_router  # noqa: E402
 from .api.routers.batch import router as batch_router  # noqa: E402
 from .api.routers.cache import router as cache_router  # noqa: E402
 from .api.routers.cards import router as cards_router  # noqa: E402
-from .api.routers.logs import router as logs_router  # noqa: E402
+from .api.routers.logs import (  # noqa: E402
+    router as logs_router,
+    logs_ingested_total,
+    log_batch_size_bytes,
+)
 from .api.routers.oauth import router as oauth_router  # noqa: E402
 from .api.routers.limits import router as limits_router  # noqa: E402
 from .api.routers.shapes import router as shapes_router  # noqa: E402
@@ -196,6 +200,8 @@ instrumentator.registry.register(task_retries)
 instrumentator.registry.register(task_dlq)
 instrumentator.registry.register(task_success)
 instrumentator.registry.register(task_duration)
+instrumentator.registry.register(logs_ingested_total)
+instrumentator.registry.register(log_batch_size_bytes)
 
 
 @app.get("/metrics")  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- track ingested logs and batch sizes via Prometheus metrics
- expose new metrics through instrumentator registration
- verify metrics update when log batches are captured

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/api/routers/logs.py src/miro_backend/main.py tests/test_logs_controller.py`
- `poetry run pytest` *(fails: tests/integration/test_miro_client.py::test_miro_client_calls_correct_endpoint[create_shape-args0-expected0] - TypeError ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a43b8dca6c832b81a9a9ba8cc1c30d