### PR TITLE
fix: modernize hasOwn usage and mermaid status output

### DIFF
--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -22,7 +22,7 @@ import {
  */
 export function findStyleKey(style: Record<string, unknown>, keys: string[]): string | null {
   for (const key of keys) {
-    if (Object.prototype.hasOwnProperty.call(style, key)) {
+    if (Object.hasOwn(style, key)) {
       return key
     }
   }

--- a/src/core/utils/debug-flags.ts
+++ b/src/core/utils/debug-flags.ts
@@ -15,7 +15,7 @@ const search = (() => {
     location?: { search?: string }
   }
 
-  if (!Object.prototype.hasOwnProperty.call(globalContext, 'location')) {
+  if (!Object.hasOwn(globalContext, 'location')) {
     return ''
   }
 

--- a/src/ui/pages/mermaid-tab.tsx
+++ b/src/ui/pages/mermaid-tab.tsx
@@ -72,7 +72,7 @@ export const MermaidTab: React.FC = () => {
   })
   const [frameTitle, setFrameTitle] = React.useState('')
   const [existingMode, setExistingMode] = React.useState<ExistingNodeMode>('move')
-  const [isRendering, setRendering] = React.useState(false)
+  const [isRendering, setIsRendering] = React.useState(false)
   const [status, setStatus] = React.useState<
     { variant: 'success'; message: string } | { variant: 'error'; message: string } | null
   >(null)
@@ -118,7 +118,7 @@ export const MermaidTab: React.FC = () => {
       return
     }
     const renderer = rendererReference.current
-    setRendering(true)
+    setIsRendering(true)
     setStatus(null)
     try {
       const graph = await renderer.render(trimmedDefinition, {
@@ -145,7 +145,7 @@ export const MermaidTab: React.FC = () => {
       }
       log.error({ error }, 'Mermaid rendering failed')
     } finally {
-      setRendering(false)
+      setIsRendering(false)
     }
   }, [existingMode, frameTitle, isDefinitionEmpty, trimmedDefinition, withFrame])
 
@@ -205,13 +205,14 @@ export const MermaidTab: React.FC = () => {
         </SidebarSection>
         {status ? (
           <Callout
-            role="status"
             variant={status.variant === 'success' ? 'success' : 'danger'}
             dismissible={false}
             style={STATUS_STYLE}
           >
             <Callout.Content>
-              <Callout.Description>{status.message}</Callout.Description>
+              <Callout.Description>
+                <output aria-live="polite">{status.message}</output>
+              </Callout.Description>
             </Callout.Content>
           </Callout>
         ) : null}


### PR DESCRIPTION
## Summary
- replace manual hasOwnProperty checks with `Object.hasOwn` in board and debug utilities
- rename the Mermaid tab rendering state setter for clarity and wrap status message in an `<output>` element for better accessibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de6ef398c0832bbb230c8f01d0aec4