### PR TITLE
feat(auth): share backend user schema with frontend

### DIFF
--- a/scripts/gen_user_info_ts.py
+++ b/scripts/gen_user_info_ts.py
@@ -1,0 +1,45 @@
+"""Generate TypeScript interfaces from backend Pydantic models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+from miro_backend.schemas.user_info import UserInfo  # noqa: E402
+
+_TYPE_MAP: dict[str, str] = {
+    "string": "string",
+    "integer": "number",
+    "number": "number",
+    "boolean": "boolean",
+}
+
+
+def _generate_interface(schema: dict[str, Any]) -> str:
+    lines = [
+        "// Generated from src/miro_backend/schemas/user_info.py",
+        "export interface UserInfo {",
+    ]
+    for name, prop in schema["properties"].items():
+        prop_type = str(prop.get("type", "string"))
+        ts_type = _TYPE_MAP.get(prop_type, "string")
+        lines.append(f"  {name}: {ts_type};")
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Write TypeScript interface for ``UserInfo`` to the generated folder."""
+    schema = UserInfo.model_json_schema()
+    content = _generate_interface(schema)
+    out_path = ROOT / "web" / "client" / "src" / "generated" / "user-info.ts"
+    out_path.write_text(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/client/README.md
+++ b/web/client/README.md
@@ -4,3 +4,13 @@
 
 - Backend URL: set `VITE_BACKEND_URL` or leave empty to use Vite proxy.
 - Dev OAuth: Vite proxies `/oauth/*` to the backend.
+
+## Generated Types
+
+Regenerate TypeScript interfaces from backend Pydantic models:
+
+```bash
+poetry run python scripts/gen_user_info_ts.py
+```
+
+The output is written to `src/generated/`.

--- a/web/client/src/generated/user-info.ts
+++ b/web/client/src/generated/user-info.ts
@@ -1,0 +1,8 @@
+// Generated from src/miro_backend/schemas/user_info.py
+export interface UserInfo {
+  id: string;
+  name: string;
+  access_token: string;
+  refresh_token: string;
+  expires_at: string;
+}

--- a/web/client/src/user-auth.ts
+++ b/web/client/src/user-auth.ts
@@ -3,15 +3,12 @@
  *
  * @property id - Unique identifier returned by Miro.
  * @property name - Display name of the user.
- * @property token - ID token proving user identity.
+ * @property access_token - ID token proving user identity.
+ * @property refresh_token - Token used to renew credentials.
+ * @property expires_at - Expiration timestamp of the access token.
  */
+import type { UserInfo } from './generated/user-info';
 import { apiFetch } from './core/utils/api-fetch';
-
-export interface AuthDetails {
-  id: string;
-  name: string;
-  token: string;
-}
 
 /** HTTP client for sending Miro auth details to the backend. */
 export class AuthClient {
@@ -20,9 +17,9 @@ export class AuthClient {
   /**
    * Send authentication info to the server.
    *
-   * @param details - User id, name and OAuth token.
+   * @param details - User id, name and OAuth tokens.
    */
-  public async register(details: AuthDetails): Promise<void> {
+  public async register(details: UserInfo): Promise<void> {
     if (typeof fetch !== 'function') {
       return;
     }
@@ -41,11 +38,11 @@ export class AuthClient {
   /**
    * Attempt to register a user, retrying with exponential backoff on failure.
    *
-   * @param details - User id, name and OAuth token.
+   * @param details - User id, name and OAuth tokens.
    * @param attempts - Maximum number of tries.
    */
   public async registerWithRetry(
-    details: AuthDetails,
+    details: UserInfo,
     attempts = 3,
   ): Promise<void> {
     for (let i = 0; i < attempts; i += 1) {
@@ -90,10 +87,10 @@ export async function registerWithCurrentUser(
   await client.registerWithRetry({
     id: String(user.id),
     name: user.name,
-    token,
+    access_token: token,
+    refresh_token: '',
+    expires_at: new Date().toISOString(),
   });
   // TODO: model the full OAuth exchange so tokens can be renewed via the server
   //       when they expire.
-  // TODO: share user registration DTOs with the server-side code generation
-  //       so both tiers validate the same shapes.
 }

--- a/web/client/tests/user-auth-type.test.ts
+++ b/web/client/tests/user-auth-type.test.ts
@@ -1,0 +1,9 @@
+import { expectTypeOf, test } from 'vitest';
+
+import { AuthClient } from '../src/user-auth';
+import type { UserInfo } from '../src/generated/user-info';
+
+test('AuthClient.register uses generated UserInfo type', () => {
+  const client = new AuthClient();
+  expectTypeOf(client.register).parameter(0).toEqualTypeOf<UserInfo>();
+});

--- a/web/client/tests/user-auth.integration.test.ts
+++ b/web/client/tests/user-auth.integration.test.ts
@@ -9,8 +9,22 @@ let url: string;
 beforeAll(async () => {
   server = http.createServer((req, res) => {
     if (req.method === 'POST' && req.url === '/api/users') {
-      req.resume();
-      res.writeHead(202).end();
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        const data = JSON.parse(body);
+        if (
+          typeof data.access_token === 'string' &&
+          typeof data.refresh_token === 'string' &&
+          typeof data.expires_at === 'string'
+        ) {
+          res.writeHead(202).end();
+        } else {
+          res.writeHead(400).end();
+        }
+      });
       return;
     }
     res.writeHead(404).end();


### PR DESCRIPTION
## Summary
- generate UserInfo TypeScript interface from backend schema
- use generated UserInfo in client auth flow
- document code generation command and test generated type

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run stylelint --silent`
- `npm run prettier --silent`
- `npm run test --silent`
- `poetry run pre-commit run --files scripts/gen_user_info_ts.py web/client/src/generated/user-info.ts web/client/src/user-auth.ts web/client/README.md web/client/tests/user-auth-type.test.ts web/client/tests/user-auth.integration.test.ts` *(failed: pytest hook interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a43b8ebddc832b8e824b695daac103