### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fenrick/MiroDiagramming/security/code-scanning/23](https://github.com/fenrick/MiroDiagramming/security/code-scanning/23)

To fix this issue, you should explicitly add a `permissions` block to the workflow or the specific jobs that both indicates a conscious permissions decision and restricts the default GITHUB_TOKEN permissions to the minimum needed. In the context of this workflow, since all actions only require reading repository contents (to check out code, install dependencies, etc.), the tightest minimal setting is `contents: read`.

You should place a `permissions` block immediately under the workflow's `name:` field (global scope), or within the job definition (`node:`) if you want it specific to that job. The global approach is recommended for a single-job workflow like this.

No other methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
