### PR TITLE
fix(prisma): use real Prisma client types

### DIFF
--- a/src/types/prisma.d.ts
+++ b/src/types/prisma.d.ts
@@ -1,6 +1,0 @@
-declare module '@prisma/client' {
-  export class PrismaClient {
-    [key: string]: any
-    $disconnect(): Promise<void>
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": ["node", "@prisma/client"]
   },
   "include": ["src/**/*", "tests/integration/**/*"],
   "exclude": ["node_modules", "dist", "src/web/**", "src/frontend/**"]


### PR DESCRIPTION
## Summary
- remove custom Prisma client type shim
- include `@prisma/client` in TypeScript config

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c1f126d928832b9dc22ec5dccfceac