### PR TITLE
feat: make log batch limits configurable

### DIFF
--- a/src/miro_backend/api/routers/logs.py
+++ b/src/miro_backend/api/routers/logs.py
@@ -7,6 +7,7 @@ from typing import Sequence
 from fastapi import APIRouter, Depends, Request, Response, status
 import logfire
 
+from ...core.config import settings
 from ...core.exceptions import PayloadTooLargeError
 
 from ...models.log_entry import LogEntry
@@ -14,9 +15,6 @@ from ...schemas.log_entry import LogEntryIn
 from ...services.log_repository import LogRepository, get_log_repository
 
 router = APIRouter(prefix="/api/logs", tags=["logs"])
-
-MAX_LOG_ENTRIES = 1000
-MAX_PAYLOAD_BYTES = 1_048_576  # 1 MiB
 
 
 @router.post("/", status_code=status.HTTP_202_ACCEPTED, response_class=Response)  # type: ignore[misc]
@@ -47,17 +45,17 @@ async def capture_logs(
         else:
             body_size = len(await request.body())
 
-        if body_size > MAX_PAYLOAD_BYTES:
+        if body_size > settings.log_max_payload_bytes:
             raise PayloadTooLargeError(
-                f"Maximum payload size is {MAX_PAYLOAD_BYTES} bytes"
+                f"Maximum payload size is {settings.log_max_payload_bytes} bytes"
             )
 
-        if len(entries) > MAX_LOG_ENTRIES:
+        if len(entries) > settings.log_max_entries:
             logfire.warning(
                 "too many log entries", count=len(entries)
             )  # warn when batch exceeds limit
             raise PayloadTooLargeError(
-                f"Maximum {MAX_LOG_ENTRIES} log entries per request"
+                f"Maximum {settings.log_max_entries} log entries per request"
             )
 
         models = [

--- a/src/miro_backend/core/config.py
+++ b/src/miro_backend/core/config.py
@@ -80,6 +80,16 @@ class Settings(BaseSettings):
         alias="MIRO_LOGFIRE_SEND_TO_LOGFIRE",
         description="Whether to send logs to Logfire.",
     )
+    log_max_entries: int = Field(
+        default=1000,
+        alias="MIRO_LOG_MAX_ENTRIES",
+        description="Maximum number of log entries per request.",
+    )
+    log_max_payload_bytes: int = Field(
+        default=1_048_576,
+        alias="MIRO_LOG_MAX_PAYLOAD_BYTES",
+        description="Maximum size of log payload in bytes.",
+    )
     http_timeout_seconds: float = Field(
         default=10.0,
         alias="MIRO_HTTP_TIMEOUT_SECONDS",

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -8,6 +8,7 @@ from typing import Iterator
 import pytest
 from fastapi.testclient import TestClient
 
+from miro_backend.core.config import settings
 from miro_backend.db.session import Base, SessionLocal, engine
 from miro_backend.main import app
 from miro_backend.models import LogEntry
@@ -70,6 +71,38 @@ def test_capture_rejects_large_payload(client: TestClient) -> None:
             "message": "m" * 1024,
         }
         for _ in range(1000)
+    ]
+
+    response = client.post("/api/logs", json=payload)
+    assert response.status_code == 413
+
+
+def test_capture_respects_custom_entry_limit(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "log_max_entries", 1)
+    payload = [
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": "info",
+            "message": "m",
+        }
+    ] * 2
+
+    response = client.post("/api/logs", json=payload)
+    assert response.status_code == 413
+
+
+def test_capture_respects_custom_payload_limit(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "log_max_payload_bytes", 10)
+    payload = [
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": "info",
+            "message": "x" * 100,
+        }
     ]
 
     response = client.post("/api/logs", json=payload)


### PR DESCRIPTION
## Summary
- add configurable log entry and payload limits
- use settings for log router limits
- test configurable log limits

## Testing
- `SKIP=pytest poetry run pre-commit run --files src/miro_backend/core/config.py src/miro_backend/api/routers/logs.py tests/test_logs_controller.py`
- `poetry run pytest tests/test_logs_controller.py`
- `poetry run pytest` *(fails: 5 failed, coverage 59% < 96%)*


------
https://chatgpt.com/codex/tasks/task_e_68a43b4f8684832b9ff5a74a3db34f89