### PR TITLE
docs: remove legacy Python references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ each element can carry metadata that controls its appearance and placement.
 
 - Node.js 20.x
 
-The previous Python FastAPI backend is deprecated. The app now runs as a single Node.js process that serves both the API and the React frontend.
+The app runs as a single Node.js process that serves both the API and the React frontend.
 
 ### Environment
 

--- a/improvement_plan.md
+++ b/improvement_plan.md
@@ -47,6 +47,7 @@ Status markers: [Done] applied, [Planned] to do.
     - Acceptance: shared helper wraps calls with exponential backoff and caps retries.
 
 10. TokenStorage tests [Done]
+
 - Why: ensure storage meets client semantics.
 - Acceptance: unit tests for get/set/delete paths.
 
@@ -131,7 +132,7 @@ Status markers: [Done] applied, [Planned] to do.
 
 ## 8) Build & Tooling
 
-25. Remove node-fetch; use global fetch [Planned]
+25. Remove node-fetch; use global fetch [Done]
 
 - Why: reduce deps; Node 20 provides fetch.
 - Acceptance: dependency removed; imports dropped; tests updated.
@@ -170,7 +171,7 @@ Status markers: [Done] applied, [Planned] to do.
 - Why: clarify raw body requirement.
 - Acceptance: docs updated with implementation detail and env note.
 
-32. Remove legacy references [Planned]
+32. Remove legacy references [Done]
 
 - Why: reduce confusion.
 - Acceptance: purge Python-era remnants and stray references from README/DEPLOYMENT.


### PR DESCRIPTION
## Summary
- remove deprecated Python backend note
- mark node-fetch and legacy reference tasks as complete

## Testing
- `npm run format` *(fails: Code style issues found in 6 files)*
- `npx prettier README.md improvement_plan.md --check`
- `npm run typecheck` *(fails: Fastify logger configuration mismatch)*
- `npm run lint`
- `npm run test` *(fails: logger options only accepts a configuration object)*

------
https://chatgpt.com/codex/tasks/task_e_68c222cf8940832b9a4bf33a551f75c6