### PR TITLE
fix(board): guard removeItems and supply board id

### DIFF
--- a/src/frontend/board/board-builder.ts
+++ b/src/frontend/board/board-builder.ts
@@ -142,7 +142,11 @@ export class BoardBuilder {
     const selection = await boardCache.getSelection(
       miro.board as unknown as import('./board').BoardLike,
     )
+    const boardId =
+      (miro.board as { id?: string; info?: { id?: string } }).id ??
+      (miro.board as { info?: { id?: string } }).info?.id
     const board: import('./board').BoardQueryLike = {
+      id: boardId,
       get: async ({ type: t }) => selection.filter((i) => (i as { type?: string }).type === t),
       getSelection: async () => selection,
     }
@@ -228,9 +232,9 @@ export class BoardBuilder {
    * Deletion is wrapped in {@link runBatch} to reduce network chatter.
    */
   public async removeItems(items: Array<BoardItem | Connector | Frame>): Promise<void> {
+    this.ensureBoard()
     const board = miro.board as unknown as BoardLike
     await runBatch(board, async () => {
-      this.ensureBoard()
       log.debug({ count: items.length }, 'Removing items')
       await Promise.all(items.map((item) => miro.board.remove(item)))
     })

--- a/tests/client/graph-convert.test.ts
+++ b/tests/client/graph-convert.test.ts
@@ -49,12 +49,15 @@ describe('graph conversion helpers', () => {
 describe('processor conversions', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
     delete global.miro
   })
 
   test('GraphProcessor converts hierarchy input', async () => {
     global.miro = {
       board: {
+        id: 'b1',
+        info: { id: 'b1' },
         get: vi.fn().mockResolvedValue([]),
         getSelection: vi.fn().mockResolvedValue([]),
         findEmptySpace: vi.fn().mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
@@ -93,6 +96,22 @@ describe('processor conversions', () => {
         }),
       },
     } as unknown as GlobalWithMiro
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      id: 's1',
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getMetadata: vi.fn(),
+      sync: vi.fn(),
+    } as unknown)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('/widgets')) {
+          return { json: async () => ({ shape: [] }) } as unknown as Response
+        }
+        return { json: async () => ({}) } as unknown as Response
+      }),
+    )
     const gp = new GraphProcessor()
     const hierarchy = [
       {
@@ -122,6 +141,8 @@ describe('processor conversions', () => {
   test('GraphProcessor uses nested layout for box algorithm', async () => {
     global.miro = {
       board: {
+        id: 'b1',
+        info: { id: 'b1' },
         get: vi.fn().mockResolvedValue([]),
         getSelection: vi.fn().mockResolvedValue([]),
         findEmptySpace: vi.fn().mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
@@ -154,6 +175,22 @@ describe('processor conversions', () => {
         createFrame: vi.fn().mockResolvedValue({ add: vi.fn(), id: 'f1' }),
       },
     } as unknown as GlobalWithMiro
+    vi.spyOn(templateManager, 'createFromTemplate').mockResolvedValue({
+      id: 's1',
+      type: 'shape',
+      setMetadata: vi.fn(),
+      getMetadata: vi.fn(),
+      sync: vi.fn(),
+    } as unknown)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('/widgets')) {
+          return { json: async () => ({ shape: [] }) } as unknown as Response
+        }
+        return { json: async () => ({}) } as unknown as Response
+      }),
+    )
 
     const gp = new GraphProcessor()
     const layoutSpy = vi.spyOn(nestedLayout, 'layoutHierarchy').mockResolvedValue({


### PR DESCRIPTION
## Summary
- ensure BoardBuilder.removeItems checks for `miro` before use
- provide board id when searching selection so BoardCache can fetch widgets
- mock widget fetches in search tools and graph conversion tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c41c5a6de4832b922c657e2b11c4aa