### PR TITLE
feat(prisma): add tag uniqueness index

### DIFF
--- a/docs/node-architecture.md
+++ b/docs/node-architecture.md
@@ -143,16 +143,16 @@ Storage interface (token persistence):
 
 ```ts
 // Implements the Storage interface required by Miro
-  export class TokenStorage {
-      async get(userId: string) {
-          return await userTokenRepo.get(userId) // returns State | undefined
-      }
+export class TokenStorage {
+    async get(userId: string) {
+        return await userTokenRepo.get(userId) // returns State | undefined
+    }
 
-      async set(userId: string, state: any) {
-          await userTokenRepo.set(userId, state)
-      }
-  }
-  ```
+    async set(userId: string, state: any) {
+        await userTokenRepo.set(userId, state)
+    }
+}
+```
 
 Our production `TokenStorage` persists tokens with Prisma, and unit tests cover the `get`, `set`, and delete paths to ensure compatibility with Miro's Storage interface.
 
@@ -208,7 +208,7 @@ Use DTOs and zod schemas for request/response validation.
 Planned Prisma models (aligned to existing SQLite data):
 
 - `Board(id, boardId, name, createdAt, updatedAt)`
-- `Tag(id, name, color, boardId)`
+- `Tag(id, board_id, name)` (unique on `board_id` + `name`)
 - `Shape(id, boardId, shapeId, data, createdAt)`
 - `UserToken(userId, provider, accessToken, refreshToken, expiresAt, scopes, rawState)`
 - `CacheEntry(key, value, createdAt, updatedAt)` (optional if keeping cache)

--- a/improvement_plan.md
+++ b/improvement_plan.md
@@ -64,10 +64,10 @@ Status markers: [Done] applied, [Planned] to do.
 - Acceptance: add `npm run migrate:deploy`; document running it in CI/prod; stop committing `app.db`.
 - Notes: `.gitignore` now excludes `*.db`. Removing tracked DB files should be a separate maintenance task.
 
-13. Indices and naming consistency [Planned]
+13. Indices and naming consistency [Done]
 
 - Why: performance and readability.
-- Acceptance: composite unique/index for `Tag(board_id, name)`; consider `@map` to camelCase or standardize snake_case.
+- Acceptance: composite unique/index for `Tag(board_id, name)`; naming remains snake_case.
 
 ## 5) Queue/Worker
 

--- a/prisma/migrations/20250911013000_tag_board_name_unique/migration.sql
+++ b/prisma/migrations/20250911013000_tag_board_name_unique/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_board_id_name_key" ON "Tag"("board_id", "name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Tag {
   // Relations
   board Board @relation(fields: [board_id], references: [id], onDelete: Cascade)
 
+  @@unique([board_id, name])
   @@index([board_id])
 }
 


### PR DESCRIPTION
## Summary
- enforce unique tag names per board via composite index
- document Tag uniqueness and mark improvement completed

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find type definition file for '@prisma/client')*
- `npm run typecheck:client`
- `npm test` *(fails: Cannot find module '.prisma/client/default')*
- `npm run format` *(fails: Code style issues found in 4 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c22440e1b0832bb5a4c3ddc960cf20