### PR TITLE
refactor: type-safe userId, centralized logger env, cards route polish, and simplified tags lookup

### DIFF
--- a/improvement_plan.md
+++ b/improvement_plan.md
@@ -6,76 +6,56 @@ Status markers: [Planned] to do. Completed items are removed from this list once
 
 ## Quick Wins (Backend)
 
-1. Type-safe `request.userId` [Planned]
-    - Why: remove repeated casts in routes and hooks.
-    - Acceptance: module augmentation for FastifyRequest; all routes use `req.userId` without casts.
-
-2. Centralize env usage for webhook/signature/logging [Planned]
-    - Why: avoid `process.env` reads scattered in code.
-    - Acceptance: `src/config/env.ts` includes `MIRO_WEBHOOK_SECRET`, `LOG_LEVEL`; `webhook.routes.ts` uses `loadEnv()`.
-
-3. Constant-time webhook signature compare [Planned]
-    - Why: prevent timing attacks; follow best practices.
-    - Acceptance: `timingSafeEqual` used on computed HMAC vs header; raw-body retained.
-
-4. DRY OAuth routes [Planned]
+1. DRY OAuth routes [Planned]
     - Why: eliminate duplicate callback/login handlers.
     - Acceptance: single callback/login handlers used by both `/auth/miro/*` and `/oauth/*` aliases.
 
-5. SPA fallback helper (dev/prod) [Planned]
+2. SPA fallback helper (dev/prod) [Planned]
     - Why: avoid drift between dev Vite middleware and prod static serving.
     - Acceptance: shared helper used in both branches; tests updated if needed.
 
-6. Cards route polish [Planned]
-    - Why: simplify and harden request handling.
-    - Acceptance: lowercased `idempotency-key` util; payload whitelisted to expected fields; `randomUUID()` for `nodeId`; empty array fast-path.
-
-7. Tags lookup simplification [Planned]
-    - Why: reduce branching/readability.
-    - Acceptance: single Prisma `OR` query handling numeric `id` or string `board_id`.
-
-8. Vite dev wiring isolation [Planned]
+3. Vite dev wiring isolation [Planned]
     - Why: clarify responsibilities; lighten `app.ts`.
     - Acceptance: dev middleware moved to `config/dev-vite.ts` (lazy import); behavior unchanged.
 
 ## Security, Resilience, Logging
 
-9. Queue configurability via env [Planned]
+4. Queue configurability via env [Planned]
     - Why: tune concurrency/backoff without code changes.
     - Acceptance: `QUEUE_CONCURRENCY`, `QUEUE_MAX_RETRIES`, `QUEUE_BASE_DELAY_MS`, `QUEUE_MAX_DELAY_MS` parsed in `env.ts` and applied.
 
-10. Unify logging under Fastify logger [Planned]
+5. Unify logging under Fastify logger [Planned]
 
 - Why: consistent redaction and correlation.
 - Acceptance: queues/services receive `app.log` (or adapter) instead of creating separate pino instances.
 
 ## Database
 
-11. Index for idempotency cleanup [Planned]
+6. Index for idempotency cleanup [Planned]
 
 - Why: speed up deletion by age.
 - Acceptance: Prisma migration adding index on `IdempotencyEntry.created_at`.
 
 ## Frontend
 
-12. Backend boundary for board reads [Planned]
+7. Backend boundary for board reads [Planned]
 
 - Why: reduce client API calls; improve testability.
 - Acceptance: minimal backend endpoints added; `shape-client`/`board-cache` progressively switched to server-backed lookups.
 
-13. BoardBuilder testability [Planned]
+8. BoardBuilder testability [Planned]
 
 - Why: easier unit tests and reuse.
 - Acceptance: inject board-like dependency into `loadShapeMap`; extract `runBatch` utility.
 
-14. Improve error messages [Planned]
+9. Improve error messages [Planned]
 
 - Why: faster debugging.
 - Acceptance: errors include invalid values/context across builder operations.
 
 ## Docs & Inline Comments
 
-15. JSDoc and inline docs across key files [Planned]
+10. JSDoc and inline docs across key files [Planned]
 
 - app.ts: server composition, cookie rationale, SPA fallback.
 - env.ts: per-variable docs, examples, security notes (incl. `MIRO_WEBHOOK_SECRET`).
