### PR TITLE
fix: remove unused ignores and resolve mypy issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ line-length = 88
 [tool.mypy]
 python_version = "3.11"
 strict = true
+mypy_path = ["src"]
+explicit_package_bases = true
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/miro_backend/api/routers/auth.py
+++ b/src/miro_backend/api/routers/auth.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 
 # mypy struggles with FastAPI decorators
-@router.get("/status", status_code=status.HTTP_200_OK, response_class=Response)  # type: ignore[misc]
+@router.get("/status", status_code=status.HTTP_200_OK, response_class=Response)
 def get_status(
     user_id: str | None = Header(default=None, alias="X-User-Id"),
     store: UserStore = Depends(get_user_store),

--- a/src/miro_backend/api/routers/batch.py
+++ b/src/miro_backend/api/routers/batch.py
@@ -23,7 +23,9 @@ _IDEMPOTENCY_CACHE: TTLCache[str, BatchResponse] = TTLCache(
 )
 
 
-@router.post("/batch", status_code=status.HTTP_202_ACCEPTED, response_model=BatchResponse)  # type: ignore[misc]
+@router.post(
+    "/batch", status_code=status.HTTP_202_ACCEPTED, response_model=BatchResponse
+)
 async def post_batch(
     request: BatchRequest,
     queue: ChangeQueue = Depends(get_change_queue),

--- a/src/miro_backend/api/routers/cache.py
+++ b/src/miro_backend/api/routers/cache.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from fastapi import APIRouter, Depends, status
 import logfire
@@ -17,7 +17,7 @@ from ...services.repository import Repository
 router = APIRouter(prefix="/api/cache", tags=["cache"])
 
 
-@router.get("/{board_id}", status_code=status.HTTP_200_OK)  # type: ignore[misc]
+@router.get("/{board_id}", status_code=status.HTTP_200_OK)
 def get_board_cache(
     board_id: str, session: Session = Depends(get_session)
 ) -> dict[str, Any]:
@@ -37,4 +37,4 @@ def get_board_cache(
         logfire.info(
             "board cache hit", board_id=board_id
         )  # event when cache lookup succeeds
-        return cast(dict[str, Any], state)
+        return state

--- a/src/miro_backend/api/routers/cards.py
+++ b/src/miro_backend/api/routers/cards.py
@@ -11,7 +11,7 @@ from ...schemas.card_create import CardCreate
 router = APIRouter(prefix="/api/cards", tags=["cards"])
 
 
-@router.post("", status_code=status.HTTP_202_ACCEPTED)  # type: ignore[misc]
+@router.post("", status_code=status.HTTP_202_ACCEPTED)
 async def create_cards(
     cards: list[CardCreate],
     user_id: str = Header(alias="X-User-Id"),

--- a/src/miro_backend/api/routers/jobs.py
+++ b/src/miro_backend/api/routers/jobs.py
@@ -13,7 +13,7 @@ from ...services.repository import Repository
 router = APIRouter(prefix="/api/jobs", tags=["jobs"])
 
 
-@router.get("/{job_id}", response_model=JobSchema)  # type: ignore[misc]
+@router.get("/{job_id}", response_model=JobSchema)
 def get_job(job_id: str, session: Session = Depends(get_session)) -> JobSchema:
     """Return the job with ``job_id`` if present."""
 

--- a/src/miro_backend/api/routers/limits.py
+++ b/src/miro_backend/api/routers/limits.py
@@ -11,7 +11,7 @@ from ...queue.provider import get_change_queue
 router = APIRouter(prefix="/api", tags=["limits"])
 
 
-@router.get("/limits", status_code=status.HTTP_200_OK)  # type: ignore[misc]
+@router.get("/limits", status_code=status.HTTP_200_OK)
 def get_limits(
     queue: ChangeQueue = Depends(get_change_queue),
     debug_limits: str | None = Header(default=None, alias="X-Debug-Limits"),

--- a/src/miro_backend/api/routers/logs.py
+++ b/src/miro_backend/api/routers/logs.py
@@ -32,7 +32,7 @@ log_batch_size_bytes = Histogram(
 )
 
 
-@router.post("/", status_code=status.HTTP_202_ACCEPTED, response_class=Response)  # type: ignore[misc]
+@router.post("/", status_code=status.HTTP_202_ACCEPTED, response_class=Response)
 async def capture_logs(
     request: Request,
     entries: Sequence[LogEntryIn],

--- a/src/miro_backend/api/routers/oauth.py
+++ b/src/miro_backend/api/routers/oauth.py
@@ -52,7 +52,7 @@ def get_oauth_config() -> OAuthConfig:
     )
 
 
-@router.get("/login", response_class=RedirectResponse)  # type: ignore[misc]
+@router.get("/login", response_class=RedirectResponse)
 def login(
     user_id: str = Query(alias="userId"),
     return_url: str | None = Query(default=None, alias="returnUrl"),
@@ -75,7 +75,7 @@ def login(
     return RedirectResponse(url)
 
 
-@router.get("/callback", response_class=RedirectResponse)  # type: ignore[misc]
+@router.get("/callback", response_class=RedirectResponse)
 async def callback(
     code: str,
     state: str,

--- a/src/miro_backend/api/routers/shapes.py
+++ b/src/miro_backend/api/routers/shapes.py
@@ -40,7 +40,7 @@ def _verify_board(board_id: str, user_id: str | None, store: ShapeStore) -> None
         )  # event on success
 
 
-@router.get("/{shape_id}", response_model=Shape)  # type: ignore[misc]
+@router.get("/{shape_id}", response_model=Shape)
 def get_shape(
     board_id: str,
     shape_id: str,
@@ -63,7 +63,7 @@ def get_shape(
         return shape
 
 
-@router.post("/", response_model=Shape, status_code=status.HTTP_201_CREATED)  # type: ignore[misc]
+@router.post("/", response_model=Shape, status_code=status.HTTP_201_CREATED)
 async def create_shape(
     board_id: str,
     payload: ShapeCreate,
@@ -95,7 +95,7 @@ async def create_shape(
         return shape
 
 
-@router.put("/{shape_id}", response_model=Shape)  # type: ignore[misc]
+@router.put("/{shape_id}", response_model=Shape)
 async def update_shape(
     board_id: str,
     shape_id: str,
@@ -133,7 +133,7 @@ async def update_shape(
         return shape
 
 
-@router.delete("/{shape_id}", status_code=status.HTTP_204_NO_CONTENT)  # type: ignore[misc]
+@router.delete("/{shape_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_shape(
     board_id: str,
     shape_id: str,

--- a/src/miro_backend/api/routers/tags.py
+++ b/src/miro_backend/api/routers/tags.py
@@ -15,7 +15,7 @@ from ...services.tag_repository import TagRepository
 router = APIRouter(prefix="/api/boards", tags=["tags"])
 
 
-@router.get("/{board_id}/tags", response_model=list[TagSchema])  # type: ignore[misc]
+@router.get("/{board_id}/tags", response_model=list[TagSchema])
 def list_tags(
     board_id: int, session: Session = Depends(get_session)
 ) -> list[TagSchema]:

--- a/src/miro_backend/api/routers/users.py
+++ b/src/miro_backend/api/routers/users.py
@@ -17,7 +17,7 @@ from ...services.repository import Repository
 router = APIRouter(prefix="/api/users", tags=["users"])
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)  # type: ignore[misc]
+@router.post("", status_code=status.HTTP_201_CREATED)
 def create_user(info: UserInfo, session: Session = Depends(get_session)) -> UserInfo:
     """Persist ``info`` and return it, rejecting duplicates."""
 

--- a/src/miro_backend/api/routers/webhook.py
+++ b/src/miro_backend/api/routers/webhook.py
@@ -33,7 +33,7 @@ def _verify_signature(secret: str, body: bytes, signature: str) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-@router.post("", status_code=status.HTTP_202_ACCEPTED, response_class=Response)  # type: ignore[misc]
+@router.post("", status_code=status.HTTP_202_ACCEPTED, response_class=Response)
 async def post_webhook(
     request: Request,
     signature: str | None = Header(default=None, alias="X-Miro-Signature"),

--- a/src/miro_backend/core/exceptions.py
+++ b/src/miro_backend/core/exceptions.py
@@ -60,11 +60,13 @@ class PayloadTooLargeError(AppError):
     code = "payload_too_large"
 
 
-@logfire.instrument("handle app error")  # type: ignore[misc]
-async def handle_app_error(_: Request, exc: AppError) -> JSONResponse:
+@logfire.instrument("handle app error")
+async def handle_app_error(_: Request, exc: Exception) -> JSONResponse:
     """Convert :class:`AppError` instances into JSON responses."""
 
     # log structured details for the raised application error
+    if not isinstance(exc, AppError):  # safety guard, registered for AppError only
+        raise exc
     logfire.warning(exc.message, code=exc.code)
     return JSONResponse(
         status_code=exc.status_code,

--- a/src/miro_backend/core/logging.py
+++ b/src/miro_backend/core/logging.py
@@ -10,10 +10,10 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.responses import Response
 
 
-class RequestIdMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+class RequestIdMiddleware(BaseHTTPMiddleware):
     """Attach a correlation ID to each request and log context."""
 
-    @logfire.instrument("request id middleware")  # type: ignore[misc]
+    @logfire.instrument("request id middleware")
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
@@ -24,7 +24,7 @@ class RequestIdMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
         return response
 
 
-@logfire.instrument("configure logging")  # type: ignore[misc]
+@logfire.instrument("configure logging")
 def configure_logging() -> None:
     """Configure logfire and database instrumentation."""
     from .config import settings
@@ -39,7 +39,7 @@ def configure_logging() -> None:
     logfire.instrument_sqlalchemy(engine)
 
 
-@logfire.instrument("setup fastapi")  # type: ignore[misc]
+@logfire.instrument("setup fastapi")
 def setup_fastapi(app: FastAPI) -> None:
     """Instrument FastAPI and register request ID middleware."""
 

--- a/src/miro_backend/core/security.py
+++ b/src/miro_backend/core/security.py
@@ -58,7 +58,7 @@ def verify_state(secret: str, state: str) -> tuple[str, str]:
     return nonce, user_id
 
 
-class ProxyHttpsRedirectMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+class ProxyHttpsRedirectMiddleware(BaseHTTPMiddleware):
     """Redirect HTTP requests to HTTPS using ``X-Forwarded-Proto``."""
 
     async def dispatch(

--- a/src/miro_backend/db/migrations/env.py
+++ b/src/miro_backend/db/migrations/env.py
@@ -6,6 +6,7 @@ from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
+from typing import Any
 
 from miro_backend.db.session import Base
 from miro_backend.core.config import settings
@@ -38,8 +39,9 @@ def run_migrations_offline() -> None:  # pragma: no cover - CLI entrypoint
 def run_migrations_online() -> None:  # pragma: no cover - CLI entrypoint
     """Run migrations in 'online' mode."""
 
+    section: dict[str, Any] = config.get_section(config.config_ini_section) or {}
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        section,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/src/miro_backend/db/session.py
+++ b/src/miro_backend/db/session.py
@@ -30,7 +30,7 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 """Factory for ``Session`` instances."""
 
 
-@logfire.instrument("database session", allow_generator=True)  # type: ignore[misc]
+@logfire.instrument("database session", allow_generator=True)
 def get_session() -> Iterator[Session]:
     """Yield a database session and ensure it is closed.
 

--- a/src/miro_backend/main.py
+++ b/src/miro_backend/main.py
@@ -111,7 +111,7 @@ OPENAPI_TAGS = [
 
 
 @asynccontextmanager
-@logfire.instrument("application lifespan", allow_generator=True)  # type: ignore[misc]
+@logfire.instrument("application lifespan", allow_generator=True)
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     """Start background workers for queue processing and cache cleanup."""
 
@@ -158,7 +158,7 @@ setup_telemetry(app)
 add_exception_handlers(app)
 
 
-@app.middleware("http")  # type: ignore[misc]
+@app.middleware("http")
 async def debug_middleware(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
@@ -210,7 +210,7 @@ instrumentator.registry.register(logs_ingested_total)
 instrumentator.registry.register(log_batch_size_bytes)
 
 
-@app.get("/metrics")  # type: ignore[misc]
+@app.get("/metrics")
 async def metrics() -> Response:
     """Expose Prometheus metrics."""
     with logfire.span("prometheus scrape"):
@@ -220,7 +220,7 @@ async def metrics() -> Response:
         )
 
 
-@app.get("/", response_class=RedirectResponse)  # type: ignore[misc]
+@app.get("/", response_class=RedirectResponse)
 async def root() -> RedirectResponse:
     """Redirect browsers to the built front-end."""
     with logfire.span("root redirect"):
@@ -228,7 +228,7 @@ async def root() -> RedirectResponse:
         return RedirectResponse(url="/static/index.html")
 
 
-@app.get("/health")  # type: ignore[misc]
+@app.get("/health")
 async def health() -> dict[str, str]:
     """Basic health check endpoint."""
     with logfire.span("health check"):

--- a/src/miro_backend/queue/change_queue.py
+++ b/src/miro_backend/queue/change_queue.py
@@ -116,7 +116,7 @@ class ChangeQueue:
 
         return self._persistence
 
-    @logfire.instrument("enqueue task {task=}")  # type: ignore[misc]
+    @logfire.instrument("enqueue task {task=}")
     async def enqueue(self, task: ChangeTask) -> None:
         """Add ``task`` to the queue and persist it if supported."""
 
@@ -135,7 +135,7 @@ class ChangeQueue:
         # Update metric after task enqueued
         change_queue_length.set(self._queue.qsize())
 
-    @logfire.instrument("dequeue task")  # type: ignore[misc]
+    @logfire.instrument("dequeue task")
     async def dequeue(self) -> ChangeTask:
         """Retrieve the next task from the queue."""
 
@@ -230,7 +230,7 @@ class ChangeQueue:
     # ------------------------------------------------------------------
     # Worker utilities
     # ------------------------------------------------------------------
-    @logfire.instrument("worker loop")  # type: ignore[misc]
+    @logfire.instrument("worker loop")
     async def worker(self, session: Session, client: MiroClient) -> None:
         """Continuously consume tasks and apply them using ``client``."""
 

--- a/src/miro_backend/services/crypto.py
+++ b/src/miro_backend/services/crypto.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import cast
-
-from cryptography.fernet import Fernet, MultiFernet, InvalidToken
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
 from ..core.config import settings
 
@@ -27,7 +25,7 @@ def encrypt(text: str) -> str:
     if _fernet is None:
         return text
     result = _fernet.encrypt(text.encode())
-    return cast(bytes, result).decode()
+    return result.decode()
 
 
 def decrypt(token: str) -> str:
@@ -45,4 +43,4 @@ def decrypt(token: str) -> str:
         result = _fernet.decrypt(token.encode())
     except InvalidToken as exc:
         raise ValueError("invalid encrypted token") from exc
-    return cast(bytes, result).decode()
+    return result.decode()

--- a/src/miro_backend/services/log_repository.py
+++ b/src/miro_backend/services/log_repository.py
@@ -19,7 +19,7 @@ class LogRepository(Repository[LogEntry]):
     def __init__(self, session: Session) -> None:
         super().__init__(session, LogEntry)
 
-    @logfire.instrument("add log entries")  # type: ignore[misc]
+    @logfire.instrument("add log entries")
     def add_all(self, entries: Sequence[LogEntry]) -> None:
         """Persist multiple log entries in a single transaction."""
 

--- a/src/miro_backend/services/repository.py
+++ b/src/miro_backend/services/repository.py
@@ -29,7 +29,7 @@ class Repository(Generic[ModelT]):
     # ------------------------------------------------------------------
     # Create / Update
     # ------------------------------------------------------------------
-    @logfire.instrument("add model")  # type: ignore[misc]
+    @logfire.instrument("add model")
     def add(self, instance: ModelT) -> ModelT:
         """Persist ``instance`` to the database."""
 
@@ -44,7 +44,7 @@ class Repository(Generic[ModelT]):
     # ------------------------------------------------------------------
     # Read operations
     # ------------------------------------------------------------------
-    @logfire.instrument("get model")  # type: ignore[misc]
+    @logfire.instrument("get model")
     def get(self, id_: Any) -> ModelT | None:
         """Return an entity by primary key if present."""
 
@@ -52,7 +52,7 @@ class Repository(Generic[ModelT]):
         logfire.info("entity retrieved", id=id_)  # event: retrieval
         return result
 
-    @logfire.instrument("list models")  # type: ignore[misc]
+    @logfire.instrument("list models")
     def list(self) -> Sequence[ModelT]:
         """Return all entities of the repository type."""
 
@@ -60,7 +60,7 @@ class Repository(Generic[ModelT]):
         logfire.info("entities listed", count=len(results))  # event: query complete
         return results
 
-    @logfire.instrument("get board state")  # type: ignore[misc]
+    @logfire.instrument("get board state")
     def get_board_state(self, board_id: str) -> dict[str, Any] | None:
         """Return cached board state for ``board_id`` if present."""
 
@@ -68,7 +68,7 @@ class Repository(Generic[ModelT]):
         logfire.info("board state fetched", board_id=board_id)  # event: cache lookup
         return entry.value if entry else None
 
-    @logfire.instrument("set board state")  # type: ignore[misc]
+    @logfire.instrument("set board state")
     def set_board_state(self, board_id: str, snapshot: dict[str, Any]) -> None:
         """Store ``snapshot`` as the cached state for ``board_id``."""
 
@@ -86,7 +86,7 @@ class Repository(Generic[ModelT]):
     # ------------------------------------------------------------------
     # Delete operations
     # ------------------------------------------------------------------
-    @logfire.instrument("delete model")  # type: ignore[misc]
+    @logfire.instrument("delete model")
     def delete(self, instance: ModelT) -> None:
         """Remove ``instance`` from the database."""
 

--- a/src/miro_backend/services/tag_repository.py
+++ b/src/miro_backend/services/tag_repository.py
@@ -17,7 +17,7 @@ class TagRepository(Repository[Tag]):
     def __init__(self, session: Session) -> None:
         super().__init__(session, Tag)
 
-    @logfire.instrument("list tags for board")  # type: ignore[misc]
+    @logfire.instrument("list tags for board")
     def list_for_board(self, board_id: int) -> Sequence[Tag]:
         """Return tags for ``board_id`` sorted by name.
 


### PR DESCRIPTION
## Summary
- configure mypy path for source layout
- remove redundant casts and unused type ignores
- tighten exception handling and migration config
- align test client with httpx timeout signature

## Testing
- `poetry run ruff tests/integration/test_miro_client.py`
- `poetry run mypy tests/integration/test_miro_client.py`
- `poetry run pytest tests/integration/test_miro_client.py` *(fails: Coverage failure: total of 56 is less than fail-under=96)*
- `poetry run pre-commit run --files tests/integration/test_miro_client.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*

------
https://chatgpt.com/codex/tasks/task_e_68a507c383e4832b94bc73640b8143c8