### PR TITLE
fix: use css props for nested tabs

### DIFF
--- a/src/ui/pages/diagrams-tab.tsx
+++ b/src/ui/pages/diagrams-tab.tsx
@@ -116,10 +116,10 @@ export const DiagramsTab: React.FC = () => {
       <Tabs value={sub} variant="tabs" onChange={handleChange} size="medium">
         <Tabs.List
           aria-label="Diagram tools"
-          style={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
+          css={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
         >
           {subTabs.map((t) => (
-            <Tabs.Trigger key={t.id} value={t.id} style={{ flex: '1 1 auto' }}>
+            <Tabs.Trigger key={t.id} value={t.id} css={{ flex: '1 1 auto' }}>
               {t.label}
             </Tabs.Trigger>
           ))}

--- a/src/ui/pages/tools-tab.tsx
+++ b/src/ui/pages/tools-tab.tsx
@@ -86,10 +86,10 @@ export const ToolsTab: React.FC = () => {
       <Tabs value={sub} variant="tabs" onChange={handleChange} size="medium">
         <Tabs.List
           aria-label="Tool categories"
-          style={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
+          css={{ display: 'flex', flexWrap: 'wrap', gap: space[100] }}
         >
           {SUB_TABS.map((t) => (
-            <Tabs.Trigger key={t.id} value={t.id} style={{ flex: '1 1 auto' }}>
+            <Tabs.Trigger key={t.id} value={t.id} css={{ flex: '1 1 auto' }}>
               {t.label}
             </Tabs.Trigger>
           ))}

--- a/tests/client/diagrams-tab.test.tsx
+++ b/tests/client/diagrams-tab.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../src/core/mermaid', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/core/mermaid')>('../../src/core/mermaid')
+  return {
+    ...actual,
+    isMermaidEnabled: vi.fn(() => true),
+  }
+})
+
+import { isMermaidEnabled } from '../../src/core/mermaid'
+import { DiagramsTab } from '../../src/ui/pages/diagrams-tab'
+
+const STORAGE_KEY = 'miro.diagrams.last-sub-tab'
+const isMermaidEnabledMock = vi.mocked(isMermaidEnabled)
+
+describe('DiagramsTab', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    isMermaidEnabledMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    isMermaidEnabledMock.mockClear()
+  })
+
+  it('restores the stored sub tab when it is still available', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'mermaid')
+
+    const { getByRole } = render(<DiagramsTab />)
+
+    expect(getByRole('tab', { name: 'Mermaid' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('ignores stored tabs that are hidden by feature flags', () => {
+    isMermaidEnabledMock.mockReturnValue(false)
+    window.localStorage.setItem(STORAGE_KEY, 'mermaid')
+
+    const { getByRole, queryByRole } = render(<DiagramsTab />)
+
+    expect(queryByRole('tab', { name: 'Mermaid' })).toBeNull()
+    expect(getByRole('tab', { name: 'Structured' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('persists user changes to the selected tab', async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+    const user = userEvent.setup()
+
+    const { getByRole } = render(<DiagramsTab />)
+    await user.click(getByRole('tab', { name: 'Layout Engine' }))
+
+    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, 'layout')
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('layout')
+    expect(getByRole('tab', { name: 'Layout Engine' })).toHaveAttribute('aria-selected', 'true')
+    setItemSpy.mockRestore()
+  })
+})

--- a/tests/client/tools-tab.test.tsx
+++ b/tests/client/tools-tab.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ToolsTab } from '../../src/ui/pages/tools-tab'
+
+const STORAGE_KEY = 'miro.tools.last-sub-tab'
+
+describe('ToolsTab', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('restores the previously selected sub tab from storage', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'style')
+
+    const { getByRole } = render(<ToolsTab />)
+
+    expect(getByRole('tab', { name: 'Colours' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('falls back to the default tab when storage contains an unknown id', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'unknown')
+
+    const { getByRole } = render(<ToolsTab />)
+
+    expect(getByRole('tab', { name: 'Size' })).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('persists user sub tab changes to storage', async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+    const user = userEvent.setup()
+
+    const { getByRole } = render(<ToolsTab />)
+    await user.click(getByRole('tab', { name: 'Frames' }))
+
+    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, 'frames')
+    expect(getByRole('tab', { name: 'Frames' })).toHaveAttribute('aria-selected', 'true')
+    setItemSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- replace inline style usage on nested Tabs.List and Tabs.Trigger with the design-system `css` prop to avoid runtime warnings
- add client-side tests that cover tab persistence and feature-flag behaviour for the tools and diagrams tabs

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de6a2ddc74832b95284a95bd8484f5