@@ -83,27 +63,26 @@ Status markers: [Planned] to do. Completed items are removed from this list once
 - queue/changeQueue.ts: concurrency model, backoff, drop policy.
 - miro/tokenStorage.ts: mapping to Prisma `User`, expire semantics, `set(undefined)`.
 - services/miroService.ts: inputs/outputs and idempotency expectations.
-- routes/cards.routes.ts: schema intent, idempotency header semantics, honored fields.
 - frontend/board/board-builder.ts: metadata assumptions, `runBatch` behavior.
 
 ## Lint, Tests & Quality
 
-16. ESLint rules refinement [Planned]
+11. ESLint rules refinement [Planned]
 
 - Why: reduce unsafe casts.
 - Acceptance: discourage `as unknown as`; prefer typed helpers or module augmentation.
 
-17. Tests for idempotency and tags lookup [Planned]
+12. Tests for idempotency and tags lookup [Planned]
 
 - Why: prevent regressions.
 - Acceptance: integration tests for `/api/cards` idempotency and `/api/boards/:id/tags` OR mapping.
 
-18. Webhook signature util tests [Planned]
+13. Webhook signature util tests [Planned]
 
 - Why: verify timing-safe logic.
 - Acceptance: unit tests covering valid/invalid signature paths with raw body.
 
-19. Coverage guard [Planned]
+14. Coverage guard [Planned]
 
 - Why: maintain targets.
 - Acceptance: threshold check (Vitest/c8) gating CI summary.

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,9 +1,12 @@
 import pino, { type LoggerOptions } from 'pino'
 
