### PR TITLE
feat: add board guards and sticky tag feedback

### DIFF
--- a/docs/CORE_MODULES.md
+++ b/docs/CORE_MODULES.md
@@ -38,6 +38,8 @@ src/frontend/core/
     file-utils.ts
     graph-auth.ts
     graph-client.ts
+    tag-client.ts
+    text-utils.ts
     unit-utils.ts
     workbook-writer.ts
 ```
@@ -71,5 +73,7 @@ src/frontend/core/
 | utils/file-utils.ts          | Read and write local files for import/export.       |
 | utils/graph-auth.ts          | Handle OAuth login for the graph service.           |
 | utils/graph-client.ts        | Fetch graph data from the backend API.              |
+| utils/tag-client.ts          | Minimal client for board tag operations.            |
+| utils/text-utils.ts          | Read and write widget text content.                 |
 | utils/unit-utils.ts          | Unit conversion helpers for board measurements.     |
 | utils/workbook-writer.ts     | Output workbook rows to an Excel file.              |

--- a/improvement_plan.md
+++ b/improvement_plan.md
@@ -115,17 +115,17 @@ Status markers: [Done] applied, [Planned] to do.
 - Why: avoid stale reads.
 - Acceptance: call `boardCache.reset()` after mutative actions (e.g., sticky tags, layout, card creation).
 
-22. Extract text read/write util [Planned]
+22. Extract text read/write util [Done]
 
 - Why: DRY across search, sticky tagging, excel sync.
 - Acceptance: shared helpers for getting/setting text fields; existing callers updated.
 
-23. SDK guards + UX feedback [Planned]
+23. SDK guards + UX feedback [Done]
 
 - Why: better UX outside Miro; actionable feedback.
 - Acceptance: central `ensureBoard()`; toast/snackbar for sticky tag results.
 
-24. Tag client enhancement [Planned]
+24. Tag client enhancement [Done]
 
 - Why: clear abstraction.
 - Acceptance: optional `createTag(name)` wrapper (or backend endpoint later) and reuse across features.

--- a/src/frontend/board/board.ts
+++ b/src/frontend/board/board.ts
@@ -1,6 +1,7 @@
 import * as log from '../logger'
 import { boardCache } from './board-cache'
 import type { BoardLike, BoardQueryLike } from './types'
+import { showError } from '../ui/hooks/notifications'
 
 export type { BoardUILike, BoardLike, BoardQueryLike } from './types'
 
@@ -35,6 +36,24 @@ export function getBoard(board?: BoardLike): BoardLike {
 export function getBoardWithQuery(board?: BoardQueryLike): BoardQueryLike {
   log.trace('Casting board with query capabilities')
   return getBoard(board) as BoardQueryLike
+}
+
+/**
+ * Ensure the Miro board API is available.
+ *
+ * Attempts to resolve the active board and displays a user-facing error when
+ * the SDK is not present, such as when opening the app outside Miro.
+ *
+ * @param board - Optional board override primarily used in tests.
+ * @returns The resolved board instance or `undefined` when unavailable.
+ */
+export function ensureBoard(board?: BoardLike): BoardLike | undefined {
+  try {
+    return getBoard(board)
+  } catch {
+    void showError('Open this app in a Miro board to use this feature.')
+    return undefined
+  }
 }
 
 /**

--- a/src/frontend/board/card-processor.ts
+++ b/src/frontend/board/card-processor.ts
@@ -193,11 +193,13 @@ export class CardProcessor extends UndoableProcessor<Card | Frame> {
     for (const name of uniqueNames) {
       let tag = tagMap.get(name)
       if (!tag) {
-        tag = await miro.board.createTag({ title: name })
-        tagMap.set(name, tag)
-        this.tagsCache?.push(tag)
+        tag = await this.tagClient.createTag(name)
+        if (tag) {
+          tagMap.set(name, tag)
+          this.tagsCache?.push(tag)
+        }
       }
-      if (tag.id) {
+      if (tag?.id) {
         ids.push(tag.id)
       }
     }

--- a/src/frontend/board/grid-tools.ts
+++ b/src/frontend/board/grid-tools.ts
@@ -24,7 +24,7 @@ import * as log from '../logger'
 import { BoardLike, getBoard, maybeSync, Syncable } from './board'
 import { boardCache } from './board-cache'
 import { calculateGridPositions } from './grid-layout'
-import { getTextFields } from './search-tools'
+import { getTextFields } from '../core/utils/text-utils'
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {

--- a/src/frontend/board/search-tools.ts
+++ b/src/frontend/board/search-tools.ts
@@ -1,6 +1,7 @@
 import { BoardQueryLike, getBoardWithQuery, maybeSync, Syncable } from './board'
 import { boardCache } from './board-cache'
 import safeRegex from 'safe-regex'
+import { getTextFields, getStringAtPath, setStringAtPath } from '../core/utils/text-utils'
 
 /** Search configuration. */
 export interface SearchOptions {
@@ -85,75 +86,6 @@ function buildRegex(opts: SearchOptions): RegExp {
  * @param item - Record containing arbitrary widget properties.
  * @returns Array of `[path, text]` tuples for each discovered field.
  */
-function pushIfString(arr: Array<[string, string]>, key: string, value: unknown): void {
-  if (typeof value === 'string') {
-    arr.push([key, value])
-  }
-}
-
-function pushNestedText(arr: Array<[string, string]>, text: Record<string, unknown>): void {
-  pushIfString(arr, 'text.plainText', text.plainText)
-  pushIfString(arr, 'text.content', text.content)
-}
-
-export function getTextFields(item: Record<string, unknown>): Array<[string, string]> {
-  const fields: Array<[string, string]> = []
-  pushIfString(fields, 'title', item.title)
-  pushIfString(fields, 'content', item.content)
-  pushIfString(fields, 'plainText', item.plainText)
-  pushIfString(fields, 'description', item.description)
-  if (typeof item.text === 'string') {
-    pushIfString(fields, 'text', item.text)
-  } else if (item.text && typeof item.text === 'object') {
-    pushNestedText(fields, item.text as Record<string, unknown>)
-  }
-  return fields
-}
-
-function getStringAtPath(item: Record<string, unknown>, path: string): string | undefined {
-  const parts = path.split('.')
-  let ref: unknown = item
-  for (const p of parts) {
-    if (!ref || typeof ref !== 'object') {
-      return undefined
-    }
-    ref = (ref as Record<string, unknown>)[p]
-  }
-  return typeof ref === 'string' ? ref : undefined
-}
-
-function isUnsafe(prop: string): boolean {
-  return prop === '__proto__' || prop === 'constructor'
-}
-
-function getParent(
-  obj: Record<string, unknown>,
-  parts: string[],
-): Record<string, unknown> | undefined {
-  let ref: unknown = obj
-  for (let i = 0; i < parts.length - 1; i += 1) {
-    const part = parts[i]!
-    if (isUnsafe(part) || !ref || typeof ref !== 'object') {
-      return undefined
-    }
-    ref = (ref as Record<string, unknown>)[part]
-  }
-  return typeof ref === 'object' && ref ? (ref as Record<string, unknown>) : undefined
-}
-
-function setStringAtPath(item: Record<string, unknown>, path: string, value: string): void {
-  const parts = path.split('.')
-  const parent = getParent(item, parts)
-  if (!parent) {
-    return
-  }
-  const last = parts[parts.length - 1]!
-  if (isUnsafe(last)) {
-    return
-  }
-  parent[last] = value
-}
-
 /**
  * Collect matching text fields from a single widget.
  */
@@ -309,4 +241,3 @@ export async function replaceBoardContent(
 }
 
 // Internal export for testing.
-export { setStringAtPath as _setStringAtPath }

--- a/src/frontend/board/sticky-tags.ts
+++ b/src/frontend/board/sticky-tags.ts
@@ -1,8 +1,10 @@
 import type { BaseItem } from '@mirohq/websdk-types'
 
 import { boardCache } from './board-cache'
-import { maybeSync } from './board'
+import { ensureBoard, maybeSync, type BoardLike } from './board'
 import { TagClient, type TagInfo } from '../core/utils/tag-client'
+import { readItemText, writeItemText } from '../core/utils/text-utils'
+import { pushToast } from '../ui/components/Toast'
 
 type TagLike = Pick<TagInfo, 'id' | 'title'>
 
@@ -14,53 +16,35 @@ function extractBracketTags(text: string): { tags: string[]; stripped: string } 
     const name = match[1]?.trim()
     if (name) tagSet.add(name)
   }
-  const stripped = text.replace(regex, '').replace(/\s{2,}/g, ' ').trim()
+  const stripped = text
+    .replace(regex, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
   return { tags: [...tagSet], stripped }
 }
 
-async function getTagMap(boardId: string): Promise<Map<string, TagLike>> {
-  const client = new TagClient(boardId, '/api/boards')
+async function getTagMap(client: TagClient): Promise<Map<string, TagLike>> {
   const tags = await client.getTags()
   return new Map(tags.map((t) => [t.title, { id: t.id, title: t.title }]))
 }
 
-async function ensureTagIds(names: string[], tagMap: Map<string, TagLike>): Promise<string[]> {
+async function ensureTagIds(
+  names: string[],
+  tagMap: Map<string, TagLike>,
+  client: TagClient,
+): Promise<string[]> {
   const ids: string[] = []
   for (const name of new Set(names)) {
     let tag = tagMap.get(name)
     if (!tag) {
-      // Create client-side to keep this purely front-end
-      tag = (await miro.board.createTag({ title: name })) as unknown as TagLike
-      tagMap.set(name, tag)
+      tag = (await client.createTag(name)) as TagLike | undefined
+      if (tag) {
+        tagMap.set(name, tag)
+      }
     }
-    if (tag.id) ids.push(tag.id)
+    if (tag?.id) ids.push(tag.id)
   }
   return ids
-}
-
-function readStickyText(item: Record<string, unknown>): string | undefined {
-  const text = (item as { plainText?: string }).plainText
-  if (typeof text === 'string' && text.length > 0) return text
-  const content = (item as { content?: string }).content
-  if (typeof content === 'string') return content
-  const nested = (item as { text?: { plainText?: string; content?: string } }).text
-  if (nested && typeof nested.plainText === 'string') return nested.plainText
-  if (nested && typeof nested.content === 'string') return nested.content
-  return undefined
-}
-
-function writeStickyText(item: Record<string, unknown>, text: string): void {
-  if (typeof (item as { plainText?: string }).plainText === 'string') {
-    ;(item as { plainText?: string }).plainText = text
-  }
-  if (typeof (item as { content?: string }).content === 'string') {
-    ;(item as { content?: string }).content = text
-  }
-  const nested = (item as { text?: { plainText?: string; content?: string } }).text
-  if (nested) {
-    if (typeof nested.plainText === 'string') nested.plainText = text
-    if (typeof nested.content === 'string') nested.content = text
-  }
 }
 
 /**
@@ -73,18 +57,25 @@ function writeStickyText(item: Record<string, unknown>, text: string): void {
  * - On failure to assign tags, leaves the original text unchanged.
  */
 export async function applyBracketTagsToSelectedStickies(): Promise<void> {
-  const boardId = (globalThis as unknown as { miro?: { board?: { id?: string } } }).miro?.board?.id
-  if (!boardId) return
-  const tagMap = await getTagMap(boardId)
+  const maybeBoard = ensureBoard() as (BoardLike & { id?: string }) | undefined
+  if (!maybeBoard?.id) {
+    return
+  }
+  const board = maybeBoard as BoardLike & { id: string }
+  const client = new TagClient(board.id, '/api/boards')
+  const tagMap = await getTagMap(client)
 
-  const selection = await boardCache.getSelection()
+  const selection = await boardCache.getSelection(board)
   const stickies = selection.filter((i) => (i as BaseItem).type === 'sticky_note')
-  if (!stickies.length) return
+  if (!stickies.length) {
+    pushToast({ message: 'Select sticky notes to tag.' })
+    return
+  }
 
   // Pre-scan all stickies to collect unique tag names across the selection
   const allNames = new Set<string>()
   for (const item of stickies) {
-    const t = readStickyText(item)
+    const t = readItemText(item)
     if (!t) continue
     const { tags } = extractBracketTags(t)
     tags.forEach((n) => allNames.add(n))
@@ -92,13 +83,14 @@ export async function applyBracketTagsToSelectedStickies(): Promise<void> {
 
   // Ensure missing tags once (cached in tagMap). Ignore failures.
   try {
-    await ensureTagIds([...allNames], tagMap)
+    await ensureTagIds([...allNames], tagMap, client)
   } catch {
     // Best-effort: unresolved names simply won't be in tagMap
   }
 
+  let tagged = 0
   for (const item of stickies) {
-    const text = readStickyText(item)
+    const text = readItemText(item)
     if (!text) continue
     const { tags, stripped } = extractBracketTags(text)
     if (tags.length === 0) continue
@@ -116,8 +108,9 @@ export async function applyBracketTagsToSelectedStickies(): Promise<void> {
       // Only strip text if all names resolved to IDs and tagging succeeded
       const allResolved = tags.every((n) => Boolean(tagMap.get(n)?.id))
       if (allResolved) {
-        writeStickyText(item, stripped)
+        writeItemText(item, stripped)
         await maybeSync(item as unknown as { sync?: () => Promise<void> })
+        tagged += 1
       }
     } catch {
       // Leave the text unchanged when tagging fails
@@ -125,4 +118,10 @@ export async function applyBracketTagsToSelectedStickies(): Promise<void> {
   }
   // Clear caches so subsequent reads see updated tags/text
   boardCache.reset()
+  pushToast({
+    message:
+      tagged > 0
+        ? `Applied tags to ${tagged} sticky note${tagged === 1 ? '' : 's'}.`
+        : 'No [tags] found in selected stickies.',
+  })
 }

--- a/src/frontend/core/utils/tag-client.ts
+++ b/src/frontend/core/utils/tag-client.ts
@@ -28,4 +28,22 @@ export class TagClient {
     }
     return (await res.json()) as TagInfo[]
   }
+
+  /** Create a tag on the current board. */
+  public async createTag(title: string): Promise<TagInfo | undefined> {
+    const board = (
+      globalThis as {
+        miro?: { board?: { createTag?: (t: { title: string }) => Promise<TagInfo> } }
+      }
+    ).miro?.board
+    if (typeof board?.createTag !== 'function') {
+      return undefined
+    }
+    try {
+      const tag = (await board.createTag({ title })) as TagInfo
+      return tag
+    } catch {
+      return undefined
+    }
+  }
 }

--- a/src/frontend/core/utils/text-utils.ts
+++ b/src/frontend/core/utils/text-utils.ts
@@ -1,0 +1,117 @@
+/**
+ * Helpers for working with textual fields on widgets.
+ *
+ * These functions normalise access to common text properties and are shared
+ * across search utilities, sticky tagging and other features that read or
+ * mutate widget text.
+ */
+
+function pushIfString(arr: Array<[string, string]>, key: string, value: unknown): void {
+  if (typeof value === 'string') {
+    arr.push([key, value])
+  }
+}
+
+function pushNestedText(arr: Array<[string, string]>, text: Record<string, unknown>): void {
+  pushIfString(arr, 'text.plainText', text.plainText)
+  pushIfString(arr, 'text.content', text.content)
+}
+
+/**
+ * Extract all textual fields from a widget-like object.
+ *
+ * The returned array preserves the discovery order of fields such as `title`,
+ * `content`, `plainText`, `description` and nested `text` properties.
+ */
+export function getTextFields(item: Record<string, unknown>): Array<[string, string]> {
+  const fields: Array<[string, string]> = []
+  pushIfString(fields, 'title', item.title)
+  pushIfString(fields, 'content', item.content)
+  pushIfString(fields, 'plainText', item.plainText)
+  pushIfString(fields, 'description', item.description)
+  if (typeof item.text === 'string') {
+    pushIfString(fields, 'text', item.text)
+  } else if (item.text && typeof item.text === 'object') {
+    pushNestedText(fields, item.text as Record<string, unknown>)
+  }
+  return fields
+}
+
+/**
+ * Retrieve a string at a dot-notated path from the given item.
+ */
+export function getStringAtPath(item: Record<string, unknown>, path: string): string | undefined {
+  const parts = path.split('.')
+  let ref: unknown = item
+  for (const p of parts) {
+    if (!ref || typeof ref !== 'object') {
+      return undefined
+    }
+    ref = (ref as Record<string, unknown>)[p]
+  }
+  return typeof ref === 'string' ? ref : undefined
+}
+
+/**
+ * Set a string at a dot-notated path on the given item.
+ *
+ * Attempts to mutate only existing string properties and guards against
+ * prototype pollution by ignoring `__proto__` and `constructor` segments.
+ */
+export function setStringAtPath(item: Record<string, unknown>, path: string, value: string): void {
+  const parts = path.split('.')
+  let ref: Record<string, unknown> = item
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i]!
+    if (key === '__proto__' || key === 'constructor') {
+      return
+    }
+    const next = ref[key]
+    if (!next || typeof next !== 'object') {
+      return
+    }
+    ref = next as Record<string, unknown>
+  }
+  const last = parts[parts.length - 1]!
+  if (last === '__proto__' || last === 'constructor') {
+    return
+  }
+  if (typeof ref[last] === 'string') {
+    ref[last] = value
+  }
+}
+
+/**
+ * Read the primary text content from a widget-like object.
+ */
+export function readItemText(item: Record<string, unknown>): string | undefined {
+  const text = (item as { plainText?: string }).plainText
+  if (typeof text === 'string' && text.length > 0) return text
+  const content = (item as { content?: string }).content
+  if (typeof content === 'string') return content
+  const nested = (item as { text?: { plainText?: string; content?: string } }).text
+  if (nested && typeof nested.plainText === 'string' && nested.plainText.length > 0)
+    return nested.plainText
+  if (nested && typeof nested.content === 'string') return nested.content
+  return undefined
+}
+
+/**
+ * Write text to all recognised fields on a widget-like object.
+ */
+export function writeItemText(item: Record<string, unknown>, text: string): void {
+  if (typeof (item as { plainText?: string }).plainText === 'string') {
+    ;(item as { plainText?: string }).plainText = text
+  }
+  if (typeof (item as { content?: string }).content === 'string') {
+    ;(item as { content?: string }).content = text
+  }
+  const nested = (item as { text?: { plainText?: string; content?: string } }).text
+  if (nested) {
+    if (typeof nested.plainText === 'string') nested.plainText = text
+    if (typeof nested.content === 'string') nested.content = text
+  }
+}
+
+// Internal utility exports for tests
+export { setStringAtPath as _setStringAtPath }

--- a/tests/client/board-utils.test.ts
+++ b/tests/client/board-utils.test.ts
@@ -1,5 +1,7 @@
-import { forEachSelection, getFirstSelection, maybeSync } from '../src/board/board'
+import { ensureBoard, forEachSelection, getFirstSelection, maybeSync } from '../src/board/board'
 import { boardCache } from '../src/board/board-cache'
+vi.mock('../src/ui/hooks/notifications', () => ({ showError: vi.fn() }))
+import { showError } from '../src/ui/hooks/notifications'
 
 beforeEach(() => boardCache.reset())
 
@@ -49,5 +51,27 @@ describe('getFirstSelection', () => {
     const board = { getSelection: vi.fn().mockResolvedValue([]) }
     const result = await getFirstSelection(board)
     expect(result).toBeUndefined()
+  })
+})
+
+describe('ensureBoard', () => {
+  const original = (globalThis as { miro?: unknown }).miro
+
+  afterEach(() => {
+    ;(globalThis as { miro?: unknown }).miro = original
+    vi.mocked(showError).mockReset()
+  })
+
+  test('returns board when available', () => {
+    const board = {}
+    ;(globalThis as { miro?: unknown }).miro = { board }
+    expect(ensureBoard()).toBe(board)
+    expect(showError).not.toHaveBeenCalled()
+  })
+
+  test('reports error when board missing', () => {
+    ;(globalThis as { miro?: unknown }).miro = undefined
+    expect(ensureBoard()).toBeUndefined()
+    expect(showError).toHaveBeenCalled()
   })
 })

--- a/tests/client/card-processor.tags.test.ts
+++ b/tests/client/card-processor.tags.test.ts
@@ -22,3 +22,20 @@ test('getBoardTags uses tag client', async () => {
   expect((fetch as vi.Mock).mock.calls[0][0]).toBe('/api/b1/tags')
   expect(tags).toHaveLength(1)
 })
+
+test('ensureTagIds creates tags via client', async () => {
+  const client = {
+    getTags: vi.fn(),
+    createTag: vi.fn().mockResolvedValue({ id: 't1', title: 'tag' }),
+  } as unknown as TagClient
+  const processor = new CardProcessor(undefined, client) as unknown as {
+    ensureTagIds: (
+      names: string[],
+      map: Map<string, { id?: string; title: string }>,
+    ) => Promise<string[]>
+  }
+  const map = new Map<string, { id?: string; title: string }>()
+  const ids = await processor.ensureTagIds(['tag'], map)
+  expect(client.createTag).toHaveBeenCalledWith('tag')
+  expect(ids).toEqual(['t1'])
+})

--- a/tests/client/search-tools.test.ts
+++ b/tests/client/search-tools.test.ts
@@ -1,6 +1,7 @@
 import { BoardQueryLike } from '../src/board/board'
 import { boardCache } from '../src/board/board-cache'
-import { getTextFields, replaceBoardContent, searchBoardContent } from '../src/board/search-tools'
+import { replaceBoardContent, searchBoardContent } from '../src/board/search-tools'
+import { getTextFields } from '../src/core/utils/text-utils'
 
 beforeEach(() => boardCache.reset())
 
@@ -194,7 +195,7 @@ describe('search-tools', () => {
   })
 
   test('setStringAtPath guards prototype pollution', async () => {
-    const { _setStringAtPath: fn } = (await import('../src/board/search-tools')) as {
+    const { _setStringAtPath: fn } = (await import('../src/core/utils/text-utils')) as {
       _setStringAtPath: (o: Record<string, unknown>, p: string, v: string) => void
     }
     const obj1: Record<string, unknown> = {}

--- a/tests/client/tag-client.test.ts
+++ b/tests/client/tag-client.test.ts
@@ -3,10 +3,16 @@ import { TagClient } from '../src/core/utils/tag-client'
 
 vi.stubGlobal('fetch', vi.fn())
 vi.stubGlobal('miro', {
-  board: { getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }) },
+  board: {
+    getUserInfo: vi.fn().mockResolvedValue({ id: 'u1' }),
+    createTag: vi.fn(),
+  },
 })
 
-beforeEach(() => (fetch as unknown as vi.Mock).mockReset())
+beforeEach(() => {
+  ;(fetch as unknown as vi.Mock).mockReset()
+  ;(miro.board.createTag as vi.Mock).mockReset()
+})
 
 test('getTags fetches board tags', async () => {
   ;(fetch as vi.Mock).mockResolvedValueOnce({
@@ -17,4 +23,12 @@ test('getTags fetches board tags', async () => {
   const tags = await api.getTags()
   expect((fetch as vi.Mock).mock.calls[0][0]).toBe('/api/b1/tags')
   expect(tags).toEqual([{ id: 't1', title: 'Tag' }])
+})
+
+test('createTag creates tag via SDK', async () => {
+  ;(miro.board.createTag as vi.Mock).mockResolvedValueOnce({ id: 't2', title: 'New' })
+  const api = new TagClient('b1', '/api')
+  const tag = await api.createTag('New')
+  expect((miro.board.createTag as vi.Mock).mock.calls[0][0]).toEqual({ title: 'New' })
+  expect(tag).toEqual({ id: 't2', title: 'New' })
 })


### PR DESCRIPTION
## Summary
- add ensureBoard guard to show user error when the Miro SDK is unavailable
- display toast summarising sticky tag operations
- extract shared text utilities and centralise tag creation via TagClient helper
- mark SDK guard, text util extraction, and tag client enhancement improvements complete

## Testing
- `npx prettier --check improvement_plan.md docs/CORE_MODULES.md src/frontend/core/utils/tag-client.ts src/frontend/board/sticky-tags.ts src/frontend/board/card-processor.ts tests/client/tag-client.test.ts tests/client/card-processor.tags.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:client`
- `npm test` *(fails: fastify-plugin: fastify-raw-body - expected '^5.x' fastify version, '4.29.1' is installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2368d6b1c832bbf75be212c2773f9