### PR TITLE
fix: stop passing style props to design-system tabs

### DIFF
--- a/src/ui/pages/diagrams-tab.tsx
+++ b/src/ui/pages/diagrams-tab.tsx
@@ -116,10 +116,10 @@ export const DiagramsTab: React.FC = () => {
       <Tabs value={sub} variant="tabs" onChange={handleChange} size="medium">
         <Tabs.List
           aria-label="Diagram tools"
-          style={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
+          css={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
         >
           {subTabs.map((t) => (
-            <Tabs.Trigger key={t.id} value={t.id} style={{ flex: '1 1 auto' }}>
+            <Tabs.Trigger key={t.id} value={t.id} css={{ flex: '1 1 auto' }}>
               {t.label}
             </Tabs.Trigger>
           ))}

--- a/src/ui/pages/tools-tab.tsx
+++ b/src/ui/pages/tools-tab.tsx
@@ -86,10 +86,10 @@ export const ToolsTab: React.FC = () => {
       <Tabs value={sub} variant="tabs" onChange={handleChange} size="medium">
         <Tabs.List
           aria-label="Tool categories"
-          style={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
+          css={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
         >
           {SUB_TABS.map((t) => (
-            <Tabs.Trigger key={t.id} value={t.id} style={{ flex: '1 1 auto' }}>
+            <Tabs.Trigger key={t.id} value={t.id} css={{ flex: '1 1 auto' }}>
               {t.label}
             </Tabs.Trigger>
           ))}


### PR DESCRIPTION
## Summary
- replace inline style usage on design-system Tabs components with the supported css prop in the diagrams and tools tabs to silence runtime warnings

## Testing
- npm run test -- tests/client/pages-smoke.test.tsx
- npm run test -- tests/client/pages-heavy-smoke.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de6b4fe1d4832ba98ce3547b8e6123