+import { loadEnv } from './env.js'
+
 export function getLoggerOptions(): LoggerOptions {
-  const isProd = process.env.NODE_ENV === 'production'
+  const env = loadEnv()
+  const isProd = env.NODE_ENV === 'production'
   return {
-    level: process.env.LOG_LEVEL || (isProd ? 'info' : 'debug'),
+    level: env.LOG_LEVEL || (isProd ? 'info' : 'debug'),
     transport: isProd
       ? undefined
       : {

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -32,20 +32,20 @@ export const registerAuthRoutes: FastifyPluginAsync = async (app) => {
 
   // OAuth callback
   app.get('/auth/miro/callback', async (req, reply) => {
-    const userId = req.userId || ''
+    const userId = req.userId
     const code = (req.query as Record<string, string> | undefined)?.code
     return handleCallback(userId, code, reply)
   })
 
   app.get('/oauth/callback', async (req, reply) => {
-    const userId = req.userId || ''
+    const userId = req.userId
     const code = (req.query as Record<string, string> | undefined)?.code
     return handleCallback(userId, code, reply)
   })
 
   // Simple auth status endpoint for client
   app.get('/api/auth/status', async (req, reply) => {
-    const userId = req.userId || ''
+    const userId = req.userId
     const authorized = await getMiro().isAuthorized(userId)
     return reply.send({ authorized })
   })

--- a/src/routes/cards.routes.ts
+++ b/src/routes/cards.routes.ts
@@ -4,6 +4,7 @@ import type { FastifyPluginAsync } from 'fastify'
 
 import { changeQueue, createNodeTask } from '../queue/changeQueue.js'
 import { IdempotencyRepo } from '../repositories/idempotencyRepo.js'
+import { getIdempotencyKey } from '../utils/headers.js'
 
 interface CardCreate {
   id?: string
@@ -29,7 +30,7 @@ const cardCreateSchema = {
     boardId: { type: 'string' },
   },
   required: ['title'],
-  additionalProperties: true,
+  additionalProperties: false,
 } as const
 
 export const registerCardsRoutes: FastifyPluginAsync = async (app) => {
@@ -47,24 +48,32 @@ export const registerCardsRoutes: FastifyPluginAsync = async (app) => {
         },
       },
     },
-    // Accepts an array of card definitions and enqueues creation tasks.
-    // Idempotency is supported via the `Idempotency-Key` header.
+    /**
+     * Accepts an array of card definitions and enqueues creation tasks.
+     * Only whitelisted fields are forwarded. Idempotency is enforced via
+     * the `Idempotency-Key` header which returns the same accepted count on
+     * retries.
+     */
     async (req, reply) => {
-      const userId = req.userId || ''
+      const userId = req.userId
       const cards = req.body
-      const idemKey = (req.headers['idempotency-key'] as string | undefined) ?? undefined
-      const repo = new IdempotencyRepo()
+      const idemKey = getIdempotencyKey(req)
 
-      if (idemKey) {
+      if (!Array.isArray(cards) || cards.length === 0) {
+        if (idemKey) {
+          const repo = new IdempotencyRepo()
+          await repo.set(idemKey, 0)
+        }
+        return reply.code(202).send({ accepted: 0 })
+      }
+
+      const repo = idemKey ? new IdempotencyRepo() : undefined
+
+      if (idemKey && repo) {
         const previous = await repo.get(idemKey)
         if (typeof previous === 'number') {
           return reply.code(202).send({ accepted: previous })
         }
-      }
-
-      if (!Array.isArray(cards) || cards.length === 0) {
-        if (idemKey) await repo.set(idemKey, 0)
-        return reply.code(202).send({ accepted: 0 })
       }
 
       for (const c of cards) {
@@ -84,7 +93,7 @@ export const registerCardsRoutes: FastifyPluginAsync = async (app) => {
         changeQueue.enqueue(createNodeTask(userId, nodeId, data))
       }
       const accepted = cards.length
-      if (idemKey) await repo.set(idemKey, accepted)
+      if (idemKey && repo) await repo.set(idemKey, accepted)
       return reply.code(202).send({ accepted })
     },
   )

--- a/src/routes/tags.routes.ts
+++ b/src/routes/tags.routes.ts
@@ -36,12 +36,12 @@ export const registerTagsRoutes: FastifyPluginAsync = async (app) => {
       const prisma = getPrisma()
       const boardParam = req.params.boardId
       // Resolve either by external board_id (string) or internal id (number)
-      const ors: Array<Record<string, unknown>> = [{ board_id: boardParam }]
-      const parsed = Number(boardParam)
-      if (Number.isFinite(parsed)) {
-        ors.push({ id: parsed })
-      }
-      const board = await prisma.board.findFirst({ where: { OR: ors } })
+      const numericId = Number(boardParam)
+      const or = [
+        { board_id: boardParam },
+        ...(Number.isFinite(numericId) ? [{ id: numericId }] : []),
+      ]
+      const board = await prisma.board.findFirst({ where: { OR: or } })
       if (!board) {
         return reply.send([])
       }

--- a/src/types/fastify-user.d.ts
+++ b/src/types/fastify-user.d.ts
@@ -1,7 +1,0 @@
-declare module 'fastify' {
-  interface FastifyRequest {
-    userId?: string
-  }
-}
-
-export {}

--- a/src/types/fastify.d.ts
+++ b/src/types/fastify.d.ts
@@ -2,6 +2,7 @@ import 'fastify'
 
 declare module 'fastify' {
   interface FastifyRequest {
+    /** Stable user identifier set via preHandler hook */
     userId: string
   }
 }

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,0 +1,15 @@
+import type { FastifyRequest } from 'fastify'
+
+export const IDEMPOTENCY_KEY_HEADER = 'idempotency-key' as const
+
+/**
+ * Extract the `Idempotency-Key` header from a Fastify request.
+ * Node.js normalizes header names to lowercase, so we only
+ * check the lowercase variant and return the first value if multiple
+ * are provided.
+ */
+export function getIdempotencyKey(req: Pick<FastifyRequest, 'headers'>): string | undefined {
+  const value = req.headers[IDEMPOTENCY_KEY_HEADER]
+  if (Array.isArray(value)) return value[0]
+  return typeof value === 'string' ? value : undefined
+}


### PR DESCRIPTION
## Summary
- require `req.userId` via Fastify module augmentation and drop casts in auth and cards routes
- load logging configuration from central `env` helper
- whitelist fields in cards route, handle empty batches early, and normalize `Idempotency-Key`
- simplify tag board resolution with a single `OR` query
- trim completed items from `improvement_plan.md`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: fastify-plugin: @fastify/cookie expected '4.x' fastify version, '5.6.0' installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c258c318a8832b94db93c3028146c6